### PR TITLE
Add a unit test for Less than max layers check

### DIFF
--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -1,12 +1,10 @@
 package shell
 
 import (
-	"encoding/json"
 	"fmt"
-	"os/exec"
 
-	"github.com/itchyny/gojq"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,55 +16,26 @@ type UnderLayerMaxCheck struct{}
 
 func (p *UnderLayerMaxCheck) Validate(image string) (bool, error) {
 	// TODO: if we're going have the image json on disk already, we should use it here instead of podman inspect-ing.
-	stdouterr, err := exec.Command("podman", "inspect", image).CombinedOutput()
+	layers, err := p.getDataToValidate(image)
 	if err != nil {
-		log.Error("unable to execute inspect on the image: ", err)
 		return false, err
 	}
 
-	// we must send gojq a []interface{}, so we have to convert our inspect output to that type
-	var inspectData []interface{}
-	err = json.Unmarshal(stdouterr, &inspectData)
+	return p.validate(layers)
+}
+
+func (p *UnderLayerMaxCheck) getDataToValidate(image string) ([]string, error) {
+	inspectData, err := podmanEngine.InspectImage(image, cli.ImageInspectOptions{})
 	if err != nil {
-		log.Error("unable to parse podman inspect data for image", err)
-		log.Debug("error marshaling podman inspect data: ", err)
-		log.Trace("failure in attempt to convert the raw bytes from `podman inspect` to a []interface{}")
-		return false, err
+		return nil, err
 	}
 
-	query, err := gojq.Parse(".[0].RootFS.Layers")
-	if err != nil {
-		log.Error("unable to parse podman inspect data for image", err)
-		log.Debug("unable to successfully parse the gojq query string:", err)
-		return false, err
-	}
+	return inspectData.Images[0].RootFS.Layers, nil
+}
 
-	// gojq expects us to iterate in the event that our query returned multiple matching values, but we only expect one.
-	iter := query.Run(inspectData)
-	val, nextOk := iter.Next()
-
-	if !nextOk {
-		log.Warn("did not receive any layer information when parsing container image")
-		// in this case, there was no data returned from jq, so we need to fail the check.
-		return false, nil
-	}
-
-	// gojq can return an error in iteration, so we need to check for that.
-	if err, ok := val.(error); ok {
-		log.Error("unable to parse podman inspect data for image", err)
-		log.Debug("unable to successfully parse the podman inspect output with the query string provided:", err)
-		// this is an error, as we didn't get the proper input from `podman inspect`
-		return false, err
-	}
-
-	layers := val.([]interface{})
-
+func (p *UnderLayerMaxCheck) validate(layers []string) (bool, error) {
 	log.Debugf("detected %d layers in image", len(layers))
-	if len(layers) < acceptableLayerMax {
-		return true, nil
-	}
-
-	return false, nil
+	return len(layers) <= acceptableLayerMax, nil
 }
 
 func (p *UnderLayerMaxCheck) Name() string {

--- a/certification/internal/shell/less_than_max_layers_test.go
+++ b/certification/internal/shell/less_than_max_layers_test.go
@@ -1,0 +1,75 @@
+package shell
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+)
+
+var _ = Describe("LessThanMaxLayers", func() {
+	var (
+		lessThanMaxLayers UnderLayerMaxCheck
+		fakeEngine        cli.PodmanEngine
+	)
+
+	BeforeEach(func() {
+		layers := make([]string, 5)
+		for i, _ := range layers {
+			layers[i] = fmt.Sprintf("layer%d", i)
+		}
+		fakeEngine = FakePodmanEngine{
+			ImageInspectReport: cli.ImageInspectReport{
+				Images: []cli.PodmanImage{
+					{
+						Id: "imageid",
+						RootFS: cli.PodmanRootFS{
+							Type:   "layers",
+							Layers: layers,
+						},
+					},
+				},
+			},
+		}
+		podmanEngine = fakeEngine
+	})
+
+	Describe("Checking for less than max layers", func() {
+		Context("When it has fewer layers than max", func() {
+			It("should pass Validate", func() {
+				ok, err := lessThanMaxLayers.Validate("dummy/image")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When has more layers than max", func() {
+			BeforeEach(func() {
+				engine := fakeEngine.(FakePodmanEngine)
+				layers := make([]string, 50)
+				for i, _ := range layers {
+					layers[i] = fmt.Sprintf("layer%d", i)
+				}
+				engine.ImageInspectReport.Images[0].RootFS.Layers = layers
+			})
+			It("should not succeed the check", func() {
+				ok, err := lessThanMaxLayers.Validate("dummy/image")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+	Describe("Checking that PodMan errors are handled correctly", func() {
+		BeforeEach(func() {
+			fakeEngine = BadPodmanEngine{}
+			podmanEngine = fakeEngine
+		})
+		Context("When PodMan throws an error", func() {
+			It("should fail Validate and return an error", func() {
+				ok, err := lessThanMaxLayers.Validate("dummy/image")
+				Expect(err).To(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})

--- a/cli/podman.go
+++ b/cli/podman.go
@@ -37,10 +37,16 @@ type ImageSaveOptions struct {
 type PodmanImage struct {
 	Id     string
 	Config PodmanImageConfig
+	RootFS PodmanRootFS
 }
 
 type PodmanImageConfig struct {
 	Labels map[string]string
+}
+
+type PodmanRootFS struct {
+	Type   string
+	Layers []string
 }
 
 type PodmanEngine interface {


### PR DESCRIPTION
Creates a unit test for max layers.
Refactors the check class to use the podman engine.
Add the RootFS to the inspect image unmarshal.

Fixes #71

Signed-off-by: Brad P. Crochet <brad@redhat.com>