### PR TITLE
Add library path to version context

### DIFF
--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -48,9 +48,9 @@ func getResponse(r runtime.Results) UserResponse {
 	}
 
 	response := UserResponse{
-		Image:             r.TestedImage,
-		Passed:            r.PassedOverall,
-		ValidationVersion: version.Version,
+		Image:       r.TestedImage,
+		Passed:      r.PassedOverall,
+		LibraryInfo: version.Version,
 		Results: resultsText{
 			Passed: passedChecks,
 			Failed: failedChecks,
@@ -62,10 +62,10 @@ func getResponse(r runtime.Results) UserResponse {
 }
 
 type UserResponse struct {
-	Image             string                 `json:"image" xml:"image"`
-	Passed            bool                   `json:"passed" xml:"passed"`
-	ValidationVersion version.VersionContext `json:"validation_lib_version" xml:"validationLibVersion"`
-	Results           resultsText            `json:"results" xml:"results"`
+	Image       string                 `json:"image" xml:"image"`
+	Passed      bool                   `json:"passed" xml:"passed"`
+	LibraryInfo version.VersionContext `json:"test_library" xml:"test_library"`
+	Results     resultsText            `json:"results" xml:"results"`
 }
 
 type resultsText struct {

--- a/version/version.go
+++ b/version/version.go
@@ -1,18 +1,21 @@
+// Package version contains all identifiable versioning info for
+// describing the preflight project.
 package version
 
 import "fmt"
 
-// TODO restructure this to be local only these packages
-// TODO dynamically generate these at release
+var projectName = "github.com/redhat-openshift-ecosystem/openshift-preflight"
 var version = "unknown"
 var commit = "unknown"
 
 var Version = VersionContext{
+	Name:    projectName,
 	Version: version,
 	Commit:  commit,
 }
 
 type VersionContext struct {
+	Name    string `json:"name"`
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
 }


### PR DESCRIPTION
Fixes #113 

Our UserResponse includes contextual information indicating exactly which commit/release of preflight was used to generate the report. We received a request (see the fixed issue) to also add the name of the library, and rename `validation_lib_version` to `test_library`. 

This PR implements both fixes.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>