### PR TITLE
Migrate check to scan the containers for unacceptable vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# openscap vulnerability report
+vuln.html
+
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -12,6 +15,7 @@
 *.dylib
 bin
 preflight
+openshift-preflight
 preflight-*.log
 
 # Test binary, build with `go test -c`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,9 @@ Vagrant.configure("2") do |config|
     bzip2 \
     go-md2man \
     runc \
-    containers-common
+    containers-common \
+    openscap-utils
+  
     curl -L https://golang.org/dl/go1.16.3.linux-amd64.tar.gz --output go1.16.3.linux-amd64.tar.gz
     rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
     rm go1.16.3.linux-amd64.tar.gz

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -1,15 +1,107 @@
 package shell
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/file"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	ovalFilename = "rhel-8.oval.xml.bz2"
+	ovalUrl      = "https://www.redhat.com/security/data/oval/v2/RHEL8/"
+	reportFile   = "vuln.html"
 )
 
 type HasMinimalVulnerabilitiesCheck struct{}
 
 func (p *HasMinimalVulnerabilitiesCheck) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+
+	ovalFileUrl := fmt.Sprintf("%s%s", ovalUrl, ovalFilename)
+	dir, err := ioutil.TempDir(".", "oval-")
+
+	if err != nil {
+		log.Error("Unable to create temp dir", err)
+		return false, err
+	}
+	log.Debugf("Oval file dir: %s", dir)
+	defer os.RemoveAll(dir)
+
+	ovalFilePath := filepath.Join(dir, ovalFilename)
+	log.Debugf("Oval file path: %s", ovalFilePath)
+
+	err = file.DownloadFile(ovalFilePath, ovalFileUrl)
+	if err != nil {
+		log.Error("Unable to download Oval file", err)
+		return false, err
+	}
+	// get the file name
+	r := regexp.MustCompile(`(?P<filename>.*).bz2`)
+	ovalFilePathDecompressed := filepath.Join(dir, r.FindStringSubmatch(ovalFilename)[1])
+
+	err = file.Unzip(ovalFilePath, ovalFilePathDecompressed)
+	if err != nil {
+		log.Error("Unable to unzip Oval file: ", err)
+		return false, err
+	}
+
+	numOfVulns, err := p.numberOfVulnerabilities(image, ovalFilePathDecompressed)
+	if err != nil {
+		return false, err
+	}
+
+	log.Debugf("The number of found vulnerabilities: %d", numOfVulns)
+
+	return numOfVulns == 0, nil
 }
+
+// numberOfVulnerabilities takes the `image` and the path to the OVAL file. It runs
+// `oscap-podman` against `image`, and parses the output to figure out how many vulnerabilities
+//  exist. It also saves results to the vuln.html file in the current directory,
+// for the end users' reference.
+
+func (p *HasMinimalVulnerabilitiesCheck) numberOfVulnerabilities(image string, ovalFilePathDecompressed string) (int, error) {
+
+	// run oscap-podman command and save the report to vuln.html
+	cmd := exec.Command("oscap-podman", image, "oval", "eval", "--report", reportFile, ovalFilePathDecompressed)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err != nil {
+		log.Error("unable to execute oscap-podman on the image: ", cmd.Stderr, reportFile)
+		return -1, err
+	}
+
+	// get the current directory
+	path, err := os.Getwd()
+	if err != nil {
+		log.Error("unable to get the current directory: ", err)
+	}
+
+	log.Debugf("The path to vulnerability report: %s/%s ", path, reportFile)
+
+	// use regex to count the number of vulnerabilities
+
+	// oscap-podman writes `Definition oval:com.redhat.<CVE#>: true` to stdout
+	// if the vulnerability exist in the container, and `Definition oval:com.redhat.<CVE#>: false`
+	// if the vulnerability does not exist
+	r := regexp.MustCompile("Definition oval:com.redhat.*: true")
+	matches := r.FindAllStringIndex(string(out.String()), -1)
+
+	// count the number of matches
+	return len(matches), nil
+}
+
 func (p *HasMinimalVulnerabilitiesCheck) Name() string {
 	return "HasMinimalVulnerabilities"
 }

--- a/certification/internal/utils/file/helper.go
+++ b/certification/internal/utils/file/helper.go
@@ -1,0 +1,50 @@
+package file
+
+import (
+	"compress/bzip2"
+	"io"
+	"net/http"
+	"os"
+)
+
+func DownloadFile(filename string, url string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+func Unzip(bzipfile string, destination string) error {
+
+	f, err := os.Open(bzipfile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	in := bzip2.NewReader(f)
+
+	out, err := os.Create(destination)
+
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(out, in)
+
+	if err != nil {
+		return err
+	}
+	out.Close()
+	return nil
+}


### PR DESCRIPTION
* The check is using the `openscap-podman` command output to identify the number of vulnerabilities.
* This check requires `root` privileges.