### PR TITLE
Simplify the json parsing in HasUniqueTags check

### DIFF
--- a/certification/internal/shell/skopeo.go
+++ b/certification/internal/shell/skopeo.go
@@ -24,22 +24,18 @@ func (e SkopeoCLIEngine) ListTags(image string) (*cli.SkopeoListTagsReport, erro
 	if err != nil {
 		return nil, err
 	}
-	var skopeoData map[string]interface{}
 
-	err = json.Unmarshal(stdout.Bytes(), &skopeoData)
+	var report cli.SkopeoListTagsReport
+
+	err = json.Unmarshal(stdout.Bytes(), &report)
 	if err != nil {
 		log.Error("unable to parse skopeo list-tags data for image", err)
 		log.Debug("error marshaling skopeo list-tags data: ", err)
 		log.Trace("failure in attempt to convert the raw bytes from `skopeo list-tags` to a [map[string]interface{}")
 		return nil, err
 	}
-	jsonData := skopeoData["Tags"].([]interface{})
+	report.Stdout = stdout.String()
+	report.Stderr = stderr.String()
 
-	var tags []string = make([]string, len(jsonData))
-
-	for i, tag := range jsonData {
-		tags[i] = tag.(string)
-	}
-
-	return &cli.SkopeoListTagsReport{Stdout: stdout.String(), Tags: tags, Stderr: stderr.String()}, nil
+	return &report, nil
 }


### PR DESCRIPTION
This cuts out the manual processing, and lets the json.Unmarshal handle it.

Signed-off-by: Brad P. Crochet <brad@redhat.com>