### PR TITLE
Use boolean value to indicate overall result

### DIFF
--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -49,7 +49,7 @@ func getResponse(r runtime.Results) UserResponse {
 
 	response := UserResponse{
 		Image:             r.TestedImage,
-		Status:            r.Status,
+		Passed:            r.PassedOverall,
 		ValidationVersion: version.Version,
 		Results: resultsText{
 			Passed: passedChecks,
@@ -63,7 +63,7 @@ func getResponse(r runtime.Results) UserResponse {
 
 type UserResponse struct {
 	Image             string                 `json:"image" xml:"image"`
-	Status            string                 `jsoon:"status" xml:"status"`
+	Passed            bool                   `json:"passed" xml:"passed"`
 	ValidationVersion version.VersionContext `json:"validation_lib_version" xml:"validationLibVersion"`
 	Results           resultsText            `json:"results" xml:"results"`
 }

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -77,12 +77,12 @@ func (e *CheckEngine) ExecuteChecks() error {
 	}
 
 	// 2 possible status codes
-	// 1. PASSED - all checks have passed successfully
-	// 2. FAILED - At least one check failed or an error occured in one of the checks
+	// 1. PassedOverall=true - all checks have passed successfully
+	// 2. PassedOverall=false - At least one check failed or an error occured in one of the checks
 	if len(e.results.Errors) > 0 || len(e.results.Failed) > 0 {
-		e.results.Status = failed
+		e.results.PassedOverall = false
 	} else {
-		e.results.Status = passed
+		e.results.PassedOverall = true
 	}
 
 	return nil

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -18,9 +18,9 @@ type Result struct {
 }
 
 type Results struct {
-	TestedImage string
-	Status      string
-	Passed      []Result
-	Failed      []Result
-	Errors      []Result
+	TestedImage   string
+	PassedOverall bool
+	Passed        []Result
+	Failed        []Result
+	Errors        []Result
 }


### PR DESCRIPTION
The endpoint that will receive preflight results would like to use a boolean flag at a top-level `passed` key to indicate the overall result of policy execution.

This PR adjusts the value from a string to a boolean, and also changes the name of the key from `status` to `passed` so that a boolean value makes more sense.

We also align the Result struct to reflect similar values, and update relevant comments to match the new definition.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>