### PR TITLE
Adding CLI subcommands for check, certify and support

### DIFF
--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var certifyCmd = &cobra.Command{
+	Use:   "certify",
+	Short: "Submits check results to Red Hat",
+	Long:  `This command will run all the checks for a container or operator and submit the results to Red Hat for Certification consideration `,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Certify command not implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(certifyCmd)
+}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Run checks for an operator or container",
+	Long:  "This command will allow you to execute the Red Hat Certificaiton tests for an operator or a container.",
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/spf13/cobra"
+)
+
+var checkContainerCmd = &cobra.Command{
+	Use:   "container",
+	Short: "Run checks for a container",
+	Long:  `This command will run the Certification checks for a container image. `,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("%w: A container image positional argument is required", errors.ErrInsufficientPosArguments)
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Expect exactly one positional arg. Check here instead of using builtin Args key
+		// so that we can get a more user-friendly error message
+
+		containerImage := args[0]
+
+		cfg := runtime.Config{
+			Image:          containerImage,
+			EnabledChecks:  engine.ContainerPolicy(),
+			ResponseFormat: parseOutputFormat(),
+		}
+
+		engine, err := engine.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		formatter, err := formatters.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		engine.ExecuteChecks()
+		results := engine.Results()
+
+		// return results to the user
+		formattedResults, err := formatter.Format(results)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprint(os.Stdout, string(formattedResults))
+
+		return nil
+	},
+}
+
+func init() {
+	checkContainerCmd.SetUsageTemplate(
+		`Usage:
+  preflight check container <url to container image> [flags]
+	
+Flags:
+  -h, --help   help for container
+`)
+	checkCmd.AddCommand(checkContainerCmd)
+}

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/spf13/cobra"
+)
+
+var checkOperatorCmd = &cobra.Command{
+	Use:   "operator",
+	Short: "Run checks for an Operator",
+	Long:  `This command will run the Certification checks for an Operator bundle image. `,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("%w: An operator image positional argument is required", errors.ErrInsufficientPosArguments)
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Expect exactly one positional arg. Check here instead of using builtin Args key
+		// so that we can get a more user-friendly error message
+
+		operatorImage := args[0]
+
+		cfg := runtime.Config{
+			Image:          operatorImage,
+			EnabledChecks:  engine.OperatorPolicy(),
+			ResponseFormat: parseOutputFormat(),
+		}
+
+		engine, err := engine.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		formatter, err := formatters.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		engine.ExecuteChecks()
+		results := engine.Results()
+
+		// return results to the user
+		formattedResults, err := formatter.Format(results)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprint(os.Stdout, string(formattedResults))
+
+		return nil
+	},
+}
+
+func init() {
+	checkOperatorCmd.SetUsageTemplate(
+		`Usage:
+  preflight check operator <url to Operator bundle image> [flags]
+	
+Flags:
+  -h, --help   help for operator
+`)
+	checkCmd.AddCommand(checkOperatorCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,62 +3,14 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "preflight <container-image>",
-	Short:   "Preflight Red Hat certification prep tool.",
-	Version: version.Version.String(),
-	Long: "A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification." +
-		"\nChoose from any of the following checks:" +
-		"\n\t" + strings.Join(engine.AllChecks(), ", ") +
-		"\nChoose from any of the following output formats:" +
-		"\n\t" + strings.Join(formatters.AllFormats(), ", "),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Expect exactly one positional arg. Check here instead of using builtin Args key
-		// so that we can get a more user-friendly error message
-		if len(args) != 1 {
-			return fmt.Errorf("%w: A container image positional argument is required", errors.ErrInsufficientPosArguments)
-		}
-		containerImage := args[0]
-
-		cfg := runtime.Config{
-			Image:          containerImage,
-			EnabledChecks:  parseEnabledChecksValue(),
-			ResponseFormat: parseOutputFormat(),
-		}
-
-		engine, err := engine.NewForConfig(cfg)
-		if err != nil {
-			return err
-		}
-
-		formatter, err := formatters.NewForConfig(cfg)
-		if err != nil {
-			return err
-		}
-
-		engine.ExecuteChecks()
-		results := engine.Results()
-
-		// return results to the user
-		formattedResults, err := formatter.Format(results)
-		if err != nil {
-			return err
-		}
-
-		fmt.Fprint(os.Stdout, string(formattedResults))
-
-		return nil
-	},
+	Use:   "preflight",
+	Short: "Preflight Red Hat certification prep tool.",
+	Long:  "A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification.",
 }
 
 var (

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var supportCmd = &cobra.Command{
+	Use:   "support",
+	Short: "Submits a support request",
+	Long: `This command will submit a support request to Red Hat along with the logs from the latest Preflight checck.
+	This command can be used when you'd like assistance from Red Hat Support when attempting to pass your certification checks. `,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Support command not implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(supportCmd)
+}


### PR DESCRIPTION
Adding three subcommands to the CLI
Check: Runs the checks.  Used for iterative development and fixes
Certify: Will send the results to Red Hat (not implemented)
Support: Will take the failing cert results and logs and create a support ticket (not implemented)