### PR TITLE
Move user-facing results definitions to formatters

### DIFF
--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -1,43 +1,57 @@
 package formatters
 
 import (
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 )
 
 // getResponse will extract the runtime's results and format it to fit the
 // UserResponse definition in a way that can then be formatted.
-func getResponse(r runtime.Results) runtime.UserResponse {
-	passedChecks := make([]certification.Metadata, len(r.Passed))
-	failedChecks := make([]certification.CheckInfo, len(r.Failed))
-	erroredChecks := make([]certification.HelpText, len(r.Errors))
+func getResponse(r runtime.Results) UserResponse {
+	passedChecks := make([]checkExecutionInfo, len(r.Passed))
+	failedChecks := make([]checkExecutionInfo, len(r.Failed))
+	erroredChecks := make([]checkExecutionInfo, len(r.Errors))
 
 	if len(r.Passed) > 0 {
 		for i, check := range r.Passed {
-			passedChecks[i] = check.Metadata()
+			passedChecks[i] = checkExecutionInfo{
+				Name:        check.Name(),
+				ElapsedTime: check.ElapsedTime.String(),
+				Description: check.Metadata().Description,
+			}
 		}
 	}
 
 	if len(r.Failed) > 0 {
 		for i, check := range r.Failed {
-			failedChecks[i] = certification.CheckInfo{
-				Metadata: check.Metadata(),
-				HelpText: check.Help(),
+			failedChecks[i] = checkExecutionInfo{
+				Name:             check.Name(),
+				ElapsedTime:      check.ElapsedTime.String(),
+				Description:      check.Metadata().Description,
+				Help:             check.Help().Message,
+				Suggestion:       check.Help().Suggestion,
+				KnowledgeBaseURL: check.Metadata().KnowledgeBaseURL,
+				CheckURL:         check.Metadata().CheckURL,
 			}
 		}
 	}
 
 	if len(r.Errors) > 0 {
 		for i, check := range r.Errors {
-			erroredChecks[i] = check.Help()
+			erroredChecks[i] = checkExecutionInfo{
+				Name:        check.Name(),
+				ElapsedTime: check.ElapsedTime.String(),
+				Description: check.Metadata().Description,
+				Help:        check.Help().Message,
+				Suggestion:  check.Help().Suggestion,
+			}
 		}
 	}
 
-	response := runtime.UserResponse{
+	response := UserResponse{
 		Image:             r.TestedImage,
 		ValidationVersion: version.Version,
-		Results: runtime.UserResponseText{
+		Results: resultsText{
 			Passed: passedChecks,
 			Failed: failedChecks,
 			Errors: erroredChecks,
@@ -45,4 +59,26 @@ func getResponse(r runtime.Results) runtime.UserResponse {
 	}
 
 	return response
+}
+
+type UserResponse struct {
+	Image             string                 `json:"image" xml:"image"`
+	ValidationVersion version.VersionContext `json:"validation_lib_version" xml:"validationLibVersion"`
+	Results           resultsText            `json:"results" xml:"results"`
+}
+
+type resultsText struct {
+	Passed []checkExecutionInfo `json:"passed" xml:"passed"`
+	Failed []checkExecutionInfo `json:"failed" xml:"failed"`
+	Errors []checkExecutionInfo `json:"errors" xml:"errors"`
+}
+
+type checkExecutionInfo struct {
+	Name             string `json:"name,omitempty" xml:"name,omitempty"`
+	ElapsedTime      string `json:"elapsed_time,omitempty" xml:"elapsed_time,omitempty"`
+	Description      string `json:"description,omitempty" xml:"description,omitempty"`
+	Help             string `json:"help,omitempty" xml:"help,omitempty"`
+	Suggestion       string `json:"suggestion,omitempty" xml:"suggestion,omitempty"`
+	KnowledgeBaseURL string `json:"knowledgebase_url,omitempty" xml:"knowledgebase_url,omitempty"`
+	CheckURL         string `json:"check_url,omitempty" xml:"check_url,omitempty"`
 }

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 )
 
 type Config struct {
@@ -23,16 +22,4 @@ type Results struct {
 	Passed      []Result
 	Failed      []Result
 	Errors      []Result
-}
-
-type UserResponse struct {
-	Image             string                 `json:"image" xml:"image"`
-	ValidationVersion version.VersionContext `json:"validation_lib_version" xml:"validationLibVersion"`
-	Results           UserResponseText       `json:"results" xml:"results"`
-}
-
-type UserResponseText struct {
-	Passed []certification.Metadata
-	Failed []certification.CheckInfo
-	Errors []certification.HelpText
 }


### PR DESCRIPTION
This moves our user-facing results definition over the formatters, and adjusts the way it renders a little bit. This also adds the ElapsedTime into the output, as well as the name (both were previously hidden).

I didn't want to spend too much time tweaking this because the schema is still being defined, but something a little better than what we had previously would help while we're working on the new checks.

```
{
    "image": "quay.io/komish/preflight-test-bundle-passes:latest",
    "validation_lib_version": {
        "version": "0.0.0",
        "commit": "51d7b962e776eb142d8700957ec3f24fe22c73b2"
    },
    "results": {
        "Passed": [
            {
                "name": "ValidateOperatorBundle",
                "elapsed_time": "4.721589672s",
                "description": "Validating Bundle image"
            },
            {
                "name": "ScorecardBasicSpecCheck",
                "elapsed_time": "7.720154257s",
                "description": "Check to make sure that all CRs have a spec block."
            }
        ],
        "Failed": [
            {
                "name": "ScorecardOlmSuiteCheck",
                "elapsed_time": "8.858909391s",
                "description": "OLM Test Suite Check",
                "help": "Operator-sdk scorecard OLM Test Suite. One or more checks failed.",
                "suggestion": "See scorecard output for details, artifacts/operator_bundle_scorecard_OlmSuiteCheck.json"
            }
        ],
        "Errors": []
    }
}
```

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>