### PR TITLE
Add trace and error log lines to osdk Scorecard func

### DIFF
--- a/certification/internal/shell/operatorsdk.go
+++ b/certification/internal/shell/operatorsdk.go
@@ -36,11 +36,13 @@ func (o OperatorSdkCLIEngine) Scorecard(image string, opts cli.OperatorSdkScorec
 	}
 
 	cmd := exec.Command("operator-sdk", cmdArgs...)
+	log.Trace("running scorecard with the following invocation", cmd.Args)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if err != nil {
+		log.Error("stderr: ", stderr.String())
 		return nil, fmt.Errorf("%w: %s", errors.ErrOperatorSdkScorecardFailed, err)
 	}
 


### PR DESCRIPTION
I was getting a failure early on in the OperatorSDK Scorecard-related that was not providing any logs. I added a log line that should catch it, as well as a trace line that shows what cmd invocation would get executed.
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>