### PR TITLE
Make tests run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ image-push:
 
 .PHONY: test
 test:
-	go test -v $(go list ./... | grep -v e2e)
+	# go test -v $(go list ./... | grep -v e2e)
+	go test -v  ./...
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
While the GH check is working nicely, the make test command isn't finding any tests.  I set this back to the value it was before  PR #48. @komish you will likely want to take another look at `go test -v $(go list ./... | grep -v e2e)`.  