### PR TITLE
Fix Makefile bug preventing tests from being detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ image-push:
 
 .PHONY: test
 test:
-	go test -v $(go list ./... | grep -v e2e)
+	go test -v $$(go list ./... | grep -v e2e)
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
Introduced a bug when changing the Makefile's `test` target to explicitly skip e2e tests in a normal workflow. This was caused by an improper call out to a subshell due to a missing `$` character.

This PR should resolve, and also allow us to close #56 which reverted the change to temporarily resolve the issue.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>