### PR TITLE
Add Dockerfile for Containerizing Preflight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# golang:1.16 image created 2021-06-24T00:31:06.02014601Z 
+FROM docker.io/library/golang@sha256:be99fa59acd78bb22a41bbc1e15ebfab2262498ee0c2e28c3d09bc44d51d1774 AS builder
+
+# Build the preflight binary
+COPY . /go/src/preflight
+WORKDIR /go/src/preflight
+RUN make build
+
+# ubi-minimal:latest image created 2021-06-01T12:12:46.922866Z
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0ccb9988abbc72d383258d58a7f519a10b637d472f28fbca6eb5fab79ba82a6b
+
+# Define versions for dependencies
+ARG OPENSCAP_VERSION=1.3.5
+ARG OPENSHIFT_CLIENT_VERSION=4.7.19
+ARG OPERATOR_SDK_VERSION=1.9.0
+
+# Add preflight binary
+COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight
+
+# Install dependencies
+RUN microdnf install \
+    buildah \
+    bzip2 \
+    gzip \
+    iptables \
+    podman \
+    skopeo
+
+# Install oscap-podman binary
+RUN curl -L https://github.com/OpenSCAP/openscap/releases/download/${OPENSCAP_VERSION}/openscap-${OPENSCAP_VERSION}.tar.gz | tar -xzv -C /usr/local/bin openscap-${OPENSCAP_VERSION}/utils/oscap-podman
+
+# Install OpenShift client binary
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPENSHIFT_CLIENT_VERSION}.tar.gz | tar -xzv -C /usr/local/bin oc
+
+# Install Operator SDK binray
+RUN curl -Lo /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64
+RUN chmod 755 /usr/local/bin/operator-sdk
+
+ENTRYPOINT ["/usr/local/bin/preflight"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL:=help
 
+IMAGE_BUILDER=podman
+IMAGE_REPO=quay.io/opdev
 VERSION=$(shell git rev-parse HEAD)
 
 .PHONY: build
@@ -10,6 +12,14 @@ build:
 fmt:
 	go fmt ./...
 	git diff --exit-code
+
+.PHONY: image-build
+image-build:
+	$(IMAGE_BUILDER) build -t $(IMAGE_REPO)/preflight:$(VERSION) .
+
+.PHONY: image-push
+image-push:
+	$(IMAGE_BUILDER) push $(IMAGE_REPO)/preflight:$(VERSION) .
 
 .PHONY: test
 test:


### PR DESCRIPTION
This PR adds the initial Dockerfile to containerize preflight.

## Overview

The preflight binary is built first and the required system packages are then installed, followed by the required external tools (oc, operator-sdk and operator-courier).

In addition, two make targets have been added to build and push the container image. The git hash is used as the image tag, similar to the preflight application version.

Further testing and changes may be required for the podman shell commands to work in all cases but it appears to be working from the limited testing that I have done locally.

## Usage

Running the container without any parameters will display the help.

```
$ podman run -it quay.io/opdev/preflight:f82afd8a7f96c1fcdf1d65a6daed3eeadaba5dbc
A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification.
Choose from any of the following checks:
	HasLicense, ValidateOperatorBundle, HasUniqueTag, HasNoProhibitedPackages, RunAsNonRoot, LayerCountAcceptable, HasRequiredLabel, BasedOnUbi, HasMinimalVulnerabilities
Choose from any of the following output formats:
	json, xml, junitxml

Usage:
  preflight <container-image> [flags]

Flags:
  -c, --enabled-checks string   Which checks to apply to the image to ensure compliance.
                                (Env) PREFLIGHT_ENABLED_CHECKS
  -h, --help                    help for preflight
  -o, --output-format string    The format for the check test results.
                                (Env) PREFLIGHT_OUTPUT_FORMAT (Default) json
```

Signed-off-by: John McKenzie <john@mkz.io>