### PR TITLE
Add a new command to run preflight in an unshare namespace

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -22,3 +22,4 @@ var ErrOperatorSdkScorecardFailed = errors.New("failed to run operator-sdk score
 var ErrOperatorSdkBundleValidateFailed = errors.New("failed to run operator-sdk bundle validate")
 var ErrInvalidImageName = errors.New("failed to validate the image name")
 var ErrNoSocketFound = errors.New("neither podman or docker socket found")
+var ErrAlreadyInUnshare = errors.New("unshare is already active")

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -1,65 +1,32 @@
 package shell
 
 import (
-	"bufio"
-	"strings"
+	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
 
+// HasProhibitedPackages evaluates that the image does not contain prohibited packages,
+// which refers to packages that are not redistributable without an appropriate license.
 type HasNoProhibitedPackagesCheck struct{}
 
 func (p *HasNoProhibitedPackagesCheck) Validate(image string) (bool, error) {
-	line, err := p.getDataToValidate(image)
+	result, err := podmanEngine.UnshareWithCheck("HasNoProhibitedPackagesMounted", image, os.Args[0], "check", "run")
 	if err != nil {
-		log.Error("unable to get a list of all packages in the image")
+		log.Trace("unable to execute preflight in the unshare env")
+		log.Debugf("Stdout: %s", result.Stdout)
+		log.Debugf("Stderr: %s", result.Stderr)
 		return false, err
 	}
 
-	return p.validate(line)
-
-}
-
-func (p *HasNoProhibitedPackagesCheck) getDataToValidate(image string) (string, error) {
-	runOpts := cli.ImageRunOptions{
-		EntryPoint:     "rpm",
-		EntryPointArgs: []string{"-qa", "--queryformat", "%{NAME}\n"},
-		LogLevel:       "debug",
-		Image:          image,
-	}
-	runReport, err := podmanEngine.Run(runOpts)
-	if err != nil {
-		log.Error("unable to get a list of all packages in the image, error: ", err)
-		log.Debugf("Stdout: %s", runReport.Stdout)
-		log.Debugf("Stderr: %s", runReport.Stderr)
-		return "", err
-	}
-	return runReport.Stdout, nil
-}
-
-func (p *HasNoProhibitedPackagesCheck) validate(line string) (bool, error) {
-	scanner := bufio.NewScanner(strings.NewReader(line))
-	var prohibitedPackages []string
-	for scanner.Scan() {
-		for _, pkg := range prohibitedPackageList {
-			if pkg == scanner.Text() {
-				prohibitedPackages = append(prohibitedPackages, pkg)
-			}
-		}
-	}
-	log.Warn("The number of prohibited package found in the container image: ", len(prohibitedPackages))
-	if len(prohibitedPackages) > 0 {
-		log.Warn("found the following prohibited packages: ", prohibitedPackages)
-	}
-
-	return len(prohibitedPackages) == 0, nil
+	return result.PassedOverall, nil
 }
 
 func (p *HasNoProhibitedPackagesCheck) Name() string {
 	return "HasNoProhibitedPackages"
 }
+
 func (p *HasNoProhibitedPackagesCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
 		Description:      "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages.",
@@ -74,28 +41,4 @@ func (p *HasNoProhibitedPackagesCheck) Help() certification.HelpText {
 		Message:    "Check HasNoProhibitedPackages encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Remove any RHEL packages that are not distributable outside of UBI",
 	}
-}
-
-// prohibitedPackageList is a list of packages commonly present in the RHEL contianer images that are not redistributable
-// without proper licensing (i.e. packages that are not under the same availability as those found in UBI).
-// TODO: Confirm these packages are the only packages in immediate scope.
-var prohibitedPackageList = []string{
-	"grub",
-	"grub2",
-	"kernel",
-	"kernel-core",
-	"kernel-debug",
-	"kernel-debug-core",
-	"kernel-debug-modules",
-	"kernel-debug-modules-extra",
-	"kernel-debug-devel",
-	"kernel-devel",
-	"kernel-doc",
-	"kernel-modules",
-	"kernel-modules-extra",
-	"kernel-tools",
-	"kernel-tools-libs",
-	"kmod-kvdo",
-	"kpatch*",
-	"linux-firmware",
 }

--- a/certification/internal/shell/has_prohibited_packages_mounted.go
+++ b/certification/internal/shell/has_prohibited_packages_mounted.go
@@ -1,0 +1,116 @@
+package shell
+
+import (
+	"path/filepath"
+	"strings"
+
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	log "github.com/sirupsen/logrus"
+)
+
+// HasProhibitedPackages evaluates that the image does not contain prohibited packages,
+// which refers to packages that are not redistributable without an appropriate license.
+type HasNoProhibitedPackagesMountedCheck struct{}
+
+func (p *HasNoProhibitedPackagesMountedCheck) Validate(image string) (bool, error) {
+	pkgList, err := p.getDataToValidate(image)
+	if err != nil {
+		log.Error("unable to get a list of all packages in the image")
+		return false, err
+	}
+
+	return p.validate(pkgList)
+}
+
+func (p *HasNoProhibitedPackagesMountedCheck) getDataToValidate(dir string) ([]string, error) {
+	log.Debugf("Mounted directory: %s", dir)
+
+	db, err := rpmdb.Open(filepath.Join(dir, "var", "lib", "rpm", "Packages"))
+	if err != nil {
+		return nil, err
+	}
+	pkgList, err := db.ListPackages()
+	if err != nil {
+		return nil, err
+	}
+	pkgs := make([]string, len(pkgList))
+	for i, pkg := range pkgList {
+		pkgs[i] = pkg.Name
+	}
+	return pkgs, nil
+}
+
+func (p *HasNoProhibitedPackagesMountedCheck) validate(pkgList []string) (bool, error) {
+	var prohibitedPackages []string
+	for _, pkg := range pkgList {
+		_, ok := prohibitedPackageList[pkg]
+		if ok {
+			prohibitedPackages = append(prohibitedPackages, pkg)
+			continue
+		}
+		for _, name := range prohibitedPackageGlobList {
+			if strings.HasPrefix(pkg, name) {
+				prohibitedPackages = append(prohibitedPackages, pkg)
+				continue
+			}
+		}
+	}
+
+	log.Warn("The number of prohibited package found in the container image: ", len(prohibitedPackages))
+	if len(prohibitedPackages) == 0 {
+		return true, nil
+	}
+
+	log.Warn("found the following prohibited packages: ", prohibitedPackages)
+	return false, nil
+}
+
+func (p *HasNoProhibitedPackagesMountedCheck) Name() string {
+	return "HasNoProhibitedPackagesMounted"
+}
+
+func (p *HasNoProhibitedPackagesMountedCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages.",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *HasNoProhibitedPackagesMountedCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check HasNoProhibitedPackages encountered an error. Please review the preflight.log file for more information.",
+		Suggestion: "Remove any RHEL packages that are not distributable outside of UBI",
+	}
+}
+
+// prohibitedPackageList is a list of packages commonly present in the RHEL contianer images that are not redistributable
+// without proper licensing (i.e. packages that are not under the same availability as those found in UBI).
+// Implementation detail: Use a map[string]struct{} so that lookups can be done, and determine their existence
+// in the map without having to do nested iteration.
+// TODO: Confirm these packages are the only packages in immediate scope.
+var prohibitedPackageList = map[string]struct{}{
+	"grub":                       {},
+	"grub2":                      {},
+	"kernel":                     {},
+	"kernel-core":                {},
+	"kernel-debug":               {},
+	"kernel-debug-core":          {},
+	"kernel-debug-modules":       {},
+	"kernel-debug-modules-extra": {},
+	"kernel-debug-devel":         {},
+	"kernel-devel":               {},
+	"kernel-doc":                 {},
+	"kernel-modules":             {},
+	"kernel-modules-extra":       {},
+	"kernel-tools":               {},
+	"kernel-tools-libs":          {},
+	"kmod-kvdo":                  {},
+	"linux-firmware":             {},
+}
+
+var prohibitedPackageGlobList = []string{
+	"kpatch",
+}

--- a/certification/internal/shell/has_prohibited_packages_test.go
+++ b/certification/internal/shell/has_prohibited_packages_test.go
@@ -1,6 +1,8 @@
 package shell
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
@@ -8,8 +10,9 @@ import (
 
 var _ = Describe("HasNoProhibitedPackages", func() {
 	var (
-		HasNoProhibitedPackages HasNoProhibitedPackagesCheck
+		HasNoProhibitedPackages HasNoProhibitedPackagesMountedCheck
 		fakeEngine              cli.PodmanEngine
+		pkgList                 []string
 	)
 
 	BeforeEach(func() {
@@ -17,26 +20,48 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 			RunReportStdout: "",
 			RunReportStderr: "",
 		}
+		pkgList = []string{
+			"this",
+			"is",
+			"not",
+			"prohibitted",
+		}
 	})
 	Describe("Checking if it has an prohibited packages", func() {
 		Context("When there are no prohibited packages found", func() {
 			BeforeEach(func() {
 				podmanEngine = fakeEngine
 			})
-			It("should pass Validate", func() {
-				ok, err := HasNoProhibitedPackages.Validate("dummy/image")
+			It("should pass validate", func() {
+				ok, err := HasNoProhibitedPackages.validate(pkgList)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
 		})
 		Context("When there was a prohibited packages found", func() {
+			var pkgs []string
 			BeforeEach(func() {
 				engine := fakeEngine.(FakePodmanEngine)
 				engine.RunReportStdout = "grub"
 				podmanEngine = engine
+				pkgs = append(pkgList, "grub")
 			})
 			It("should not pass Validate", func() {
-				ok, err := HasNoProhibitedPackages.Validate("dummy/image")
+				ok, err := HasNoProhibitedPackages.validate(pkgs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+		Context("When there is a prohibited package in the glob list found", func() {
+			var pkgs []string
+			BeforeEach(func() {
+				engine := fakeEngine.(FakePodmanEngine)
+				engine.RunReportStdout = "kpatch2121"
+				podmanEngine = engine
+				pkgs = append(pkgList, "kpatch2121")
+			})
+			It("should not pass Validate", func() {
+				ok, err := HasNoProhibitedPackages.validate(pkgs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -46,12 +71,18 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 		BeforeEach(func() {
 			fakeEngine = BadPodmanEngine{}
 			podmanEngine = fakeEngine
+			os.Setenv("PREFLIGHT_EXEC_CHECK", HasNoProhibitedPackages.Name())
 		})
-		Context("When PodMan throws an error", func() {
-			It("should fail Validate and return an error", func() {
-				ok, err := HasNoProhibitedPackages.Validate("dummy/image")
-				Expect(err).To(HaveOccurred())
-				Expect(ok).To(BeFalse())
+		AfterEach(func() {
+			os.Unsetenv("PREFLIGHT_EXEC_CHECK")
+		})
+		Context("When calling the Unshare", func() {
+			Context("When PodMan throws an error", func() {
+				It("should fail Validate and return an error", func() {
+					ok, err := HasNoProhibitedPackages.Validate("dummy/image")
+					Expect(err).To(HaveOccurred())
+					Expect(ok).To(BeFalse())
+				})
 			})
 		})
 	})

--- a/certification/internal/shell/mounted_engine.go
+++ b/certification/internal/shell/mounted_engine.go
@@ -1,0 +1,62 @@
+package shell
+
+import (
+	"time"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	containerutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/container"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	log "github.com/sirupsen/logrus"
+)
+
+type MountedCheckEngine struct {
+	Image string
+	Check certification.Check
+
+	results runtime.Results
+}
+
+// ExecuteChecks runs all checks stored in the check engine.
+func (e *MountedCheckEngine) ExecuteChecks() error {
+	log.Info("target image: ", e.Image)
+
+	e.results.TestedImage = e.Image
+	targetImage := e.Image
+
+	log.Info("running check: ", e.Check.Name())
+	// We want to know the time just for the check itself, so reset checkStartTime
+	checkStartTime := time.Now()
+
+	// run the validation
+	pass, err := containerutil.RunInsideContainerFS(podmanEngine, targetImage, e.Check.Validate)
+
+	checkElapsedTime := time.Since(checkStartTime)
+
+	switch {
+	case err != nil:
+		log.WithFields(log.Fields{"result": "ERROR", "error": err.Error()}).Info("check completed: ", e.Check.Name())
+		e.results.Errors = append(e.results.Errors, runtime.Result{Check: e.Check, ElapsedTime: checkElapsedTime})
+	case !pass:
+		log.WithFields(log.Fields{"result": "FAILED"}).Info("check completed: ", e.Check.Name())
+		e.results.Failed = append(e.results.Failed, runtime.Result{Check: e.Check, ElapsedTime: checkElapsedTime})
+	default:
+		log.WithFields(log.Fields{"result": "PASSED"}).Info("check completed: ", e.Check.Name())
+		e.results.Passed = append(e.results.Passed, runtime.Result{Check: e.Check, ElapsedTime: checkElapsedTime})
+	}
+
+	// 2 possible status codes
+	// 1. PASSED - all checks have passed successfully
+	// 2. FAILED - At least one check failed or an error occured in one of the checks
+	if len(e.results.Errors) > 0 || len(e.results.Failed) > 0 {
+		e.results.PassedOverall = false
+	} else {
+		e.results.PassedOverall = true
+	}
+
+	return nil
+}
+
+// Results will return the results of check execution.
+func (e *MountedCheckEngine) Results() runtime.Results {
+	return e.results
+}

--- a/certification/internal/shell/shell_suite_test.go
+++ b/certification/internal/shell/shell_suite_test.go
@@ -56,6 +56,10 @@ type FakePodmanEngine struct {
 	CreateReport        cli.PodmanCreateReport
 	CopyFromReport      cli.PodmanCopyReport
 	RemoveReport        cli.PodmanRemoveReport
+	UnshareReport       cli.PodmanUnshareReport
+	MountReport         cli.PodmanMountReport
+	UnmountReport       cli.PodmanUnmountReport
+	UnshareCheckReport  cli.PodmanUnshareCheckReport
 }
 
 func (fpe FakePodmanEngine) Run(opts cli.ImageRunOptions) (*cli.ImageRunReport, error) {
@@ -99,6 +103,22 @@ func (fpe FakePodmanEngine) Remove(containerID string) (*cli.PodmanRemoveReport,
 	return &fpe.RemoveReport, nil
 }
 
+func (fpe FakePodmanEngine) Mount(containerId string) (*cli.PodmanMountReport, error) {
+	return &fpe.MountReport, nil
+}
+
+func (fpe FakePodmanEngine) Unmount(containerId string) (*cli.PodmanUnmountReport, error) {
+	return &fpe.UnmountReport, nil
+}
+
+func (fpe FakePodmanEngine) Unshare(env map[string]string, command ...string) (*cli.PodmanUnshareReport, error) {
+	return &fpe.UnshareReport, nil
+}
+
+func (fpe FakePodmanEngine) UnshareWithCheck(check, image string, command ...string) (*cli.PodmanUnshareCheckReport, error) {
+	return &fpe.UnshareCheckReport, nil
+}
+
 type BadPodmanEngine struct{}
 
 func (bpe BadPodmanEngine) Run(cli.ImageRunOptions) (*cli.ImageRunReport, error) {
@@ -139,6 +159,22 @@ func (bpe BadPodmanEngine) CopyFrom(containerID, sourcePath, destinationPath str
 
 func (bpe BadPodmanEngine) Remove(containerID string) (*cli.PodmanRemoveReport, error) {
 	return nil, errors.New("The Podman Remove operator has failed")
+}
+
+func (bpe BadPodmanEngine) Mount(containerId string) (*cli.PodmanMountReport, error) {
+	return nil, errors.New("The Podman Mount failed")
+}
+
+func (bpe BadPodmanEngine) Unmount(containerId string) (*cli.PodmanUnmountReport, error) {
+	return nil, errors.New("The Podman Unmount failed")
+}
+
+func (bpe BadPodmanEngine) Unshare(env map[string]string, command ...string) (*cli.PodmanUnshareReport, error) {
+	return nil, errors.New("The Podman Unshare operation has failed")
+}
+
+func (bpe BadPodmanEngine) UnshareWithCheck(check, image string, command ...string) (*cli.PodmanUnshareCheckReport, error) {
+	return nil, errors.New("The Podman Unshare With Check operation has failed")
 }
 
 /*

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -10,6 +10,7 @@ type Config struct {
 	Image          string
 	EnabledChecks  []string
 	ResponseFormat string
+	Mounted        bool
 }
 
 type Result struct {

--- a/cli/podman.go
+++ b/cli/podman.go
@@ -77,13 +77,38 @@ type PodmanRemoveReport struct {
 	Stderr string
 }
 
+type PodmanMountReport struct {
+	Stdout   string
+	Stderr   string
+	MountDir string
+}
+
+type PodmanUnmountReport struct {
+	Stdout string
+	Stderr string
+}
+
+type PodmanUnshareReport struct {
+	Stdout string
+	Stderr string
+}
+
+type PodmanUnshareCheckReport struct {
+	PodmanUnshareReport
+	PassedOverall bool `json:"passed"`
+}
+
 type PodmanEngine interface {
+	Create(rawImage string, opts *PodmanCreateOptions) (*PodmanCreateReport, error)
+	CopyFrom(containerID, sourcePath, destinationPath string) (*PodmanCopyReport, error)
 	InspectImage(rawImage string, opts ImageInspectOptions) (*ImageInspectReport, error)
+	Mount(containerId string) (*PodmanMountReport, error)
 	Pull(rawImage string, opts ImagePullOptions) (*ImagePullReport, error)
+	Remove(containerID string) (*PodmanRemoveReport, error)
 	Run(opts ImageRunOptions) (*ImageRunReport, error)
 	Save(nameOrID string, tags []string, opts ImageSaveOptions) error
 	ScanImage(image string) (*ImageScanReport, error)
-	Create(rawImage string, opts *PodmanCreateOptions) (*PodmanCreateReport, error)
-	CopyFrom(containerID, sourcePath, destinationPath string) (*PodmanCopyReport, error)
-	Remove(containerID string) (*PodmanRemoveReport, error)
+	Unmount(containerId string) (*PodmanUnmountReport, error)
+	Unshare(env map[string]string, command ...string) (*PodmanUnshareReport, error)
+	UnshareWithCheck(check, image string, command ...string) (*PodmanUnshareCheckReport, error)
 }

--- a/cmd/check_run.go
+++ b/cmd/check_run.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var checkRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run a single check inside of podman unshare",
+	Long: `This command will run a check while wrapped inside of podman unshare.
+It is an internal command, and is not meant to be called by the user.
+It takes its input from environment variables only.`,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Expect an environment variable named PREFLIGHT_CHECK_EXEC
+		// It will specify the one check to execute inside of the podman unshare
+		// environment.
+		enabledCheck, ok := os.LookupEnv("PREFLIGHT_EXEC_CHECK")
+		if !ok {
+			log.Error("Enabled check envvar not specified")
+			return errors.New("required environment variable PREFLIGHT_EXEC_CHECK not specified")
+		}
+		image, ok := os.LookupEnv("PREFLIGHT_EXEC_IMAGE")
+		if !ok {
+			log.Error("Operator image envvar not specified")
+			return errors.New("required environment variable PREFLIGHT_EXEC_IMAGE not specified")
+		}
+
+		cfg := runtime.Config{
+			Image:          image,
+			EnabledChecks:  []string{enabledCheck},
+			ResponseFormat: DefaultOutputFormat,
+			Mounted:        true,
+		}
+
+		engine, err := engine.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		formatter, err := formatters.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		// execute the checks
+		if err := engine.ExecuteChecks(); err != nil {
+			return err
+		}
+
+		results := engine.Results()
+
+		// return results to the user and then close output files
+		formattedResults, err := formatter.Format(results)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprint(os.Stdout, string(formattedResults))
+
+		return nil
+	},
+}
+
+func init() {
+	checkCmd.AddCommand(checkRunCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/containers/podman/v3 v3.2.2
 	github.com/docker/docker v20.10.7+incompatible
+	github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,8 @@ github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL9
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1 h1:LoN2wx/aN8JPGebG+2DaUyk4M+xRcqJXfuIbs8AWHdE=
+github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1/go.mod h1:KqrpKpn4M8OLznErihXTGLlsXFGeLxHUrLRRI/1YjGk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
@@ -572,6 +574,8 @@ github.com/klauspost/compress v1.12.2 h1:2KCfW3I9M7nSc5wOqXAlW2v2U6v+w6cbjvbfp+O
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1 h1:sRDvjjWoHLWAxtPXBKYRJp8Ot4ugxYE/ZyADl3jzc1g=
+github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1/go.mod h1:RDPNeIkU5NWXtt0OMEoILyxwUC/DyXeRtK295wpqSi0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Introduces a new command: 'preflight check run'. This command will inspect
the environment for specific values, and exit if they are not found.
Values are:
PREFLIGHT_EXEC_CHECK - The name of a check as given by check.Name()
PREFLIGHT_EXEC_IMAGE - The image under test

What this gives us is the ability to run a test within a podman
namespace, via the unshare command.

This will allow a container to be created, mounted, have the filesystem
directly operated upon, then unmounted and removed, all within the context
of podman unshare.

HasNoProhibitedPackages has been modified to utilize this behavior, in order
to operator on the RPM db directly, without the need for the 'rpm' executable,
which happens to not be available in either a scratch or microubi-based
image.

Fixes #104 

Signed-off-by: Brad P. Crochet <brad@redhat.com>