### PR TITLE
Extract common test logic into helper functions

### DIFF
--- a/certification/internal/shell/base_on_ubi_test.go
+++ b/certification/internal/shell/base_on_ubi_test.go
@@ -2,9 +2,7 @@ package shell
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
-	log "github.com/sirupsen/logrus"
 )
 
 // podmanEngine is a package-level variable. In some tests, we
@@ -31,11 +29,7 @@ NAME="Red Hat Enterprise Linux"
 			BeforeEach(func() {
 				podmanEngine = fakeEngine
 			})
-			It("should pass Validate", func() {
-				ok, err := baseOnUbiCheck.Validate("dummy/image")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ok).To(BeTrue())
-			})
+			checkShouldPassValidate(&baseOnUbiCheck)()
 		})
 		Context("When it is not based on UBI", func() {
 			BeforeEach(func() {
@@ -43,25 +37,8 @@ NAME="Red Hat Enterprise Linux"
 				engine.RunReportStdout = `ID="notrhel"`
 				podmanEngine = engine
 			})
-			It("should not pass Validate", func() {
-				log.Errorf("Run Report: %s", podmanEngine)
-				ok, err := baseOnUbiCheck.Validate("dummy/image")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ok).To(BeFalse())
-			})
+			checkShouldNotPassValidate(&baseOnUbiCheck)()
 		})
 	})
-	Describe("Checking that PodMan errors are handled correctly", func() {
-		BeforeEach(func() {
-			fakeEngine = BadPodmanEngine{}
-			podmanEngine = fakeEngine
-		})
-		Context("When PodMan throws an error", func() {
-			It("should fail Validate and return an error", func() {
-				ok, err := baseOnUbiCheck.Validate("dummy/image")
-				Expect(err).To(HaveOccurred())
-				Expect(ok).To(BeFalse())
-			})
-		})
-	})
+	checkPodmanErrors(&baseOnUbiCheck)()
 })

--- a/certification/internal/shell/has_required_labels_test.go
+++ b/certification/internal/shell/has_required_labels_test.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -38,35 +37,15 @@ var _ = Describe("HasRequiredLabels", func() {
 
 	Describe("Checking for required labels", func() {
 		Context("When it has required labels", func() {
-			It("should pass Validate", func() {
-				ok, err := hasRequiredLabelsCheck.Validate("dummy/image")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ok).To(BeTrue())
-			})
+			It("should pass Validate", checkShouldPassValidate(&hasRequiredLabelsCheck))
 		})
 		Context("When it does not have required labels", func() {
 			BeforeEach(func() {
 				engine := fakeEngine.(FakePodmanEngine)
 				delete(engine.ImageInspectReport.Images[0].Config.Labels, "description")
 			})
-			It("should not succeed the check", func() {
-				ok, err := hasRequiredLabelsCheck.Validate("dummy/image")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ok).To(BeFalse())
-			})
+			It("should not pass Validate", checkShouldNotPassValidate(&hasRequiredLabelsCheck))
 		})
 	})
-	Describe("Checking that PodMan errors are handled correctly", func() {
-		BeforeEach(func() {
-			fakeEngine = BadPodmanEngine{}
-			podmanEngine = fakeEngine
-		})
-		Context("When PodMan throws an error", func() {
-			It("should fail Validate and return an error", func() {
-				ok, err := hasRequiredLabelsCheck.Validate("dummy/image")
-				Expect(err).To(HaveOccurred())
-				Expect(ok).To(BeFalse())
-			})
-		})
-	})
+	checkPodmanErrors(&hasRequiredLabelsCheck)()
 })

--- a/certification/internal/shell/shell_suite_test.go
+++ b/certification/internal/shell/shell_suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
@@ -90,4 +91,39 @@ func (bpe BadPodmanEngine) Save(nameOrID string, tags []string, opts cli.ImageSa
 
 func (bpe BadPodmanEngine) InspectImage(rawImage string, opts cli.ImageInspectOptions) (*cli.ImageInspectReport, error) {
 	return nil, errors.New("the Podman Inspect Image has failed")
+}
+
+func checkPodmanErrors(check certification.Check) func() {
+	return func() {
+		Describe("Checking that Podman errors are handled correctly", func() {
+			BeforeEach(func() {
+				fakeEngine := BadPodmanEngine{}
+				podmanEngine = fakeEngine
+			})
+			Context("When PodMan throws an error", func() {
+				It("should fail Validate and return an error", func() {
+					ok, err := check.Validate("dummy/image")
+					Expect(err).To(HaveOccurred())
+					Expect(ok).To(BeFalse())
+				})
+			})
+		})
+
+	}
+}
+
+func checkShouldPassValidate(check certification.Check) func() {
+	return func() {
+		ok, err := check.Validate("dummy/image")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	}
+}
+
+func checkShouldNotPassValidate(check certification.Check) func() {
+	return func() {
+		ok, err := check.Validate("dummy/image")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	}
 }


### PR DESCRIPTION
The unit tests for each of the checks follow a basic pattern.

Set up the fake engine
Verify that is passes Validate
Modify the fake engine for a failure mode
Verify that it does not pass Validate
Verify that Podman errors are handled properly

This extracts the verifications into helper functions that can be reused
to cut down on the boilerplate.

Fixes #44