### PR TITLE
Turn on github action using existing make targets

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,22 @@
+name: Go
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ image-push:
 
 .PHONY: test
 test:
-	go test -v ./... 
+	go test -v $(go list ./... | grep -v e2e)
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
We have low test coverage for now, but there's an active effort working on addressing that. This turns on a GitHub Action that just runs `make build` and `make test` (i.e. what we're likely already doing in code reviews)

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

EDIT: full disclosure, I'm not sure of a way to test that make test make build functions in the GH action environment right now (it's not doing anything in my fork for some reason), so this may need some tweaking after merged. I can send a dummy PR to confirm.