### PR TITLE
Add Unit tests for UniqueTagCheck and refactor the check (Fixes #37)

### DIFF
--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -1,9 +1,7 @@
 package shell
 
 import (
-	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -13,34 +11,34 @@ import (
 type HasUniqueTagCheck struct{}
 
 func (p *HasUniqueTagCheck) Validate(image string) (bool, error) {
-	imageName := strings.Split(image, ":")[0]
-	stdouterr, err := exec.Command("skopeo", "list-tags", "docker://"+imageName).CombinedOutput()
+	tags, err := p.getDataToValidate(image)
+	if err != nil {
+		return false, err
+	}
+	return p.validate(image, tags)
+}
+
+func (p *HasUniqueTagCheck) getDataToValidate(image string) ([]string, error) {
+
+	runReport, err := skopeoEngine.ListTags(image)
+
 	if err != nil {
 		log.Error("unable to execute skopeo on the image: ", err)
-		return false, err
+		return nil, err
 	}
 
-	// we must send gojq a []interface{}, so we have to convert our inspect output to that type
-	var skopeoData map[string]interface{}
-	err = json.Unmarshal(stdouterr, &skopeoData)
-	if err != nil {
-		log.Error("unable to parse skopeo list-tags data for image", err)
-		log.Debug("error marshaling skopeo list-tags data: ", err)
-		log.Trace("failure in attempt to convert the raw bytes from `skopeo list-tags` to a [map[string]interface{}")
-		return false, err
-	}
-	tags := skopeoData["Tags"].([]interface{})
+	return runReport.Tags, nil
+}
 
-	var tagsString string
-	for _, tag := range tags {
-		tagsString = tagsString + tag.(string) + " "
-	}
-	log.Debugf(fmt.Sprintf("detected these tags for %s image: %s", imageName, tagsString))
+func (p *HasUniqueTagCheck) validate(image string, tags []string) (bool, error) {
 
-	if len(tags) > 1 || len(tags) == 1 && strings.ToLower(tags[0].(string)) != "latest" {
-		return true, nil
-	}
-	return false, nil
+	log.Debugf(fmt.Sprintf("detected these tags for %s: %s", strings.Split(image, ":")[0], tags))
+
+	// An image passes the check if:
+	// 1) it has more than one tag (`latest` is acceptable)
+	// OR
+	// 2) it has only one tag, and it is not `latest`
+	return len(tags) > 1 || len(tags) == 1 && strings.ToLower(tags[0]) != "latest", nil
 }
 
 func (p *HasUniqueTagCheck) Name() string {

--- a/certification/internal/shell/has_unique_tag_test.go
+++ b/certification/internal/shell/has_unique_tag_test.go
@@ -1,0 +1,76 @@
+package shell
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	log "github.com/sirupsen/logrus"
+)
+
+// podmanEngine is a package-level variable. In some tests, we
+// override it with a "happy path" engine, that returns good data.
+// In the unhappy path, we override it with an engine that returns
+// nothing but errors.
+
+var _ = Describe("UniqueTag", func() {
+	var (
+		hasUniqueTagCheck HasUniqueTagCheck
+		fakeEngine        cli.SkopeoEngine
+	)
+
+	BeforeEach(func() {
+		fakeEngine = FakeSkopeoEngine{
+			SkopeoReportStdout: "",
+			Tags:               validImageTags(),
+			SkopeoReportStderr: "",
+		}
+	})
+	Describe("Checking for unique tags", func() {
+		Context("When it has tags other than latest", func() {
+			BeforeEach(func() {
+				skopeoEngine = fakeEngine
+			})
+			It("should pass Validate", func() {
+				ok, err := hasUniqueTagCheck.Validate("dummy/image")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When it has only latest tag", func() {
+			BeforeEach(func() {
+				engine := fakeEngine.(FakeSkopeoEngine)
+				engine.SkopeoReportStdout = ""
+				engine.Tags = invalidImageTags()
+				engine.SkopeoReportStderr = ""
+				skopeoEngine = engine
+			})
+			It("should not pass Validate", func() {
+				log.Errorf("Run Report: %s", skopeoEngine)
+				ok, err := hasUniqueTagCheck.Validate("dummy/image")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+	Describe("Checking that SkopeoEngine errors are handled correctly", func() {
+		BeforeEach(func() {
+			fakeEngine = BadSkopeoEngine{}
+			skopeoEngine = fakeEngine
+		})
+		Context("When Skopeo throws an error", func() {
+			It("should fail Validate and return an error", func() {
+				ok, err := hasUniqueTagCheck.Validate("dummy/image")
+				Expect(err).To(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})
+
+func validImageTags() []string {
+	return []string{"0.0.1", "0.0.2", "latest"}
+}
+
+func invalidImageTags() []string {
+	return []string{"latest"}
+}

--- a/certification/internal/shell/shell.go
+++ b/certification/internal/shell/shell.go
@@ -9,8 +9,10 @@ import "github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 // at the test level.
 var (
 	podmanEngine cli.PodmanEngine
+	skopeoEngine cli.SkopeoEngine
 )
 
 func init() {
 	podmanEngine = PodmanCLIEngine{}
+	skopeoEngine = SkopeoCLIEngine{}
 }

--- a/certification/internal/shell/skopeo.go
+++ b/certification/internal/shell/skopeo.go
@@ -1,0 +1,45 @@
+package shell
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	log "github.com/sirupsen/logrus"
+)
+
+type SkopeoCLIEngine struct{}
+
+func (e SkopeoCLIEngine) ListTags(image string) (*cli.SkopeoListTagsReport, error) {
+	imageName := strings.Split(image, ":")[0]
+	cmd := exec.Command("skopeo", "list-tags", "docker://"+imageName)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err != nil {
+		return nil, err
+	}
+	var skopeoData map[string]interface{}
+
+	err = json.Unmarshal(stdout.Bytes(), &skopeoData)
+	if err != nil {
+		log.Error("unable to parse skopeo list-tags data for image", err)
+		log.Debug("error marshaling skopeo list-tags data: ", err)
+		log.Trace("failure in attempt to convert the raw bytes from `skopeo list-tags` to a [map[string]interface{}")
+		return nil, err
+	}
+	jsonData := skopeoData["Tags"].([]interface{})
+
+	var tags []string = make([]string, len(jsonData))
+
+	for i, tag := range jsonData {
+		tags[i] = tag.(string)
+	}
+
+	return &cli.SkopeoListTagsReport{Stdout: stdout.String(), Tags: tags, Stderr: stderr.String()}, nil
+}

--- a/cli/skopeo.go
+++ b/cli/skopeo.go
@@ -1,0 +1,11 @@
+package cli
+
+type SkopeoListTagsReport struct {
+	Stdout string
+	Stderr string
+	Tags   []string
+}
+
+type SkopeoEngine interface {
+	ListTags(rawImage string) (*SkopeoListTagsReport, error)
+}


### PR DESCRIPTION
This PR adds the unit tests for UniqueTagCheck and refactor the checks to make it testable.