### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Tell us about an issue you encountered.
+title: ''
+labels: 'kind/bug'
+assignees: ''
+
+---
+
+## Bug Description
+(A clear and concise description of the issue)
+
+## Version and Command Invocation
+(The output of `preflight --version`)
+
+## Steps to Reproduce:
+(How can we reproduce this?)
+1)
+2)
+3)
+
+## Expected Result
+(What did you expect to happen and why?)
+
+
+## Actual Result
+(What actually happened)
+
+
+## Additional Context
+(Anything else you think might help us troubleshoot, like your platform, dependency versions, etc).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+title: ''
+labels: 'kind/feature'
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+(A clear and concise description of what the problem is. Ex. I'm always frustrated when [...])
+
+## Describe the solution you'd like.
+(A clear and concise description of what you want to happen.)
+
+## Describe alternatives you've considered.
+(A clear and concise description of any alternative solutions or features you've considered.)
+
+## Additional context.
+(Add any other context or screenshots about the feature request here.)


### PR DESCRIPTION
Fixed #97 

This PR just adds basic issue templates for feature/bug requests that helps users more efficiently provide us the information to troubleshoot and resolve a problem.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>