### PR TITLE
Handle image pull failures gracefully in one place instead of on a per-check basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config.yaml
 
 # Log files
 *.log
+results.json
 
 # Test binary, build with `go test -c`
 *.test

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -29,8 +29,15 @@ type ContainerFileManager interface {
 	GetContainerFromRegistry(podmanEngine cli.PodmanEngine, containerLoc string) (containerDownloadPath string, containerDownloadErro error)
 }
 
+// CheckRunner defines the functonality necessary to run all checks for a policy,
+// and return the results of that check execution.
 type CheckRunner interface {
-	ExecuteChecks()
+	// ExecuteChecks should execute all checks in a policy and internally
+	// store the results. Errors returned by ExecuteChecks should reflect
+	// errors in pre-validation tasks, and not errors in individual check
+	// execution itself.
+	ExecuteChecks() error
+	// Results returns the outcome of executing all checks.
 	Results() runtime.Results
 }
 

--- a/certification/internal/shell/podman.go
+++ b/certification/internal/shell/podman.go
@@ -27,7 +27,7 @@ type PodmanCLIEngine struct{}
 func (pe PodmanCLIEngine) Pull(rawImage string, opts cli.ImagePullOptions) (*cli.ImagePullReport, error) {
 	stdouterr, err := exec.Command("podman", "pull", rawImage).CombinedOutput()
 	if err != nil {
-		return nil, err
+		return &cli.ImagePullReport{StdoutErr: string(stdouterr)}, err
 	}
 
 	return &cli.ImagePullReport{StdoutErr: string(stdouterr)}, nil

--- a/certification/internal/utils/container/helper.go
+++ b/certification/internal/utils/container/helper.go
@@ -37,7 +37,7 @@ func ExtractContainerTar(tarball string) (string, error) {
 func GetContainerFromRegistry(podmanEngine cli.PodmanEngine, imageLoc string) (string, error) {
 	pullReport, err := podmanEngine.Pull(imageLoc, cli.ImagePullOptions{})
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", errors.ErrGetRemoteContainerFailed, err)
+		return pullReport.StdoutErr, fmt.Errorf("%w: %s", errors.ErrGetRemoteContainerFailed, err)
 	}
 
 	return pullReport.StdoutErr, nil

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -60,7 +60,9 @@ var checkContainerCmd = &cobra.Command{
 		resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
 
 		// execute the checks
-		engine.ExecuteChecks()
+		if err := engine.ExecuteChecks(); err != nil {
+			return err
+		}
 		results := engine.Results()
 
 		// return results to the user and then close output files


### PR DESCRIPTION
Fixes #96

## Context

The `CheckRunner.ExecuteChecks` implementation doesn't allow for errors to be returned. This was designed to ensure that encountering an error when executing an individual check did not cause the overall Policy to fail to execute (i.e. so that you can see if all other checks in the policy are passing/failing). Instead, checks that encounter an error fall into the `Results.Errors` slice, and we report that to the user. See notes about this below[1].

That said, it's possible in `CheckRunner.ExecuteChecks()` for the implementation to execute logic that may throw an error before ever calling `check.Validate()`. The `shell.CheckEngine` implementation does this today (it pre-pulls images in case we want to use them).

For this reason, this PR expands the `CheckRunner` interface so that `	ExecuteChecks()` now looks like this `ExecuteChecks() error`, and updated the `shell.CheckEngine` to properly implement the new definition.

## Change Summary

- This change updates the CheckEngine.ExecuteChecks call to exit if we fail to pull the image passed in by the user. Previously, this would continue to iterate through all checks and report them as individual having encountered an error (failed to pull the image)

- Since we're now throwing an error, this code does not need to be in the iterative execution of each check. It was originally in this iteration to ensure that the image was locally available for each check (in case something happened to the state of the local image store in between checks).

- In order to give the user more information as to why the pull failed, I've also the combined stdouterr to return statements even in the case of errors so that users can have more visibility into their image pull issues.

- Lastly, added some comments to the things that I touched in this PR, and removed commented code that changed the test image reference to be a local, on-disk image given that I don't think we'll ever uncomment it with the current implementation of checks across the board.

## New Output vs. Old Output

In fairness, my test is on MacOS where podman isn't running (I'm currently away from my lab machine), but this is the still the expected result

```
$ ./preflight check container quay.io/example/doesnotexist
Error: failed to pull remote container: exit status 125: Error: cannot connect to the Podman socket, please verify that Podman REST API service is running: Get "http://d/v3.2.1/libpod/_ping": dial unix ///var/folders/cn/r49cg2wx5z97qwq_s48f4vm80000gn/T/podman-run--1/podman/podman.sock: connect: no such file or directory

Usage:
  preflight check container <url to container image> [flags]

Flags:
  -h, --help   help for container

time="2021-07-16T11:30:58-05:00" level=fatal msg="failed to pull remote container: exit status 125: Error: cannot connect to the Podman socket, please verify that Podman REST API service is running: Get \"http://d/v3.2.1/libpod/_ping\": dial unix ///var/folders/cn/r49cg2wx5z97qwq_s48f4vm80000gn/T/podman-run--1/podman/podman.sock: connect: no such file or directory\n"
```

What it used to look like is documented in #96

---

[1] I do think it's worth evaluating this design as a whole, and considering a definition where we encourage failing the preflight execution as a whole if any individual check failed to validate.
