### PR TITLE
Remove references to unimplemented design concepts and add basic usage statement to top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # Preflight
+
+**Preflight** is a commandline interface for validating if
+[OpenShift](https://www.openshift.com/) operator bundles meet minimum
+reqiurements for [Red Hat OpenShift
+Certification](https://connect.redhat.com/en/partner-with-us/red-hat-openshift-certification).
+
+This project is in active and rapid development! Many facets of this project are
+subject to change.
+
+## Usage
+
+```shell
+A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification.
+Choose from any of the following checks:
+        RunAsNonRoot, LayerCountAcceptable, HasUniqueTag, HasNoProhibitedPackages, ValidateOperatorBundle, HasRequiredLabel, BasedOnUbi, HasLicense, HasMinimalVulnerabilities
+Choose from any of the following output formats:
+        xml, junitxml, json
+
+Usage:
+  preflight <container-image> [flags]
+
+Flags:
+  -c, --enabled-checks string   Which checks to apply to the image to ensure compliance.
+                                (Env) PREFLIGHT_ENABLED_CHECKS
+  -h, --help                    help for preflight
+  -o, --output-format string    The format for the check test results.
+                                (Env) PREFLIGHT_OUTPUT_FORMAT (Default) json
+```
+

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,7 +15,7 @@ including writing and ensuring your bundle complies with your own custom tests.
 ## Design
 
 The current design leverages a series of interfaces for handling the following
-tasks related to check enforcement:
+tasks related to check validation:
 
 * managing container image assets (e.g. pulling from an external registry,
   managing an image tarball on disk, etc.)
@@ -29,16 +29,13 @@ tasks related to check enforcement:
 The interface definitions for managing each of these tasks should allow for
 developers to:
 
-* define their own approach for managing container assets in their own test
-  environments if the included approach is not preferred.
-
 * define their own checks and implementation details in addition to the
   built-in checks
 
 * define custom output formats other than those built-in to the tooling.
 
 The included CLI will leverage these interfaces to provide built-in checks,
-built-in formatters, and built-in container asset managers. 
+built-in formatters, and built-in container asset managers.
 
 ## Libraries
 
@@ -53,12 +50,6 @@ build out your own custom formatters. Developers can leverage the included
 formatters by simply passing in a `certification/formatters.FormatterFunc` and
 additional metadata, or they can build out their own by implementing the
 `certification/formatters.ResponseFormatter` interface.
-
-The `certification/inputmanager` library includes the necessary constructs to
-build out your own custom input managers. Input management just refers to the
-managing of container image assets on disk, and to/from remote registries if
-needed.
-*TODO: complete implementation and documentation*
 
 The `certification/runtime` library includes the necessary constructs to build
 out your own check runner. A check runner just refers to the interface that
@@ -81,19 +72,15 @@ taking precedence. See `cmd/constants.go` for the existing supported environment
 variables. 
 
 The CLI will take all user input and derive a `certification/runtime.Config`
-instance with the appropriate values filled in. Then, an inputmanager,
-formatter, and checkrunner is derived based on that configuration (commonly
-seen as `NewForConfig(...)` functions available in each package).
+instance with the appropriate values filled in. Then, a check runner and a
+formatter are derived based on that configuration (commonly seen as
+`NewForConfig(...)` functions available in each package).
 
-The inputmanager manager is then used to gather the required assets. The
-runtime, will execute checks and store results, and finally the formatter will
-prepare that output. The CLI will end execution by writing that output to
-whatever output has been specified (`os.Stdout` today, but this will eventually
-support additional locations).
+The check engine will execute validation functions based on enabled checks
+defined in the environment, or alternatively all checks if no checks were specified.
 
-## Input Manager Implementation
-
-*TODO Currently Unimplemented*
+Finally, the results of those validations will be passed to the formatter which
+will prepare them for final output to the user.
 
 ## CheckRunner Implementation
 


### PR DESCRIPTION
There were several concepts in the initial dev docs draft that we did not implement (e.g. `inputmanager`). These are being removed from the dev docs.

In addition, I just added a simple text blurb to the README indicating the intention of the project, and reflecting the current build's `--help` output. We'll refine this more as time goes. 