### PR TITLE
Fix a couple of linter issues

### DIFF
--- a/certification/internal/shell/less_than_max_layers_test.go
+++ b/certification/internal/shell/less_than_max_layers_test.go
@@ -16,7 +16,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 
 	BeforeEach(func() {
 		layers := make([]string, 5)
-		for i, _ := range layers {
+		for i := range layers {
 			layers[i] = fmt.Sprintf("layer%d", i)
 		}
 		fakeEngine = FakePodmanEngine{
@@ -47,7 +47,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 			BeforeEach(func() {
 				engine := fakeEngine.(FakePodmanEngine)
 				layers := make([]string, 50)
-				for i, _ := range layers {
+				for i := range layers {
 					layers[i] = fmt.Sprintf("layer%d", i)
 				}
 				engine.ImageInspectReport.Images[0].RootFS.Layers = layers

--- a/certification/internal/shell/validate_operator_bundle_test.go
+++ b/certification/internal/shell/validate_operator_bundle_test.go
@@ -42,8 +42,8 @@ var _ = Describe("BundleValidateCheck", func() {
 				engine := fakeEngine.(FakeOperatorSdkEngine)
 				engine.OperatorSdkBVReport.Passed = false
 				engine.OperatorSdkBVReport.Outputs = []cli.OperatorSdkBundleValidateOutput{
-					cli.OperatorSdkBundleValidateOutput{Type: "warning", Message: "This is a warning"},
-					cli.OperatorSdkBundleValidateOutput{Type: "error", Message: "This is an error"},
+					{Type: "warning", Message: "This is a warning"},
+					{Type: "error", Message: "This is an error"},
 				}
 				operatorSdkEngine = engine
 			})


### PR DESCRIPTION
The go linter was throwing a couple of warnings. One to simplify a range expression,
and the other had a redundant type specified.

Signed-off-by: Brad P. Crochet <brad@redhat.com>