### PR TITLE
Remove logger as a parameter

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -1,12 +1,10 @@
 package certification
 
-import "github.com/sirupsen/logrus"
-
 // Check as an interface containing all methods necessary
 // to use and identify a given check.
 type Check interface {
 	// Validate checks whether the asset enforces the check.
-	Validate(image string, logger *logrus.Logger) (result bool, err error)
+	Validate(image string) (result bool, err error)
 	// Name returns the name of the check.
 	Name() string
 	// Metadata returns the check's metadata.

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -7,7 +7,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/shell"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
-	"github.com/sirupsen/logrus"
 )
 
 type CheckEngine interface {
@@ -21,16 +20,16 @@ type ContainerFileManager interface {
 	// IsRemote will check user-provided path and determine if that path is
 	// local or remote. Here local means that it's a location on the filesystem, and
 	// remote means that it's an image in a registry.
-	ContainerIsRemote(path string, logger *logrus.Logger) (isRemote bool, remotecheckErr error)
+	ContainerIsRemote(path string) (isRemote bool, remotecheckErr error)
 	// ExtractContainerTar will accept a path on the filesystem and extract it.
-	ExtractContainerTar(path string, logger *logrus.Logger) (tarballPath string, extractionErr error)
+	ExtractContainerTar(path string) (tarballPath string, extractionErr error)
 	// GetContainerFromRegistry will accept a container location and write it locally
 	// as a tarball as done by `podman save`
-	GetContainerFromRegistry(containerLoc string, logger *logrus.Logger) (containerDownloadPath string, containerDownloadErro error)
+	GetContainerFromRegistry(containerLoc string) (containerDownloadPath string, containerDownloadErro error)
 }
 
 type CheckRunner interface {
-	ExecuteChecks(logger *logrus.Logger)
+	ExecuteChecks()
 	// StoreChecks(...[]certification.Check)
 	Results() runtime.Results
 }

--- a/certification/generic_check.go
+++ b/certification/generic_check.go
@@ -1,10 +1,8 @@
 package certification
 
-import "github.com/sirupsen/logrus"
-
 // ValidatorFunc describes a function that, when executed, will check that an
 // artifact (e.g. operator bundle) complies with a given check.
-type ValidatorFunc = func(string, *logrus.Logger) (bool, error)
+type ValidatorFunc = func(string) (bool, error)
 
 type genericCheckDefinition struct {
 	name        string
@@ -17,8 +15,8 @@ func (pd *genericCheckDefinition) Name() string {
 	return pd.name
 }
 
-func (pd *genericCheckDefinition) Validate(image string, logger *logrus.Logger) (bool, error) {
-	return pd.validatorFn(image, logger)
+func (pd *genericCheckDefinition) Validate(image string) (bool, error) {
+	return pd.validatorFn(image)
 }
 
 func (pd *genericCheckDefinition) Metadata() Metadata {

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -5,17 +5,17 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type BaseOnUBICheck struct{}
 
-func (p *BaseOnUBICheck) Validate(image string, logger *logrus.Logger) (bool, error) {
+func (p *BaseOnUBICheck) Validate(image string) (bool, error) {
 	podmanEngine := PodmanCLIEngine{}
-	return p.validate(podmanEngine, image, logger)
+	return p.validate(podmanEngine, image)
 }
 
-func (p *BaseOnUBICheck) validate(podmanEngine cli.PodmanEngine, image string, logger *logrus.Logger) (bool, error) {
+func (p *BaseOnUBICheck) validate(podmanEngine cli.PodmanEngine, image string) (bool, error) {
 	runOpts := cli.ImageRunOptions{
 		EntryPoint:     "cat",
 		EntryPointArgs: []string{"/etc/os-release"},
@@ -24,9 +24,9 @@ func (p *BaseOnUBICheck) validate(podmanEngine cli.PodmanEngine, image string, l
 	}
 	runReport, err := podmanEngine.Run(runOpts)
 	if err != nil {
-		logger.Error("unable to inspect the os-release file in the target container: ", err)
-		logger.Debugf("Stdout: %s", runReport.Stdout)
-		logger.Debugf("Stderr: %s", runReport.Stderr)
+		log.Error("unable to inspect the os-release file in the target container: ", err)
+		log.Debugf("Stdout: %s", runReport.Stdout)
+		log.Debugf("Stderr: %s", runReport.Stderr)
 		return false, err
 	}
 

--- a/certification/internal/shell/base_on_ubi_test.go
+++ b/certification/internal/shell/base_on_ubi_test.go
@@ -23,7 +23,7 @@ NAME="Red Hat Enterprise Linux"
 	Describe("Checking for UBI as a base", func() {
 		Context("When it is based on UBI", func() {
 			It("should succeed the check", func() {
-				ok, err := base_on_ubi.validate(engine, "dummy/image", logger)
+				ok, err := base_on_ubi.validate(engine, "dummy/image")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -35,7 +35,7 @@ NAME="Some Other Linux"
 `
 			})
 			It("should not succeed the check", func() {
-				ok, err := base_on_ubi.validate(engine, "dummy/image", logger)
+				ok, err := base_on_ubi.validate(engine, "dummy/image")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type CheckEngine struct {
@@ -17,8 +17,8 @@ type CheckEngine struct {
 }
 
 // ExecuteChecks runs all checks stored in the check engine.
-func (e *CheckEngine) ExecuteChecks(logger *logrus.Logger) {
-	logger.Info("target image: ", e.Image)
+func (e *CheckEngine) ExecuteChecks() {
+	log.Info("target image: ", e.Image)
 	for _, check := range e.Checks {
 		checkStartTime := time.Now()
 		e.results.TestedImage = e.Image
@@ -26,18 +26,18 @@ func (e *CheckEngine) ExecuteChecks(logger *logrus.Logger) {
 
 		// check if the image needs downloading
 		if !e.isDownloaded {
-			isRemote, err := e.ContainerIsRemote(e.Image, logger)
+			isRemote, err := e.ContainerIsRemote(e.Image)
 			if err != nil {
-				logger.Error("unable to determine if the image was remote: ", err)
+				log.Error("unable to determine if the image was remote: ", err)
 				e.results.Errors = append(e.results.Errors, runtime.Result{Check: check, ElapsedTime: time.Since(checkStartTime)})
 				continue
 			}
 
 			if isRemote {
-				logger.Info("downloading image")
+				log.Info("downloading image")
 				err := GetContainerFromRegistry(e.Image)
 				if err != nil {
-					logger.Error("unable to the container from the registry: ", err)
+					log.Error("unable to the container from the registry: ", err)
 					e.results.Errors = append(e.results.Errors, runtime.Result{Check: check, ElapsedTime: time.Since(checkStartTime)})
 					continue
 				}
@@ -52,28 +52,28 @@ func (e *CheckEngine) ExecuteChecks(logger *logrus.Logger) {
 		// 	targetImage = e.localImagePath
 		// }
 
-		logger.Info("running check: ", check.Name())
+		log.Info("running check: ", check.Name())
 		// We want to know the time just for the check itself, so reset checkStartTime
 		checkStartTime = time.Now()
 
 		// run the validation
-		passed, err := check.Validate(targetImage, logger)
+		passed, err := check.Validate(targetImage)
 
 		checkElapsedTime := time.Since(checkStartTime)
 
 		if err != nil {
-			logger.WithFields(logrus.Fields{"result": "ERROR", "error": err.Error()}).Info("check completed: ", check.Name())
+			log.WithFields(log.Fields{"result": "ERROR", "error": err.Error()}).Info("check completed: ", check.Name())
 			e.results.Errors = append(e.results.Errors, runtime.Result{Check: check, ElapsedTime: checkElapsedTime})
 			continue
 		}
 
 		if !passed {
-			logger.WithFields(logrus.Fields{"result": "FAILED"}).Info("check completed: ", check.Name())
+			log.WithFields(log.Fields{"result": "FAILED"}).Info("check completed: ", check.Name())
 			e.results.Failed = append(e.results.Failed, runtime.Result{Check: check, ElapsedTime: checkElapsedTime})
 			continue
 		}
 
-		logger.WithFields(logrus.Fields{"result": "PASSED"}).Info("check completed: ", check.Name())
+		log.WithFields(log.Fields{"result": "PASSED"}).Info("check completed: ", check.Name())
 		e.results.Passed = append(e.results.Passed, runtime.Result{Check: check, ElapsedTime: checkElapsedTime})
 	}
 }
@@ -88,7 +88,7 @@ func (e *CheckEngine) Results() runtime.Results {
 	return e.results
 }
 
-func (e *CheckEngine) ContainerIsRemote(path string, logger *logrus.Logger) (bool, error) {
+func (e *CheckEngine) ContainerIsRemote(path string) (bool, error) {
 	// TODO: Implement, for not this is just returning
 	// that the resource is remote and needs to be pulled.
 	return true, nil

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -5,27 +5,27 @@ import (
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type HasLicenseCheck struct{}
 
-func (p *HasLicenseCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
+func (p *HasLicenseCheck) Validate(image string) (bool, error) {
 	stdouterr, err := exec.Command("podman", "run", "-it", "--rm", "--entrypoint", "ls", image, "-A", "/licenses").CombinedOutput()
 	result := string(stdouterr)
 	if err != nil {
 		if strings.Contains(result, "No such file or directory") || result == "" {
-			logger.Warn("license not found in the container image at /licenses")
+			log.Warn("license not found in the container image at /licenses")
 			return false, nil
 		}
 
-		logger.Error("some error attempting to identify if /licenses container the license: ", err)
+		log.Error("some error attempting to identify if /licenses container the license: ", err)
 		return false, err
 	}
 
 	// sanity check - in case we don't get an error, but also don't have the file.
 	if strings.Contains(result, "No such file or directory") || result == "" {
-		logger.Warn("license not found in the container image at /licenses")
+		log.Warn("license not found in the container image at /licenses")
 		return false, nil
 	}
 

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -3,12 +3,11 @@ package shell
 import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type HasMinimalVulnerabilitiesCheck struct{}
 
-func (p *HasMinimalVulnerabilitiesCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
+func (p *HasMinimalVulnerabilitiesCheck) Validate(image string) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 func (p *HasMinimalVulnerabilitiesCheck) Name() string {

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -6,15 +6,15 @@ import (
 	"os/exec"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type HasNoProhibitedPackagesCheck struct{}
 
-func (p *HasNoProhibitedPackagesCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
+func (p *HasNoProhibitedPackagesCheck) Validate(image string) (bool, error) {
 	stdouterr, err := exec.Command("podman", "run", "-it", "--rm", "--entrypoint", "rpm", image, "-qa", "--queryformat", "%{NAME}\n").CombinedOutput()
 	if err != nil {
-		logger.Error("unable to get a list of all packages in the image")
+		log.Error("unable to get a list of all packages in the image")
 		return false, err
 	}
 
@@ -22,7 +22,7 @@ func (p *HasNoProhibitedPackagesCheck) Validate(image string, logger *logrus.Log
 	for scanner.Scan() {
 		for _, pkg := range prohibitedPackageList {
 			if pkg == scanner.Text() {
-				logger.Warn("found a prohibited package in the container image: ", pkg)
+				log.Warn("found a prohibited package in the container image: ", pkg)
 				return false, nil
 			}
 		}

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -7,16 +7,16 @@ import (
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type HasUniqueTagCheck struct{}
 
-func (p *HasUniqueTagCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
+func (p *HasUniqueTagCheck) Validate(image string) (bool, error) {
 	imageName := strings.Split(image, ":")[0]
 	stdouterr, err := exec.Command("skopeo", "list-tags", "docker://"+imageName).CombinedOutput()
 	if err != nil {
-		logger.Error("unable to execute skopeo on the image: ", err)
+		log.Error("unable to execute skopeo on the image: ", err)
 		return false, err
 	}
 
@@ -24,9 +24,9 @@ func (p *HasUniqueTagCheck) Validate(image string, logger *logrus.Logger) (bool,
 	var skopeoData map[string]interface{}
 	err = json.Unmarshal(stdouterr, &skopeoData)
 	if err != nil {
-		logger.Error("unable to parse skopeo list-tags data for image", err)
-		logger.Debug("error marshaling skopeo list-tags data: ", err)
-		logger.Trace("failure in attempt to convert the raw bytes from `skopeo list-tags` to a [map[string]interface{}")
+		log.Error("unable to parse skopeo list-tags data for image", err)
+		log.Debug("error marshaling skopeo list-tags data: ", err)
+		log.Trace("failure in attempt to convert the raw bytes from `skopeo list-tags` to a [map[string]interface{}")
 		return false, err
 	}
 	tags := skopeoData["Tags"].([]interface{})
@@ -35,7 +35,7 @@ func (p *HasUniqueTagCheck) Validate(image string, logger *logrus.Logger) (bool,
 	for _, tag := range tags {
 		tagsString = tagsString + tag.(string) + " "
 	}
-	logger.Debugf(fmt.Sprintf("detected these tags for %s image: %s", imageName, tagsString))
+	log.Debugf(fmt.Sprintf("detected these tags for %s image: %s", imageName, tagsString))
 
 	if len(tags) > 1 || len(tags) == 1 && strings.ToLower(tags[0].(string)) != "latest" {
 		return true, nil

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type RunAsNonRootCheck struct{}
 
-func (p *RunAsNonRootCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
+func (p *RunAsNonRootCheck) Validate(image string) (bool, error) {
 	cmd := exec.Command("podman", "run", "-it", "--rm", "--entrypoint", "id", image, "-u")
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -20,9 +20,9 @@ func (p *RunAsNonRootCheck) Validate(image string, logger *logrus.Logger) (bool,
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		logger.Error("unable to get the id of the runtime user of this image")
-		logger.Debugf("stdout: %s", out.String())
-		logger.Debugf("stderr: %s", stderr.String())
+		log.Error("unable to get the id of the runtime user of this image")
+		log.Debugf("stdout: %s", out.String())
+		log.Debugf("stderr: %s", stderr.String())
 		return false, err
 	}
 
@@ -30,12 +30,12 @@ func (p *RunAsNonRootCheck) Validate(image string, logger *logrus.Logger) (bool,
 	stdoutString := strings.TrimSpace(out.String())
 	uid, err := strconv.Atoi(stdoutString)
 	if err != nil {
-		logger.Error("unable to determine the runtime user id of the image")
-		logger.Debug("expected a value that could be converted to an integer, and got: ", out.String())
+		log.Error("unable to determine the runtime user id of the image")
+		log.Debug("expected a value that could be converted to an integer, and got: ", out.String())
 		return false, err
 	}
 
-	logger.Debugf("the runtime user id is %d", uid)
+	log.Debugf("the runtime user id is %d", uid)
 
 	if uid != 0 {
 		return true, nil

--- a/certification/internal/shell/shell_suite_test.go
+++ b/certification/internal/shell/shell_suite_test.go
@@ -1,38 +1,13 @@
 package shell
 
 import (
-	"fmt"
-	"io"
-	"os"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-)
-
-var (
-	logger *logrus.Logger
 )
 
 func TestShell(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Shell Suite")
 }
-
-var _ = BeforeSuite(func() {
-	logger = logrus.New()
-
-	time := time.Now().Unix()
-	logname := fmt.Sprintf("preflight-test-%d.log", time)
-	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0700)
-	if err == nil {
-		mw := io.MultiWriter(os.Stdout, logFile)
-		logger.SetOutput(mw)
-	} else {
-		logger.Info("Failed to log to file, using default stderr")
-	}
-	logger.SetFormatter(&logrus.TextFormatter{})
-	logger.SetLevel(logrus.TraceLevel)
-})

--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type ValidateOperatorBundlePolicy struct {
 }
 
-func (p ValidateOperatorBundlePolicy) Validate(bundle string, logger *logrus.Logger) (bool, error) {
+func (p ValidateOperatorBundlePolicy) Validate(bundle string) (bool, error) {
 	stdouterr, err := exec.Command("operator-sdk", "bundle", "validate", "-b", "podman", "--verbose", bundle).CombinedOutput()
 	if err != nil {
-		logger.Error("Error will executing operator-sdk validate bundle: ", err)
+		log.Error("Error will executing operator-sdk validate bundle: ", err)
 		return false, err
 	}
 
@@ -23,7 +23,7 @@ func (p ValidateOperatorBundlePolicy) Validate(bundle string, logger *logrus.Log
 	if strings.Contains(lines[len(lines)-1], "All validation tests have completed successfully") {
 		return true, nil
 	}
-	logger.Warn("The bundle image did not pass all of the validation tests")
+	log.Warn("The bundle image did not pass all of the validation tests")
 	return false, nil
 }
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -6,23 +6,19 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
-var logger *logrus.Logger
-
 func init() {
-	logger = logrus.New()
-
 	time := time.Now().Unix()
 	logname := fmt.Sprintf("preflight-%d.log", time)
 	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0700)
 	if err == nil {
 		mw := io.MultiWriter(os.Stdout, logFile)
-		logger.SetOutput(mw)
+		log.SetOutput(mw)
 	} else {
-		logger.Info("Failed to log to file, using default stderr")
+		log.Info("Failed to log to file, using default stderr")
 	}
-	logger.SetFormatter(&logrus.TextFormatter{})
-	logger.SetLevel(logrus.TraceLevel)
+	log.SetFormatter(&log.TextFormatter{})
+	log.SetLevel(log.TraceLevel)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		engine.ExecuteChecks(logger)
+		engine.ExecuteChecks()
 		results := engine.Results()
 
 		// return results to the user


### PR DESCRIPTION
Originally, the logger was being passed around, and was a part of the
main interfaces. This removes that dependency, and allows code to just
import logrus as 'log' and be able to log without setup or passing the
logger around. This patch maintains backwards compatibility with the
functionality that existed for the logger.

Signed-off-by: Brad P. Crochet <brad@redhat.com>