### PR TITLE
Write distinct message for error

### DIFF
--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -39,11 +39,10 @@ func getResponse(r runtime.Results) UserResponse {
 	if len(r.Errors) > 0 {
 		for i, check := range r.Errors {
 			erroredChecks[i] = checkExecutionInfo{
-				Name:        check.Name(),
-				ElapsedTime: check.ElapsedTime.String(),
-				Description: check.Metadata().Description,
-				Help:        check.Help().Message,
-				Suggestion:  check.Help().Suggestion,
+				Name:         check.Name(),
+				ElapsedTime:  check.ElapsedTime.String(),
+				Description:  check.Metadata().Description,
+				ErrorMessage: "Check " + check.Name() + " encountered an error. Please review the logs for more information",
 			}
 		}
 	}
@@ -81,4 +80,5 @@ type checkExecutionInfo struct {
 	Suggestion       string `json:"suggestion,omitempty" xml:"suggestion,omitempty"`
 	KnowledgeBaseURL string `json:"knowledgebase_url,omitempty" xml:"knowledgebase_url,omitempty"`
 	CheckURL         string `json:"check_url,omitempty" xml:"check_url,omitempty"`
+	ErrorMessage     string `json:"error_message,omitempty" xml:"error_message,omitempty"`
 }

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -39,10 +39,10 @@ func getResponse(r runtime.Results) UserResponse {
 	if len(r.Errors) > 0 {
 		for i, check := range r.Errors {
 			erroredChecks[i] = checkExecutionInfo{
-				Name:         check.Name(),
-				ElapsedTime:  check.ElapsedTime.String(),
-				Description:  check.Metadata().Description,
-				ErrorMessage: "Check " + check.Name() + " encountered an error. Please review the logs for more information",
+				Name:        check.Name(),
+				ElapsedTime: check.ElapsedTime.String(),
+				Description: check.Metadata().Description,
+				Help:        check.Help().Message,
 			}
 		}
 	}
@@ -80,5 +80,4 @@ type checkExecutionInfo struct {
 	Suggestion       string `json:"suggestion,omitempty" xml:"suggestion,omitempty"`
 	KnowledgeBaseURL string `json:"knowledgebase_url,omitempty" xml:"knowledgebase_url,omitempty"`
 	CheckURL         string `json:"check_url,omitempty" xml:"check_url,omitempty"`
-	ErrorMessage     string `json:"error_message,omitempty" xml:"error_message,omitempty"`
 }

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -62,7 +62,7 @@ func (p *BaseOnUBICheck) Name() string {
 
 func (p *BaseOnUBICheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking if the container's base image is based on UBI",
+		Description:      "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide", // Placeholder
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -71,7 +71,7 @@ func (p *BaseOnUBICheck) Metadata() certification.Metadata {
 
 func (p *BaseOnUBICheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "It is recommened that your image be based upon the Red Hat Universal Base Image (UBI)",
+		Message:    "Check BasedOnUbi encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Change the FROM directive in your Dockerfile or Containerfile to FROM registry.access.redhat.com/ubi8/ubi",
 	}
 }

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -50,7 +50,7 @@ func (p *HasLicenseCheck) Name() string {
 
 func (p *HasLicenseCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking if terms and conditions for images are present.",
+		Description:      "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -59,7 +59,7 @@ func (p *HasLicenseCheck) Metadata() certification.Metadata {
 
 func (p *HasLicenseCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Container images must include terms and conditions applicable to the software including open source licensing information. The license must be at /licenses",
+		Message:    "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
 	}
 }

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -57,7 +57,7 @@ func (p *HasMinimalVulnerabilitiesCheck) Name() string {
 
 func (p *HasMinimalVulnerabilitiesCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking for critical or important security vulnerabilites.",
+		Description:      "Checking container image does not contain any critical or important security vulnerabilites, as defined at https://access.redhat.com/security/updates/classification.",
 		Level:            "good",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -66,7 +66,7 @@ func (p *HasMinimalVulnerabilitiesCheck) Metadata() certification.Metadata {
 
 func (p *HasMinimalVulnerabilitiesCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Components in the container image cannot contain any critical or important vulnerabilities, as defined at https://access.redhat.com/security/updates/classification",
+		Message:    "Check HasMinimalVulnerabilities encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distrubuted by Red Hat.",
 	}
 }

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -62,7 +62,7 @@ func (p *HasNoProhibitedPackagesCheck) Name() string {
 }
 func (p *HasNoProhibitedPackagesCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checks to ensure that the image in use does not contain prohibited packages.",
+		Description:      "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages.",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -71,7 +71,7 @@ func (p *HasNoProhibitedPackagesCheck) Metadata() certification.Metadata {
 
 func (p *HasNoProhibitedPackagesCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "The container image should not include Red Hat Enterprise Linux (RHEL) kernel packages.",
+		Message:    "Check HasNoProhibitedPackages encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Remove any RHEL packages that are not distributable outside of UBI",
 	}
 }

--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -50,7 +50,7 @@ func (p *HasRequiredLabelsCheck) Name() string {
 
 func (p *HasRequiredLabelsCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking if the required labels are present in the container metadata.",
+		Description:      "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata.",
 		Level:            "good",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -59,7 +59,7 @@ func (p *HasRequiredLabelsCheck) Metadata() certification.Metadata {
 
 func (p *HasRequiredLabelsCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Container images must include the following metadata: name, vendor, version, release, summary, description",
+		Message:    "Check Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description",
 	}
 }

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -47,7 +47,7 @@ func (p *HasUniqueTagCheck) Name() string {
 
 func (p *HasUniqueTagCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking if container has a tag other than 'latest'.",
+		Description:      "Checking if container has a tag other than 'latest', so that the image can be uniquely identfied.",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -56,7 +56,7 @@ func (p *HasUniqueTagCheck) Metadata() certification.Metadata {
 
 func (p *HasUniqueTagCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Containers should have a tag other than latest, so that the image can be uniquely identfied.",
+		Message:    "Check HasUniqueTag encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Add a tag to your image. Consider using Semantic Versioning. https://semver.org/",
 	}
 }

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -44,7 +44,7 @@ func (p *UnderLayerMaxCheck) Name() string {
 
 func (p *UnderLayerMaxCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      fmt.Sprintf("Checking if container has less than %d layers", acceptableLayerMax),
+		Description:      fmt.Sprintf("Checking if container has less than %d layers.  Too many layers within the container images can degrade container performance.", acceptableLayerMax),
 		Level:            "better",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -53,7 +53,7 @@ func (p *UnderLayerMaxCheck) Metadata() certification.Metadata {
 
 func (p *UnderLayerMaxCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    fmt.Sprintf("Uncompressed container images should have less than %d layers. Too many layers within the container images can degrade container performance.", acceptableLayerMax),
+		Message:    "Check LayerCountAcceptable encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Optimize your Dockerfile to consolidate and minimize the number of layers. Each RUN command will produce a new layer. Try combining RUN commands using && where possible.",
 	}
 }

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -62,7 +62,7 @@ func (p *RunAsNonRootCheck) Name() string {
 
 func (p *RunAsNonRootCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking if container runs as the root user",
+		Description:      "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -71,7 +71,7 @@ func (p *RunAsNonRootCheck) Metadata() certification.Metadata {
 
 func (p *RunAsNonRootCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "A container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
+		Message:    "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Indicate a specific USER in the dockerfile or containerfile",
 	}
 }

--- a/certification/internal/shell/scorecard_basic_check_spec.go
+++ b/certification/internal/shell/scorecard_basic_check_spec.go
@@ -38,7 +38,7 @@ func (p *ScorecardBasicSpecCheck) Metadata() certification.Metadata {
 
 func (p *ScorecardBasicSpecCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Operator-sdk scorecard basic spec check failed.",
+		Message:    "Check ScorecardBasicSpecCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_BasicSpecCheck.json file for more information.",
 		Suggestion: "Make sure that all CRs have a spec block",
 	}
 }

--- a/certification/internal/shell/scorecard_olm_suite.go
+++ b/certification/internal/shell/scorecard_olm_suite.go
@@ -29,7 +29,7 @@ func (p *ScorecardOlmSuiteCheck) Name() string {
 
 func (p *ScorecardOlmSuiteCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "OLM Test Suite Check",
+		Description:      "Operator-sdk scorecard OLM Test Suite Check",
 		Level:            "best",
 		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#overview", // Placeholder
 		CheckURL:         "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#olm-test-suite",
@@ -38,7 +38,7 @@ func (p *ScorecardOlmSuiteCheck) Metadata() certification.Metadata {
 
 func (p *ScorecardOlmSuiteCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Operator-sdk scorecard OLM Test Suite. One or more checks failed.",
+		Message:    "Check ScorecardOlmSuiteCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_OlmSuiteCheck.json file for more information.",
 		Suggestion: "See scorecard output for details, artifacts/operator_bundle_scorecard_OlmSuiteCheck.json",
 	}
 }

--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -38,7 +38,7 @@ func (p ValidateOperatorBundlePolicy) Name() string {
 
 func (p ValidateOperatorBundlePolicy) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Validating Bundle image",
+		Description:      "Validating Bundle image that checks if it can validate the content and format of the operator bundle",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -47,7 +47,7 @@ func (p ValidateOperatorBundlePolicy) Metadata() certification.Metadata {
 
 func (p ValidateOperatorBundlePolicy) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Operator sdk validation test failed, this test checks if it can validate the content and format of the operator bundle",
+		Message:    "Check ValidateOperatorBundle encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Valid bundles are definied by bundle spec, so make sure that this bundle conforms to that spec. More Information: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md",
 	}
 }


### PR DESCRIPTION
Instead of the help text being displayed when there is an error with a check we want to display a message that directs the user to look at the logs to figure out the issue. We want there to be a distinction between a check failure and error.

Fixes #12 