### PR TITLE
Update Operator Bundle Validate to use OperatorSdkEngine

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -94,7 +94,7 @@ var hasLicenseCheck certification.Check = &shell.HasLicenseCheck{}
 var hasMinimalVulnerabilitiesCheck certification.Check = &shell.HasMinimalVulnerabilitiesCheck{}
 var hasUniqueTagCheck certification.Check = &shell.HasUniqueTagCheck{}
 var hasNoProhibitedCheck certification.Check = &shell.HasNoProhibitedPackagesCheck{}
-var validateOperatorBundle certification.Check = &shell.ValidateOperatorBundlePolicy{}
+var validateOperatorBundle certification.Check = &shell.ValidateOperatorBundleCheck{}
 var scorecardBasicSpecCheck certification.Check = &shell.ScorecardBasicSpecCheck{}
 var scorecardOlmSuiteCheck certification.Check = &shell.ScorecardOlmSuiteCheck{}
 

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("TestPolicyEngine", func() {
 	var (
 		hasNoProhibitedCheck   certification.Check = &shell.HasNoProhibitedPackagesCheck{}
-		validateOperatorBundle certification.Check = &shell.ValidateOperatorBundlePolicy{}
+		validateOperatorBundle certification.Check = &shell.ValidateOperatorBundleCheck{}
 	)
 
 	Describe("Querying all policies", func() {

--- a/certification/internal/shell/validate_operator_bundle_test.go
+++ b/certification/internal/shell/validate_operator_bundle_test.go
@@ -1,0 +1,70 @@
+package shell
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+)
+
+var _ = Describe("BundleValidateCheck", func() {
+	var (
+		bundleValidateCheck ValidateOperatorBundleCheck
+		fakeEngine          cli.OperatorSdkEngine
+	)
+
+	BeforeEach(func() {
+		stdout := `{
+	"passed": true,
+	"outputs": null
+}`
+		stderr := ""
+		report := cli.OperatorSdkBundleValidateReport{
+			Stdout:  stdout,
+			Stderr:  stderr,
+			Passed:  true,
+			Outputs: []cli.OperatorSdkBundleValidateOutput{},
+		}
+		fakeEngine = FakeOperatorSdkEngine{
+			OperatorSdkBVReport: report,
+		}
+		operatorSdkEngine = fakeEngine
+	})
+	Describe("Operator Bundle Validate", func() {
+		Context("When Operator Bundle Validate passes", func() {
+			It("Should pass Validate", func() {
+				ok, err := bundleValidateCheck.Validate("dummy/image")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When Operator Bundle Validate does not Pass", func() {
+			BeforeEach(func() {
+				engine := fakeEngine.(FakeOperatorSdkEngine)
+				engine.OperatorSdkBVReport.Passed = false
+				engine.OperatorSdkBVReport.Outputs = []cli.OperatorSdkBundleValidateOutput{
+					cli.OperatorSdkBundleValidateOutput{Type: "warning", Message: "This is a warning"},
+					cli.OperatorSdkBundleValidateOutput{Type: "error", Message: "This is an error"},
+				}
+				operatorSdkEngine = engine
+			})
+			It("Should not pass Validate", func() {
+				ok, err := bundleValidateCheck.Validate("dummy/image")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+	Describe("Checking that OperatorSdkEngine errors are handled correctly", func() {
+		BeforeEach(func() {
+			fakeEngine = BadOperatorSdkEngine{}
+			operatorSdkEngine = fakeEngine
+		})
+		Context("When OperatorSdk throws an error", func() {
+			It("should fail Validate and return an error", func() {
+				ok, err := bundleValidateCheck.Validate("dummy/image")
+				Expect(err).To(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})

--- a/cli/operatorsdk.go
+++ b/cli/operatorsdk.go
@@ -28,10 +28,11 @@ type OperatorSdkScorecardResult struct {
 }
 
 type OperatorSdkBundleValidateOptions struct {
-	LogLevel         string
-	ContainerEnginer string
-	Selector         []string
-	OutputFormat     string
+	LogLevel        string
+	ContainerEngine string
+	Selector        []string
+	OutputFormat    string
+	Verbose         bool
 }
 
 type OperatorSdkBundleValidateReport struct {

--- a/test/containerfiles/successful-bundle-assets/manifests/sample-operator.clusterserviceversion.yaml
+++ b/test/containerfiles/successful-bundle-assets/manifests/sample-operator.clusterserviceversion.yaml
@@ -32,8 +32,8 @@ spec:
   description: Test operator that should pass operator validation
   displayName: Preflight Sample Operator
   icon:
-  - base64data: ""
-    mediatype: ""
+  - base64data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    mediatype: "image/png"
   install:
     spec:
       clusterPermissions:


### PR DESCRIPTION
* Rename Policy to Check
* Add unit test for Check
* Fix a typo in BundleValidateOptions
* Add Verbose flag to BundleValidateOptions
* Add support for Verbose to OperatorSdkEngine implementation

Fixes #33

Signed-off-by: Brad P. Crochet <brad@redhat.com>