### PR TITLE
Add log level default definition and use it in logging init

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -3,4 +3,5 @@ package cmd
 var (
 	DefaultOutputFormat = "json"
 	DefaultLogFile      = "preflight.log"
+	DefaultLogLevel     = "warn"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,8 +45,8 @@ func initConfig() {
 	}
 
 	// Set up logging config defaults
-	viper.SetDefault("logfile", "preflight.log")
-	viper.SetDefault("loglevel", "warn")
+	viper.SetDefault("logfile", DefaultLogFile)
+	viper.SetDefault("loglevel", DefaultLogLevel)
 
 	// set up logging
 	logname := viper.GetString("logfile")


### PR DESCRIPTION
Quick fix up after #55 - this PR just adds the log level to the default configurations and uses those in our logg initialization logic.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>