### PR TITLE
Add podman create, remove, copyFrom, and skopeo inspect

### DIFF
--- a/certification/internal/shell/shell_suite_test.go
+++ b/certification/internal/shell/shell_suite_test.go
@@ -52,6 +52,9 @@ type FakePodmanEngine struct {
 	PullReportStdouterr string
 	ImageInspectReport  cli.ImageInspectReport
 	ImageScanReport     cli.ImageScanReport
+	CreateReport        cli.PodmanCreateReport
+	CopyFromReport      cli.PodmanCopyReport
+	RemoveReport        cli.PodmanRemoveReport
 }
 
 func (fpe FakePodmanEngine) Run(opts cli.ImageRunOptions) (*cli.ImageRunReport, error) {
@@ -80,6 +83,18 @@ func (fpe FakePodmanEngine) InspectImage(rawImage string, opts cli.ImageInspectO
 
 func (fpe FakePodmanEngine) ScanImage(rawImage string) (*cli.ImageScanReport, error) {
 	return &fpe.ImageScanReport, nil
+}
+
+func (fpe FakePodmanEngine) Create(rawImage string, opts *cli.PodmanCreateOptions) (*cli.PodmanCreateReport, error) {
+	return &fpe.CreateReport, nil
+}
+
+func (fpe FakePodmanEngine) CopyFrom(containerID, sourcePath, destinationPath string) (*cli.PodmanCopyReport, error) {
+	return &fpe.CopyFromReport, nil
+}
+
+func (fpe FakePodmanEngine) Remove(containerID string) (*cli.PodmanRemoveReport, error) {
+	return &fpe.RemoveReport, nil
 }
 
 type BadPodmanEngine struct{}
@@ -111,6 +126,18 @@ func (bpe BadPodmanEngine) ScanImage(rawImage string) (*cli.ImageScanReport, err
 	return nil, errors.New("the Podman Scan Image has failed")
 }
 
+func (bpe BadPodmanEngine) Create(rawImage string, opts *cli.PodmanCreateOptions) (*cli.PodmanCreateReport, error) {
+	return nil, errors.New("The Podman Create operation has failed")
+}
+
+func (bpe BadPodmanEngine) CopyFrom(containerID, sourcePath, destinationPath string) (*cli.PodmanCopyReport, error) {
+	return nil, errors.New("The Podman Copy From operation has failed")
+}
+
+func (bpe BadPodmanEngine) Remove(containerID string) (*cli.PodmanRemoveReport, error) {
+	return nil, errors.New("The Podman Remove operator has failed")
+}
+
 /*
 ------------------- Skopeo Engine ---------------------
 */
@@ -119,6 +146,7 @@ type FakeSkopeoEngine struct {
 	SkopeoReportStdout string
 	SkopeoReportStderr string
 	Tags               []string
+	InspectReport      cli.SkopeoInspectReport
 }
 
 type SkopeoData struct {
@@ -135,6 +163,10 @@ func (fse FakeSkopeoEngine) ListTags(image string) (*cli.SkopeoListTagsReport, e
 	return &skopeoReport, nil
 }
 
+func (fse FakeSkopeoEngine) InspectImage(rawImage string, inspectOptions cli.SkopeoInspectOptions) (*cli.SkopeoInspectReport, error) {
+	return &fse.InspectReport, nil
+}
+
 type BadSkopeoEngine struct{}
 
 func (bse BadSkopeoEngine) ListTags(string) (*cli.SkopeoListTagsReport, error) {
@@ -144,6 +176,10 @@ func (bse BadSkopeoEngine) ListTags(string) (*cli.SkopeoListTagsReport, error) {
 		Tags:   []string{""},
 	}
 	return &skopeoReport, errors.New("the Skopeo ListTags has failed")
+}
+
+func (bse BadSkopeoEngine) InspectImage(rawImage string, inspectOptions cli.SkopeoInspectOptions) (*cli.SkopeoInspectReport, error) {
+	return &cli.SkopeoInspectReport{Stdout: "", Stderr: "some error output"}, errors.New("the skopeo image inspection has failed")
 }
 
 /*

--- a/certification/internal/shell/skopeo.go
+++ b/certification/internal/shell/skopeo.go
@@ -71,3 +71,33 @@ func (e SkopeoCLIEngine) imageName(image string) (string, error) {
 
 	return "", errors.ErrInvalidImageName
 }
+
+// InspectImage will use skopeo to inspect the input image given input options.
+func (e SkopeoCLIEngine) InspectImage(image string, opts cli.SkopeoInspectOptions) (*cli.SkopeoInspectReport, error) {
+	cmdArgs := []string{"inspect"}
+
+	// add options to the command string
+	if opts.Raw {
+		cmdArgs = append(cmdArgs, "--raw")
+	}
+
+	cmdArgs = append(cmdArgs, "docker://"+image)
+
+	log.Trace("running skopeo with the following invocation", cmdArgs)
+	cmd := exec.Command("skopeo", cmdArgs...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err != nil {
+		return &cli.SkopeoInspectReport{Stdout: stdout.String(), Stderr: stderr.String()}, err
+	}
+
+	return &cli.SkopeoInspectReport{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+		Blob:   stdout.Bytes(),
+	}, nil
+}

--- a/cli/podman.go
+++ b/cli/podman.go
@@ -54,10 +54,35 @@ type ImageScanReport struct {
 	Stderr string
 }
 
+type PodmanCopyReport struct {
+	Stdout string
+	Stderr string
+}
+
+type PodmanCreateReport struct {
+	Stdout      string
+	Stderr      string
+	ContainerID string
+}
+
+type PodmanCreateOptions struct {
+	// Entrypoint is an explicit entrypoint to pass to the Create command. Leaving this
+	// empty will not add the --entrypoint flag to the command invocation.
+	Entrypoint string
+}
+
+type PodmanRemoveReport struct {
+	Stdout string
+	Stderr string
+}
+
 type PodmanEngine interface {
 	InspectImage(rawImage string, opts ImageInspectOptions) (*ImageInspectReport, error)
 	Pull(rawImage string, opts ImagePullOptions) (*ImagePullReport, error)
 	Run(opts ImageRunOptions) (*ImageRunReport, error)
 	Save(nameOrID string, tags []string, opts ImageSaveOptions) error
 	ScanImage(image string) (*ImageScanReport, error)
+	Create(rawImage string, opts *PodmanCreateOptions) (*PodmanCreateReport, error)
+	CopyFrom(containerID, sourcePath, destinationPath string) (*PodmanCopyReport, error)
+	Remove(containerID string) (*PodmanRemoveReport, error)
 }

--- a/cli/skopeo.go
+++ b/cli/skopeo.go
@@ -6,6 +6,24 @@ type SkopeoListTagsReport struct {
 	Tags   []string
 }
 
+// SkopeoInspectReport contains information about the execution of a
+// skopeo inspect.
+type SkopeoInspectReport struct {
+	Stdout string
+	Stderr string
+	// Blob represents the JSON response from Skopeo.
+	// This response could vary in format so it is up to the caller
+	// to serialize this as they expect based on SkopeoInspectOptions
+	Blob []byte
+}
+
+// SkopeoInspectOptions represent options to pass to `skopeo inspect` command
+// invocations
+type SkopeoInspectOptions struct {
+	Raw bool
+}
+
 type SkopeoEngine interface {
 	ListTags(rawImage string) (*SkopeoListTagsReport, error)
+	InspectImage(rawImage string, inspectOptions SkopeoInspectOptions) (*SkopeoInspectReport, error)
 }


### PR DESCRIPTION
## Context

In implementing #35 (Operator Related Image Schema Version Check), I'll need to temporarily "run" a container so that I can copy files out of the running container.

In addition, I need to utilize `skopeo inspect --raw` in order to parse the schemaVersion value from the rawManifest.

This PR extends both the Podman and Skopeo engines and interfaces, adding the necessary functionality that I can leverage for to implement the check.

## Change Summary

- Defines `Create(...)` for the Podman Engine which allows us to run `podman create` in order to create a running container. I've also defined options for this method, and only included the specific option I need for my implementation. The FakePodmanEngine and BadPodmanEngine have corresponding methods to ensure they implement the interfaces.

- Defines `CopyFrom(...)` for the Podman Engine  which allows us to run `podman cp` with implicit direction (copy from container to host). FakePodmanEngine and BadPodmanEngine are updated with corresponding methods.

- Defines `Remove(...)` for the Podman Engine which allows us to run `podman rm` to clean up the container we're creating above. FakePodmanEngine and BadPodmanEngine are updated with corresponding methods.

- Defines `Inspect(...)` for the Skopeo Engine which allows us to run `skopeo inspect` to inspect images as we need. Podman inspect was already implemented, but I don't believe it has the ability to inspect the raw manifest as skopeo does. FakeSkopeoEngine has been updated to ensure it continues to implement the interface.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>