### PR TITLE
Add version flag support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .DEFAULT_GOAL:=help
 
 VERSION=$(shell git rev-parse HEAD)
+RELEASE_TAG ?= "0.0.0"
 
 .PHONY: build
 build:
-	go build -o preflight -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION)" main.go
+	go build -o preflight -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" main.go
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ subject to change.
 ```shell
 A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification.
 Choose from any of the following checks:
-        RunAsNonRoot, LayerCountAcceptable, HasUniqueTag, HasNoProhibitedPackages, ValidateOperatorBundle, HasRequiredLabel, BasedOnUbi, HasLicense, HasMinimalVulnerabilities
+        HasLicense, HasUniqueTag, RunAsNonRoot, LayerCountAcceptable, HasMinimalVulnerabilities, HasNoProhibitedPackages, ValidateOperatorBundle, HasRequiredLabel, BasedOnUbi
 Choose from any of the following output formats:
-        xml, junitxml, json
+        json, xml, junitxml
 
 Usage:
   preflight <container-image> [flags]
@@ -26,5 +26,6 @@ Flags:
   -h, --help                    help for preflight
   -o, --output-format string    The format for the check test results.
                                 (Env) PREFLIGHT_OUTPUT_FORMAT (Default) json
+  -v, --version                 version for preflight
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,12 +9,14 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "preflight <container-image>",
-	Short: "Preflight Red Hat certification prep tool.",
+	Use:     "preflight <container-image>",
+	Short:   "Preflight Red Hat certification prep tool.",
+	Version: version.Version.String(),
 	Long: "A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification." +
 		"\nChoose from any of the following checks:" +
 		"\n\t" + strings.Join(engine.AllChecks(), ", ") +

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+import "fmt"
+
 // TODO restructure this to be local only these packages
 // TODO dynamically generate these at release
 var version = "unknown"
@@ -13,4 +15,8 @@ var Version = VersionContext{
 type VersionContext struct {
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
+}
+
+func (vc *VersionContext) String() string {
+	return fmt.Sprintf("%s <commit: %s>", vc.Version, vc.Commit)
 }


### PR DESCRIPTION
Just a quick addition - I meant to wire this up previously. This just adds the ability to call `./preflight --version` and have the CLI respond.

I added a `String()` method to format a `VersionContext` on a single line, which we then use in our cobra root.go definition. Cobra, then, handles the actual addition of the `-v` or `--version` flag.

Finally, this updates the Makefile so that we can build the CLI with a RELEASE_TAG environment variable and have it injected into the binary. Example:

```
$ RELEASE_TAG=1.2.3 make build
go build -o preflight -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=52f97749b3ac5fbcdf4877bd31582221e592bce6 -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=1.2.3" main.go

$ ./preflight --version
preflight version 1.2.3 <commit: 52f97749b3ac5fbcdf4877bd31582221e592bce6>
```

By default, this will inject `0.0.0` indicating that no release tag was provided. 

I also updated the README to include the help output which shows the version flag. I'm noticing that the available test and formatters output changed, and that's probably because we internally use a slice there and I'm assuming ordering is changing. When README gets more refined, we'll need to be cognizant of that.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>