### PR TITLE
Increase documentation coverage

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -3,31 +3,39 @@ package certification
 // Check as an interface containing all methods necessary
 // to use and identify a given check.
 type Check interface {
-	// Validate checks whether the asset enforces the check.
+	// Validate will test the provided image and determine whether the
+	// image complies with the check's requirements.
 	Validate(image string) (result bool, err error)
 	// Name returns the name of the check.
 	Name() string
 	// Metadata returns the check's metadata.
 	Metadata() Metadata
-	// Help return the check's help text.
+	// Help return the check's help information
 	Help() HelpText
 }
 
-// Metadata contains useful information regarding the check
+// Metadata contains useful information regarding the check.
 type Metadata struct {
-	Description      string `json:"description" xml:"description"`
-	Level            string `json:"level" xml:"level"`
+	// Description contains a brief text detailing the overall goal of the check.
+	Description string `json:"description" xml:"description"`
+	// Level describes the certification level associated with the given check.
+	//
+	// TODO: define this more explicitly when requirements surrounding this metadata
+	// text.
+	Level string `json:"level" xml:"level"`
+	// KnowledgeBaseURL is a URL detailing how to resolve a check failure.
 	KnowledgeBaseURL string `json:"knowledge_base_url,omitempty" xml:"knowledgeBaseURL"`
-	CheckURL         string `json:"check_url,omitempty" xml:"checkURL"`
+	// CheckURL is a URL pointing to the official policy documentation from Red Hat, containing
+	// information on exactly what is being tested and why.
+	CheckURL string `json:"check_url,omitempty" xml:"checkURL"`
 }
 
 // HelpText is the help message associated with any given check
 type HelpText struct {
-	Message    string `json:"message" xml:"message"`
+	// Message is text provided to the user indicating where they should look
+	// to find out why they failed or encountered an error in validation.
+	Message string `json:"message" xml:"message"`
+	// Suggestion is text provided to the user indicating what might need to
+	// change in order to pass a check.
 	Suggestion string `json:"suggestion" xml:"suggestion"`
-}
-
-type CheckInfo struct {
-	Metadata `json:"metadata" xml:"metadata"`
-	HelpText `json:"helptext"`
 }

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -1,3 +1,4 @@
+// Package engine contains the interfaces necessary to implement policy execution.
 package engine
 
 import (

--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -1,3 +1,5 @@
+// Package formatters defines the abstractions used to properly format a preflight
+// Result.
 package formatters
 
 import (
@@ -70,10 +72,13 @@ func (f *genericFormatter) PrettyName() string {
 	return f.name
 }
 
+// Format returns the formatted results as a byte slice.
 func (f *genericFormatter) Format(r runtime.Results) ([]byte, error) {
 	return f.formatterFunc(r)
 }
 
+// FileExtension returns the extension a user might use when formatting
+// results with this formatter and writing that to disk.
 func (f *genericFormatter) FileExtension() string {
 	return f.fileExtension
 }

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -61,6 +61,7 @@ func getResponse(r runtime.Results) UserResponse {
 	return response
 }
 
+// UserResponse is the standard user-facing response.
 type UserResponse struct {
 	Image             string                 `json:"image" xml:"image"`
 	Status            string                 `jsoon:"status" xml:"status"`
@@ -68,12 +69,15 @@ type UserResponse struct {
 	Results           resultsText            `json:"results" xml:"results"`
 }
 
+// resultsText represents the results of check execution against the asset.
 type resultsText struct {
 	Passed []checkExecutionInfo `json:"passed" xml:"passed"`
 	Failed []checkExecutionInfo `json:"failed" xml:"failed"`
 	Errors []checkExecutionInfo `json:"errors" xml:"errors"`
 }
 
+// checkExecutionInfo contains all possible output fields that a user might see in their result.
+// Empty fields will be omitted.
 type checkExecutionInfo struct {
 	Name             string `json:"name,omitempty" xml:"name,omitempty"`
 	ElapsedTime      string `json:"elapsed_time,omitempty" xml:"elapsed_time,omitempty"`

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -10,6 +10,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// BasedOnUBICheck evaluates if the provided image is based on the Red Hat Univeral Base Image
+// by inspecting the contents of the `/etc/os-release` and identifying if the ID is `rhel` and the
+// Name value is `Red Hat Enterprise Linux`
 type BaseOnUBICheck struct{}
 
 func (p *BaseOnUBICheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -15,6 +15,8 @@ const (
 	minLicenseFileCount = 1
 )
 
+// HasLicenseCheck evaluates that the image contains a license definition available at
+// /licenses.
 type HasLicenseCheck struct{}
 
 func (p *HasLicenseCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -10,6 +10,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// HasMinimalVulnerabilitiesCheck evaluates the image to confirm that only vulnerabilities
+// below the Critical or Important severities, using oscap-podman and a corresponding
+// OVAL definition.
 type HasMinimalVulnerabilitiesCheck struct{}
 
 func (p *HasMinimalVulnerabilitiesCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -9,6 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// HasProhibitedPackages evaluates that the image does not contain prohibited packages,
+// which refers to packages that are not redistributable without an appropriate license.
 type HasNoProhibitedPackagesCheck struct{}
 
 func (p *HasNoProhibitedPackagesCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -8,6 +8,8 @@ import (
 
 var requiredLabels = []string{"name", "vendor", "version", "release", "summary", "description"}
 
+// HasRequiredLabelsCheck evaluates the image manifest to ensure that the appropriate metadata
+// labels are present on the image asset as it exists in its current container registry.
 type HasRequiredLabelsCheck struct{}
 
 func (p *HasRequiredLabelsCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -7,6 +7,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// HasUniqueTagCheck evaluates the image to ensure that it has a tag other than
+// the latest tag, which is considered to be a "floating" tag and may not accurately
+// represent the same image over time.
 type HasUniqueTagCheck struct{}
 
 func (p *HasUniqueTagCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -12,6 +12,7 @@ const (
 	acceptableLayerMax = 40
 )
 
+// UnderLayerMaxCheck ensures that the image has less layers in its assembly than a predefined maximum.
 type UnderLayerMaxCheck struct{}
 
 func (p *UnderLayerMaxCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -9,6 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// RunAsNonRootCheck evaluates the image to determine that the runtime UID is not 0,
+// which correlates to the root user.
 type RunAsNonRootCheck struct{}
 
 func (p *RunAsNonRootCheck) Validate(image string) (bool, error) {

--- a/certification/internal/shell/scorecard_basic_check_spec.go
+++ b/certification/internal/shell/scorecard_basic_check_spec.go
@@ -5,6 +5,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ScorecardBasicSpecCheck evaluates the image to ensure it passes the operator-sdk
+// scorecard check with the basic-check-spec-test suite selected.
 type ScorecardBasicSpecCheck struct {
 	scorecardCheck
 }

--- a/certification/internal/shell/scorecard_olm_suite.go
+++ b/certification/internal/shell/scorecard_olm_suite.go
@@ -5,6 +5,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ScorecardOlmSuiteCheck evaluates the image to ensure it passes the operator-sdk
+// scorecard check with the olm suite selected.
 type ScorecardOlmSuiteCheck struct {
 	scorecardCheck
 }

--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -6,13 +6,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ValidateOperatorBundleCheck evaluates the image and ensures that it passes bundle validation
+// as executed by `operator-sdk bundle validate`
 type ValidateOperatorBundleCheck struct {
 }
 
 func (p ValidateOperatorBundleCheck) Validate(bundle string) (bool, error) {
 	report, err := p.getDataToValidate(bundle)
 	if err != nil {
-		log.Error("Error will executing operator-sdk validate bundle: ", err)
+		log.Error("Error while executing operator-sdk bundle validate: ", err)
 		return false, err
 	}
 

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -1,3 +1,5 @@
+// Package runtime contains the structs and definitions consumed by Preflight at
+// runtime.
 package runtime
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,4 @@
+// Package cmd implements the command-line interface for Preflight.
 package cmd
 
 import (

--- a/docs/dev/IMPLEMENT_A_CHECK.md
+++ b/docs/dev/IMPLEMENT_A_CHECK.md
@@ -1,0 +1,87 @@
+# Check Implementation
+
+Checks make up the core validation logic used in Preflight. Operators and
+containers must pass all checks defined by the corresponding policy in order to
+be considered certifiable by Red Hat.
+
+All checks must fulfill the `Check` interface to be executed against a given
+bundle or container image. For full documentation on what each method that must
+be implemented to fulfill the check interface, please refer to the [package
+documentation](https://pkg.go.dev/github.com/redhat-openshift-ecosystem/openshift-preflight/certification).
+
+## Defining a new check
+
+The Preflight project focuses on implementing all the checks necessary for a
+given container or Operator to pass Red Hat Certification. As a result, the
+project may not merge pull requests containing checks that are added to the
+mentioned policies if those checks are not explicit requirements of the
+certification pipeline.
+
+We recommend opening an issue for guidance on a validation that you would like
+to see implemented.
+
+### Using `NewGenericCheck`
+
+Simple checks can be written by simply defining a `ValidatorFunc` and all
+surrounding metadata, and then feeding that information to `NewGenericCheck`.
+What's returned is a `genericCheckDefinition` which implements the `Check`
+interface.
+
+This check can then be added to a policy and passed to a CheckEngine
+implementation.
+
+### Custom Structs
+
+Defining a custom struct will provide you more flexibility in the execution of
+your validation.
+
+All checks built into the Preflight project are defined in the
+`certification/internal` package as they are implementation details specific to
+the project.
+
+A new policy file might look something like this:
+
+```go
+package shell
+
+type ValidateThingCheck struct{
+    // your struct fields here
+}
+
+func (p *ValidateThingCheck) Validate(image string) (bool, error) {
+    // your logic here ...
+}
+
+func (p *ValidateThingCheck) Name() string {
+	return "ValidateThing"
+}
+
+func (p *ValidateThingCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "A brief description of what your check is doing.",
+		Level:            "best",
+		KnowledgeBaseURL: "https://example.com/path/to/your/knowlebase/url", 
+		CheckURL:         "https://example.com/path/to/your/check/url",
+	}
+}
+
+func (p *ValidateThingCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Information about where to look when a user fails this check",
+		Suggestion: "A quick tidbit on exactly how one might have passed this check",
+	}
+}
+```
+
+The container or bundle that is being validated is passed to each check in the
+event that the information is necessary in performing the validation. All checks
+are expected to standalone in their execution, and may not assume that they are
+executed in a particular order, or with a particular shared context with other
+checks.
+
+With a new check defined, the check will then need to be registered with the
+appropriate policy. A map of enabled checks for all policies exists in the
+`engine` package.
+
+Once the check is added to the appropriate package, the Preflight utility will
+automatically executed the check when the associated policy is called by users.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,91 +5,27 @@ operator projects to see if they pass Red Hat operator certification
 requirements.
 
 The project will include a commandline interface that will accept your operator
-bundle image as an input, and will run validate that your operator bundle
-complies with a configurable set of checks.
+bundle or container image as an input, and will run validate that your container
+image or operator bundle complies with a series of validations.
 
-The project also has a goal of providing a library that can be leveraged to
-check your operator bundle's certification compliance in your own testing use cases,
-including writing and ensuring your bundle complies with your own custom tests.
+## Checks
 
-## Design
+The term "check" refers to a single validation executed against the given asset.
+See our docs on [check implementation](../IMPLEMENT_A_CHECK.md) to find out more
+about how checks are implemented.
 
-The current design leverages a series of interfaces for handling the following
-tasks related to check validation:
+## Policies
 
-* managing container image assets (e.g. pulling from an external registry,
-  managing an image tarball on disk, etc.)
+The Preflight utility validates a given Operator or Container by applying a
+series of validations (or "checks") against the asset. The term "policy" is used
+to describe a collection of checks.
 
-* enforcing checks against the assets on disk, and storing the results of the
-  checks
+In order for a given asset (container or operator) to pass certification, it
+must pass all checks defined in the corresponding policy.
 
-* formatting the results into various output formats to fit various known use
-  cases.
-
-The interface definitions for managing each of these tasks should allow for
-developers to:
-
-* define their own checks and implementation details in addition to the
-  built-in checks
-
-* define custom output formats other than those built-in to the tooling.
-
-The included CLI will leverage these interfaces to provide built-in checks,
-built-in formatters, and built-in container asset managers.
-
-## Libraries
-
-The `certification` library contains the built-in check definitions that are
-used to validate an operator bundle is in compliance with Red Hat's operator
-bundle certification requirements. These are the built-in tests that can be
-enabled when using the compiled binary.
-
-The `certification/formatters` library includes the necessary constructs to
-build out your own custom formatters. Developers can leverage the included
-`certification.formatters.GenericFormatter` struct to build out custom
-formatters by simply passing in a `certification/formatters.FormatterFunc` and
-additional metadata, or they can build out their own by implementing the
-`certification/formatters.ResponseFormatter` interface.
-
-The `certification/runtime` library includes the necessary constructs to build
-out your own check runner. A check runner just refers to the interface that
-registers what checks to execute, and to which asset.
-*TODO: complete the reusable generic implementation and documentation*
-
-## CLI Implementation
-
-The Preflight CLI utilizes the libraries and design mentioned above. The bulk
-of the CLI code is found in the `cmd` package.
-
-Currently, we assume that the user must provide a single positional argument:
-the container image which will be checked for compliance with our checks.
-
-The user can then further tailor their execution by specifying configurables
-such as the exact checks to enforce, and the output format. The CLI currently
-allows for the definition of those configurables via flags (e.g.
-`--output-format`), but environment variables are also parsed, with flag values
-taking precedence. See `cmd/constants.go` for the existing supported environment
-variables. 
-
-The CLI will take all user input and derive a `certification/runtime.Config`
-instance with the appropriate values filled in. Then, a check runner and a
-formatter are derived based on that configuration (commonly seen as
-`NewForConfig(...)` functions available in each package).
-
-The check engine will execute validation functions based on enabled checks
-defined in the environment, or alternatively all checks if no checks were specified.
-
-Finally, the results of those validations will be passed to the formatter which
-will prepare them for final output to the user.
-
-## CheckEngine Implementation
-
-The built-in CheckEngine is referred to as `shell` (this name may change
-as we make calls to other tools as well). It issues calls out to `podman` and
-other shell tools directly in order to determine if the provided asset is in
-compliance.
-
-## Formatter Implementation
-
-The built-in formatters allow for formatting output as JSON or XML. The final
-user-facing response is still being defined.
+The project has an [Operator
+policy](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/certification/engine/engine.go#L101)
+and a [Container
+policy](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/certification/engine/engine.go#L101),
+corresponding with the validations `preflight check` implements. Each
+implemented policy has its own checks.


### PR DESCRIPTION
The goal of this PR is just to increase documentation coverage. 

This PR does add a net-new doc on how to implement a check, with a clear note indicating that we may reject a PR for a check given our goal of ensuring this tool accurately reflects the pipeline's validation.

Finally, this adds several comments throughout, including package comments which will show up in pkg.go.dev.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>