### PR TITLE
Remove unused CheckEngine and ContainerFileManager and rename CheckRunner to CheckEngine

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -7,31 +7,11 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/shell"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
-type CheckEngine interface {
-	ContainerFileManager
-	CheckRunner
-}
-
-// ContainerFileManager describes the functionality necessary to interact
-// with a container image tarball on disk.
-type ContainerFileManager interface {
-	// IsRemote will check user-provided path and determine if that path is
-	// local or remote. Here local means that it's a location on the filesystem, and
-	// remote means that it's an image in a registry.
-	ContainerIsRemote(path string) (isRemote bool, remotecheckErr error)
-	// ExtractContainerTar will accept a path on the filesystem and extract it.
-	ExtractContainerTar(path string) (tarballPath string, extractionErr error)
-	// GetContainerFromRegistry will accept a container location and write it locally
-	// as a tarball as done by `podman save`
-	GetContainerFromRegistry(podmanEngine cli.PodmanEngine, containerLoc string) (containerDownloadPath string, containerDownloadErro error)
-}
-
-// CheckRunner defines the functonality necessary to run all checks for a policy,
+// CheckEngine defines the functonality necessary to run all checks for a policy,
 // and return the results of that check execution.
-type CheckRunner interface {
+type CheckEngine interface {
 	// ExecuteChecks should execute all checks in a policy and internally
 	// store the results. Errors returned by ExecuteChecks should reflect
 	// errors in pre-validation tasks, and not errors in individual check
@@ -41,7 +21,7 @@ type CheckRunner interface {
 	Results() runtime.Results
 }
 
-func NewForConfig(config runtime.Config) (CheckRunner, error) {
+func NewForConfig(config runtime.Config) (CheckEngine, error) {
 	if len(config.EnabledChecks) == 0 {
 		// refuse to run if the user has not specified any checks
 		return nil, errors.ErrNoChecksEnabled

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -17,7 +17,7 @@ const (
 	errored string = "ERROR"
 )
 
-// CheckEngine implements a CheckRunner.
+// CheckEngine implements a CheckEngine.
 type CheckEngine struct {
 	Image  string
 	Checks []certification.Check

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -82,9 +82,9 @@ defined in the environment, or alternatively all checks if no checks were specif
 Finally, the results of those validations will be passed to the formatter which
 will prepare them for final output to the user.
 
-## CheckRunner Implementation
+## CheckEngine Implementation
 
-The built-in checkrunner is referred to as `shell` (this name may change
+The built-in CheckEngine is referred to as `shell` (this name may change
 as we make calls to other tools as well). It issues calls out to `podman` and
 other shell tools directly in order to determine if the provided asset is in
 compliance.


### PR DESCRIPTION
While working through some docs, I noticed that our CheckEngine implementation (Which composed CheckRunner and ContainerFileManager) was unused. I also noticed that ContainerFileManager was not used either; we implement the functionality but we do not bind it to a struct.

Given that ContainerFileManager logic is effectively an implementation detail of the `ExecuteChecks` logic today, and is otherwise not called in packages upstream from its definition (such as `cmd`, where our user-facing logic sits), I concluded that we likely didn't need this abstraction anymore.

As such, this PR removes the CheckEngine and ContainerFileManager interfaces. It renames CheckRunner (which remains) to CheckEngine to be consistent with the term's usage in the package naming.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>