### PR TITLE
Add formatter unit tests

### DIFF
--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -14,22 +14,6 @@ type ResponseFormatter interface {
 	Format(runtime.Results) (response []byte, formattingError error)
 }
 
-// GenericFormatter represents a generic approach to formatting that implements the
-// ResponseFormatter interface. Can be leveraged to build a custom formatter quickly.
-type GenericFormatter struct {
-	Name          string
-	FormatterFunc FormatterFunc
-}
-
-// Name returns a string identification of the formatter that's in use.
-func (f *GenericFormatter) PrettyName() string {
-	return f.Name
-}
-
-func (f *GenericFormatter) Format(r runtime.Results) ([]byte, error) {
-	return f.FormatterFunc(r)
-}
-
 // FormatterFunc describes a function that formats the check validation
 // results.
 type FormatterFunc = func(runtime.Results) (response []byte, formattingError error)
@@ -58,7 +42,7 @@ func New(name string, fn FormatterFunc) (ResponseFormatter, error) {
 		)
 	}
 
-	gf := GenericFormatter{
+	gf := genericFormatter{
 		Name:          name,
 		FormatterFunc: fn,
 	}
@@ -66,11 +50,27 @@ func New(name string, fn FormatterFunc) (ResponseFormatter, error) {
 	return &gf, nil
 }
 
+// genericFormatter represents a generic approach to formatting that implements the
+// ResponseFormatter interface. Can be leveraged to build a custom formatter quickly.
+type genericFormatter struct {
+	Name          string
+	FormatterFunc FormatterFunc
+}
+
+// Name returns a string identification of the formatter that's in use.
+func (f *genericFormatter) PrettyName() string {
+	return f.Name
+}
+
+func (f *genericFormatter) Format(r runtime.Results) ([]byte, error) {
+	return f.FormatterFunc(r)
+}
+
 // availableFormatters maps configuration-friendly values to pretty representations
 // of the same value, and their corresponding Formatter included with this library.
 var availableFormatters = map[string]ResponseFormatter{
-	"json": &GenericFormatter{"Generic JSON", genericJSONFormatter},
-	"xml":  &GenericFormatter{"Generic XML", genericXMLFormatter},
+	"json": &genericFormatter{"Generic JSON", genericJSONFormatter},
+	"xml":  &genericFormatter{"Generic XML", genericXMLFormatter},
 }
 
 // AllFormats returns all formats and formatters made available by this library.

--- a/certification/formatters/formatters_suite_test.go
+++ b/certification/formatters/formatters_suite_test.go
@@ -1,0 +1,13 @@
+package formatters
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFormatters(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Formatters Suite")
+}

--- a/certification/formatters/formatters_test.go
+++ b/certification/formatters/formatters_test.go
@@ -1,0 +1,83 @@
+package formatters_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cmd"
+)
+
+var _ = Describe("Formatters", func() {
+	Describe("When getting a new formatter for a configuration", func() {
+		Context("with a valid configuration", func() {
+			cfg := runtime.Config{
+				ResponseFormat: "json",
+			}
+
+			It("should return a formatter and no error", func() {
+				formatter, err := formatters.NewForConfig(cfg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(formatter).ToNot(BeNil())
+			})
+		})
+
+		Context("with an unknown format requested by the user", func() {
+			cfg := runtime.Config{
+				ResponseFormat: "unknownFormat",
+			}
+
+			It("should return an error", func() {
+				formatter, err := formatters.NewForConfig(cfg)
+
+				Expect(err).To(HaveOccurred())
+				Expect(formatter).To(BeNil())
+			})
+		})
+	})
+
+	Describe("When creating a new generic formatter", func() {
+		Context("with proper arguments", func() {
+			var expectedResult []byte = []byte("this is a test")
+			var name string = "testFormatter"
+			var fn formatters.FormatterFunc = func(runtime.Results) ([]byte, error) {
+				return expectedResult, nil
+			}
+
+			formatter, err := formatters.New(name, fn)
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(formatter).ToNot(BeNil())
+			})
+
+			formattingResult, err := formatter.Format(runtime.Results{})
+			It("should format results as expected", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(formattingResult).To(Equal(expectedResult))
+			})
+
+			It("should be identifiable as the provided name", func() {
+				Expect(formatter.PrettyName()).To(Equal(name))
+			})
+		})
+	})
+
+	Describe("When querying all supported formats", func() {
+		all := formatters.AllFormats()
+		It("should support at least one format", func() {
+			Expect(len(all)).ToNot(BeZero())
+		})
+
+		It("should support the default format", func() {
+			var exists = false
+			for _, format := range all {
+				if format == cmd.DefaultOutputFormat {
+					exists = true
+					break
+				}
+			}
+
+			Expect(exists).To(BeTrue())
+		})
+	})
+})

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -30,8 +30,8 @@ var checkContainerCmd = &cobra.Command{
 		cfg := runtime.Config{
 			Image:          containerImage,
 			EnabledChecks:  engine.ContainerPolicy(),
-			ResponseFormat: defaultOutputFormat,
-			LogFile:        defaultLogFile,
+			ResponseFormat: DefaultOutputFormat,
+			LogFile:        DefaultLogFile,
 		}
 
 		if err := initLogger(cfg); err != nil {

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -30,8 +30,8 @@ var checkOperatorCmd = &cobra.Command{
 		cfg := runtime.Config{
 			Image:          operatorImage,
 			EnabledChecks:  engine.OperatorPolicy(),
-			ResponseFormat: defaultOutputFormat,
-			LogFile:        defaultLogFile,
+			ResponseFormat: DefaultOutputFormat,
+			LogFile:        DefaultLogFile,
 		}
 
 		if err := initLogger(cfg); err != nil {

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,6 +1,6 @@
 package cmd
 
 var (
-	defaultOutputFormat = "json"
-	defaultLogFile      = "preflight.log"
+	DefaultOutputFormat = "json"
+	DefaultLogFile      = "preflight.log"
 )


### PR DESCRIPTION
This PR adds unit tests to the formatters package. It contains three commits:

* Unexported the genericFormatter struct, forcing developers to utilize the instantiator `New(...)` function. This was the original goal. There's no functional benefit to having direct access to the struct, so we reduce our API surface by removing it.
* Publishes the default configuration options. I believe this is also covered in another unmerged PR, so I can fix this later if need be depending on what merges first.
* Implements unit tests for the `formatters` package.

Fixes #67 