### PR TITLE
update HasRequiredLabels check to fall back to failing

### DIFF
--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -6,6 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var requiredLabels = []string{"name", "vendor", "version", "release", "summary", "description"}
+
 type HasRequiredLabelsCheck struct{}
 
 func (p *HasRequiredLabelsCheck) Validate(image string) (bool, error) {
@@ -28,7 +30,6 @@ func (p *HasRequiredLabelsCheck) getDataForValidate(image string) (map[string]st
 }
 
 func (p *HasRequiredLabelsCheck) validate(labels map[string]string) (bool, error) {
-	requiredLabels := []string{"name", "vendor", "version", "release", "summary", "description"}
 	missingLabels := []string{}
 	for _, label := range requiredLabels {
 		if labels[label] == "" {
@@ -38,10 +39,9 @@ func (p *HasRequiredLabelsCheck) validate(labels map[string]string) (bool, error
 
 	if len(missingLabels) > 0 {
 		log.Warn("expected labels are missing:", missingLabels)
-		return false, nil
 	}
 
-	return true, nil
+	return len(missingLabels) == 0, nil
 }
 
 func (p *HasRequiredLabelsCheck) Name() string {


### PR DESCRIPTION
We want the checks to fall back to failing instead of falling back on passing. We want to be checking for specific cases in which the check passes instead of looking for cases the check fails. This is because we want to prevent getting false positive checks and the default be failure instead of passing.

Currently the only check that this needs to be addressed in is HasRequiredLabels

fixes #16 