### PR TITLE
Fixing a name bug in push-image step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
       id: push-image
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.build-image.outputs.image }}
+        image: preflight
         tags: ${{ steps.build-image.outputs.tags }}
         registry: ${{ env.IMAGE_REGISTRY }}
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
     - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      run: echo "Image pushed to ${{ steps.push-image.outputs.registry-paths }}"


### PR DESCRIPTION
Combining image name "quay.io/opdev/preflight" and registry "quay.io/opdev" to form registry path "quay.io/opdev/quay.io/opdev/preflight"
Warning: "quay.io/opdev/quay.io/opdev/preflight" does not seem to be a valid registry path. The registry path should not contain more than 2 slashes. Refer to the Inputs section of the readme for naming image and registry.