### PR TITLE
Write results to disk and to stdout

### DIFF
--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -10,7 +10,13 @@ import (
 // ResponseFormatter describes the expected methods a formatter
 // must implement.
 type ResponseFormatter interface {
+	// PrettyName is the name used to represent this formatter.
 	PrettyName() string
+	// FileExtension represents the file extension one might use when creating
+	// a file with the contents of this formatter.
+	FileExtension() string
+	// Format takes Results, formats it as needed, and returns the formatted
+	// results ready to write as a byte slice.
 	Format(runtime.Results) (response []byte, formattingError error)
 }
 
@@ -34,7 +40,7 @@ func NewForConfig(cfg runtime.Config) (ResponseFormatter, error) {
 }
 
 // New returns a new formatter with the provided name and FormatterFunc.
-func New(name string, fn FormatterFunc) (ResponseFormatter, error) {
+func New(name, extension string, fn FormatterFunc) (ResponseFormatter, error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf(
 			"failed to create a new generic formatter: %w",
@@ -43,8 +49,9 @@ func New(name string, fn FormatterFunc) (ResponseFormatter, error) {
 	}
 
 	gf := genericFormatter{
-		Name:          name,
-		FormatterFunc: fn,
+		name:          name,
+		formatterFunc: fn,
+		fileExtension: extension,
 	}
 
 	return &gf, nil
@@ -53,35 +60,27 @@ func New(name string, fn FormatterFunc) (ResponseFormatter, error) {
 // genericFormatter represents a generic approach to formatting that implements the
 // ResponseFormatter interface. Can be leveraged to build a custom formatter quickly.
 type genericFormatter struct {
-	Name          string
-	FormatterFunc FormatterFunc
+	name          string
+	fileExtension string
+	formatterFunc FormatterFunc
 }
 
 // Name returns a string identification of the formatter that's in use.
 func (f *genericFormatter) PrettyName() string {
-	return f.Name
+	return f.name
 }
 
 func (f *genericFormatter) Format(r runtime.Results) ([]byte, error) {
-	return f.FormatterFunc(r)
+	return f.formatterFunc(r)
+}
+
+func (f *genericFormatter) FileExtension() string {
+	return f.fileExtension
 }
 
 // availableFormatters maps configuration-friendly values to pretty representations
 // of the same value, and their corresponding Formatter included with this library.
 var availableFormatters = map[string]ResponseFormatter{
-	"json": &genericFormatter{"Generic JSON", genericJSONFormatter},
-	"xml":  &genericFormatter{"Generic XML", genericXMLFormatter},
-}
-
-// AllFormats returns all formats and formatters made available by this library.
-func AllFormats() []string {
-	all := make([]string, len(availableFormatters))
-	i := 0
-
-	for k := range availableFormatters {
-		all[i] = k
-		i++
-	}
-
-	return all
+	"json": &genericFormatter{"Generic JSON", "json", genericJSONFormatter},
+	"xml":  &genericFormatter{"Generic XML", "xml", genericXMLFormatter},
 }

--- a/certification/formatters/formatters_test.go
+++ b/certification/formatters/formatters_test.go
@@ -1,11 +1,9 @@
-package formatters_test
+package formatters
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/cmd"
 )
 
 var _ = Describe("Formatters", func() {
@@ -16,7 +14,7 @@ var _ = Describe("Formatters", func() {
 			}
 
 			It("should return a formatter and no error", func() {
-				formatter, err := formatters.NewForConfig(cfg)
+				formatter, err := NewForConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(formatter).ToNot(BeNil())
 			})
@@ -28,7 +26,7 @@ var _ = Describe("Formatters", func() {
 			}
 
 			It("should return an error", func() {
-				formatter, err := formatters.NewForConfig(cfg)
+				formatter, err := NewForConfig(cfg)
 
 				Expect(err).To(HaveOccurred())
 				Expect(formatter).To(BeNil())
@@ -40,11 +38,12 @@ var _ = Describe("Formatters", func() {
 		Context("with proper arguments", func() {
 			var expectedResult []byte = []byte("this is a test")
 			var name string = "testFormatter"
-			var fn formatters.FormatterFunc = func(runtime.Results) ([]byte, error) {
+			var extension string = "txt"
+			var fn FormatterFunc = func(runtime.Results) ([]byte, error) {
 				return expectedResult, nil
 			}
 
-			formatter, err := formatters.New(name, fn)
+			formatter, err := New(name, extension, fn)
 			It("should not return an error", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(formatter).ToNot(BeNil())
@@ -59,25 +58,6 @@ var _ = Describe("Formatters", func() {
 			It("should be identifiable as the provided name", func() {
 				Expect(formatter.PrettyName()).To(Equal(name))
 			})
-		})
-	})
-
-	Describe("When querying all supported formats", func() {
-		all := formatters.AllFormats()
-		It("should support at least one format", func() {
-			Expect(len(all)).ToNot(BeZero())
-		})
-
-		It("should support the default format", func() {
-			var exists = false
-			for _, format := range all {
-				if format == cmd.DefaultOutputFormat {
-					exists = true
-					break
-				}
-			}
-
-			Expect(exists).To(BeTrue())
 		})
 	})
 })

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
@@ -43,16 +44,35 @@ var checkOperatorCmd = &cobra.Command{
 			return err
 		}
 
+		// create the results file early to catch cases where we are not
+		// able to write to the filesystem before we attempt to execute checks.
+		resultsFile, err := os.OpenFile(
+			resultsFilenameWithExtension(formatter.FileExtension()),
+			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			0600,
+		)
+
+		if err != nil {
+			return err
+		}
+
+		// also write to stdout
+		resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
+
+		// execute the checks
 		engine.ExecuteChecks()
 		results := engine.Results()
 
-		// return results to the user
+		// return results to the user and then close output files
 		formattedResults, err := formatter.Format(results)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprint(os.Stdout, string(formattedResults))
+		fmt.Fprint(resultsOutputTarget, string(formattedResults))
+		if err := resultsFile.Close(); err != nil {
+			return err
+		}
 
 		return nil
 	},

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,7 @@
+package cmd
+
+import "strings"
+
+func resultsFilenameWithExtension(ext string) string {
+	return strings.Join([]string{"results", ext}, ".")
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cmd package utility functions", func() {
+	Describe("Determine filename to which to write test results", func() {
+		// Ensure resultsFilenameWithExtension accurately joins the
+		// expected default filename of "results" with the extension
+		// that is provided.
+		Context("with an extension of txt", func() {
+			extension := "txt"
+			expected := "results.txt"
+
+			It("should be results.txt", func() {
+				actual := resultsFilenameWithExtension(extension)
+				Expect(actual).To(Equal(expected))
+			})
+		})
+
+		Context("with an extension of txt", func() {
+			extension := "json"
+			expected := "results.json"
+
+			It("should be results.json", func() {
+				actual := resultsFilenameWithExtension(extension)
+				Expect(actual).To(Equal(expected))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Fixes #14 

## Summary

This PR configures preflight to write the check Results to a file as well as stdout using a MultiWriter.

This PR recognizes that different formatter types might have different file extensions, so this extends to ResponseFormatter interface to allow for the definition of the desired file extension [3ad9a1a22c757491d93d20dc345e70424732df4c](https://github.com/redhat-openshift-ecosystem/openshift-preflight/commit/3ad9a1a22c757491d93d20dc345e70424732df4c).

The writers then take this into account to write the file. [48140895b3ae9d6fa17a9da0f9ddcddd2082376b](https://github.com/redhat-openshift-ecosystem/openshift-preflight/commit/48140895b3ae9d6fa17a9da0f9ddcddd2082376b)

## Highlights
- Removed AllFormats() function as it was not in use.
- Made the formatters_test suite and internal test. This was previously an external test suite due to a dependency cycle with the cmd package which has now been removed. An equivalent test should live in the `cmd` package.
- Introduced a new interface method ResponseFormatter.FileExtension() which returns a string containing the file extension someone might use when writing the data from that formatter to disk.
- Expended the genericFormatter to continue implementing the ResponseFormatter interface
- Reduced the public surface of the genericFormatter
- Added comments to the interface definition.
- Added a function that takes the extension defined by the formatter and concatenates it with our expected results file.
- Modified the `check container` and `check operator` subcommands to write to a default file.