### PR TITLE
fix log inconcistency causing config-related log line to have a diferrent format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,9 +38,11 @@ func initConfig() {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(".")
+
+	configFileUsed := true
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			log.Info("Config file not found.  Proceeding without it.")
+			configFileUsed = false
 		}
 	}
 
@@ -57,9 +59,12 @@ func initConfig() {
 	} else {
 		log.Info("Failed to log to file, using default stderr")
 	}
-
-	log.SetFormatter(&log.TextFormatter{})
 	if ll, err := log.ParseLevel(viper.GetString("loglevel")); err == nil {
 		log.SetLevel(ll)
+	}
+
+	log.SetFormatter(&log.TextFormatter{})
+	if !configFileUsed {
+		log.Info("config file not found, proceeding without it")
 	}
 }


### PR DESCRIPTION
This PR fixes a logging inconsistency caused by notifying the user that a configuration file was not found before we completed initialization of the logger. The result was a log that looked like this:

Previously this looked like this:

```
# ../preflight check operator quay.io/komish/preflight-test-bundle-passes:latest
INFO[0000] Config file not found.  Proceeding without it. 
time="2021-07-14T10:14:40-05:00" level=info msg="target image: quay.io/komish/preflight-test-bundle-passes:latest"
time="2021-07-14T10:14:40-05:00" level=info msg="downloading image"
```

Now this looks like this:

```
# ../preflight check operator quay.io/komish/preflight-test-bundle-passes:latest
time="2021-07-14T10:40:50-05:00" level=info msg="config file not found, proceeding without it"
time="2021-07-14T10:40:50-05:00" level=info msg="target image: quay.io/komish/preflight-test-bundle-passes:latest"
time="2021-07-14T10:40:50-05:00" level=info msg="downloading image"
```

I will note that there appears to be further room for inconsistency that I believe is a result of attaching the MultiWriter. From what I can tell, it's an internal behavior of the TextFormatter which changes the format of the message depending on whether a TTY is attached. It's documented in their README. I'm wasn't sure off hand how to go about resolving this in a consistent way across the tooling as well as testing so I've left things as in for now and simply fixed the inconsistency.

Ref: https://github.com/sirupsen/logrus (it's in the README, but doesn't have an anchor). Search for

```
To ensure this behaviour even if a TTY is attached, set your formatter as follows:
```

I also considered an alternative which was to remove the log line altogether since we only catch the error to log this line.



Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>