### PR TITLE
Add overall status of all checks

### DIFF
--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -49,6 +49,7 @@ func getResponse(r runtime.Results) UserResponse {
 
 	response := UserResponse{
 		Image:             r.TestedImage,
+		Status:            r.Status,
 		ValidationVersion: version.Version,
 		Results: resultsText{
 			Passed: passedChecks,
@@ -62,6 +63,7 @@ func getResponse(r runtime.Results) UserResponse {
 
 type UserResponse struct {
 	Image             string                 `json:"image" xml:"image"`
+	Status            string                 `jsoon:"status" xml:"status"`
 	ValidationVersion version.VersionContext `json:"validation_lib_version" xml:"validationLibVersion"`
 	Results           resultsText            `json:"results" xml:"results"`
 }

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -19,6 +19,7 @@ type Result struct {
 
 type Results struct {
 	TestedImage string
+	Status      string
 	Passed      []Result
 	Failed      []Result
 	Errors      []Result


### PR DESCRIPTION
Wanted to add an overall status for the policy execution. Right now the user has to parse 3 lists to see if their preflight was successful. The Status label will represent the overall status of the preflight policy execution. There are 3 possible status codes ("PASSED", "FAILED", "ERROR").

Passed - All checks were successful without any errors
Failed - At least one check failed but there were no errors
Error - An error occurred in at least one of the checks

Fixes #106 