### PR TITLE
Add system dependencies required for golang container bindings (PR #50)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install system deps
+      run: 'sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev'
+
     - name: Set up Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
PR #50 adds dependencies to our go.mod file that I believe are causing tests to fail.

Specific error messages are the following:

```
Error: ../../../go/pkg/mod/github.com/mtrmac/gpgme@v0.1.2/data.go:4:11: fatal error: gpgme.h: No such file or directory
132

Error: ../../../go/pkg/mod/github.com/containers/storage@v1.31.3/drivers/btrfs/btrfs.go:8:10: fatal error: btrfs/ioctl.h: No such file or directory
143
```

see: https://github.com/redhat-openshift-ecosystem/openshift-preflight/runs/3175166552?check_suite_focus=true

The tool seems to build without an issue, but `make test` fails. I'm thinking this will probably translate to a system dependency that we'll require to run preflight in the future, but I'm not 100% sure on that piece yet.

Either way, these packages are being installed via apt in our GitHub action with this PR to try and resolve this issue.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>