### PR TITLE
Add OWNERS file for openshift-ci

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+owners:
+
+approvers:
+- bcrochet
+- jomkz
+- komish
+- samira-barouti
+- tonytcampbell
+
+reviewers:


### PR DESCRIPTION
This PR adds the initial OWNERS file for use with openshift-ci and addresses #20.

The file should include everyone that has contributed so far in some way up to this point. The owners list comes from the members of the [preflight-maintainers](https://github.com/orgs/redhat-openshift-ecosystem/teams/preflight-maintainers) team on the [redhat-openshift-ecosystem](https://github.com/redhat-openshift-ecosystem) GitHub organization.

We can add additional people to this file as needed in the future.

Signed-off-by: John McKenzie <john@mkz.io>