### PR TITLE
Make operator-sdk scorecard tests pass

### DIFF
--- a/certification/internal/shell/scorecard_check.go
+++ b/certification/internal/shell/scorecard_check.go
@@ -18,6 +18,7 @@ func (p *scorecardCheck) validate(items []cli.OperatorSdkScorecardItem) (bool, e
 	for _, item := range items {
 		for _, result := range item.Status.Results {
 			if strings.Contains(result.State, "fail") {
+				log.Error(result.Log)
 				foundTestFailed = true
 			}
 		}

--- a/test/containerfiles/successful-bundle-assets/manifests/operators.my.domain_mykinds.yaml
+++ b/test/containerfiles/successful-bundle-assets/manifests/operators.my.domain_mykinds.yaml
@@ -13,35 +13,35 @@ spec:
     plural: mykinds
     singular: mykind
   scope: Namespaced
+  subresources:
+    status: {}
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: MyKind is the Schema for the mykinds API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MyKindSpec defines the desired state of MyKind
-            properties:
-              foo:
-                description: Foo is an example field of MyKind. Edit mykind_types.go to remove/update
-                type: string
-            type: object
-          status:
-            description: MyKindStatus defines the observed state of MyKind
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+  schema:
+    openAPIV3Schema:
+      description: MyKind is the Schema for the mykinds API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MyKindSpec defines the desired state of MyKind
+          properties:
+            foo:
+              description: Foo is an example field of MyKind. Edit mykind_types.go to remove/update
+              type: string
+          type: object
+        status:
+          description: MyKindStatus defines the observed state of MyKind
+          type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/test/containerfiles/successful-bundle-assets/manifests/sample-operator.clusterserviceversion.yaml
+++ b/test/containerfiles/successful-bundle-assets/manifests/sample-operator.clusterserviceversion.yaml
@@ -29,11 +29,27 @@ spec:
       kind: MyKind
       name: mykinds.operators.my.domain
       version: v1alpha1
+      resources:
+       - kind: Pod
+         name: ''
+         version: v1
+      specDescriptors:
+        - description: Foo
+          displayName: Foo
+          path: foo
+          x-descriptors:
+            - 'urn:alm:descriptor'
+      statusDescriptors:
+        - description: Accepted names
+          displayName: Accepted Names
+          path: acceptedNames
+          x-descriptors:
+            - 'urn:alm:descriptor'
   description: Test operator that should pass operator validation
   displayName: Preflight Sample Operator
   icon:
-  - base64data: ""
-    mediatype: ""
+  - base64data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    mediatype: "image/png"
   install:
     spec:
       clusterPermissions:


### PR DESCRIPTION
These changes fix the data in the successful-bundle-assets that allow the
scorecard tests to actually pass.

This was tested against a CRC cluster, and KUBECONFIG=${HOME}/.kube/config
exported into the env.

Signed-off-by: Brad P. Crochet <brad@redhat.com>