### PR TITLE
Catch error in operator policy execution

### DIFF
--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -61,7 +61,9 @@ var checkOperatorCmd = &cobra.Command{
 		resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
 
 		// execute the checks
-		engine.ExecuteChecks()
+		if err := engine.ExecuteChecks(); err != nil {
+			return err
+		}
 		results := engine.Results()
 
 		// return results to the user and then close output files


### PR DESCRIPTION
Quick bugfix, When running `check operator`, we were not catching errors when calling `engine.ExecuteChecks()`, so we were getting results that reflected no checks were executed because the engine was throwing an error before any validations took place.

The `check container` command was updated to account for this, and I must have just ovelrooked `check container`. My apologies! 

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>