### PR TITLE
Add image mounting to podman engine

### DIFF
--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -56,7 +56,7 @@ func (e *CheckEngine) ExecuteChecks() error {
 		checkStartTime := time.Now()
 
 		// run the validation
-		passed, err := check.Validate(targetImage)
+		checkPassed, err := check.Validate(targetImage)
 
 		checkElapsedTime := time.Since(checkStartTime)
 
@@ -66,7 +66,7 @@ func (e *CheckEngine) ExecuteChecks() error {
 			continue
 		}
 
-		if !passed {
+		if !checkPassed {
 			log.WithFields(log.Fields{"result": failed}).Info("check completed: ", check.Name())
 			e.results.Failed = append(e.results.Failed, runtime.Result{Check: check, ElapsedTime: checkElapsedTime})
 			continue

--- a/certification/internal/shell/mounted_engine.go
+++ b/certification/internal/shell/mounted_engine.go
@@ -26,17 +26,14 @@ func (e *MountedCheckEngine) ExecuteChecks() error {
 	log.Info("running check: ", e.Check.Name())
 	// We want to know the time just for the check itself, so reset checkStartTime
 	checkStartTime := time.Now()
-
-	// run the validation
-	pass, err := containerutil.RunInsideContainerFS(podmanEngine, targetImage, e.Check.Validate)
-
+	checkPassed, err := containerutil.RunInsideImageFS(podmanEngine, targetImage, e.Check.Validate)
 	checkElapsedTime := time.Since(checkStartTime)
 
 	switch {
 	case err != nil:
 		log.WithFields(log.Fields{"result": "ERROR", "error": err.Error()}).Info("check completed: ", e.Check.Name())
 		e.results.Errors = append(e.results.Errors, runtime.Result{Check: e.Check, ElapsedTime: checkElapsedTime})
-	case !pass:
+	case !checkPassed:
 		log.WithFields(log.Fields{"result": "FAILED"}).Info("check completed: ", e.Check.Name())
 		e.results.Failed = append(e.results.Failed, runtime.Result{Check: e.Check, ElapsedTime: checkElapsedTime})
 	default:

--- a/certification/internal/shell/shell_suite_test.go
+++ b/certification/internal/shell/shell_suite_test.go
@@ -111,6 +111,14 @@ func (fpe FakePodmanEngine) Unmount(containerId string) (*cli.PodmanUnmountRepor
 	return &fpe.UnmountReport, nil
 }
 
+func (fpe FakePodmanEngine) MountImage(imageID string) (*cli.PodmanMountReport, error) {
+	return &fpe.MountReport, nil
+}
+
+func (fpe FakePodmanEngine) UnmountImage(imageID string) (*cli.PodmanUnmountReport, error) {
+	return &fpe.UnmountReport, nil
+}
+
 func (fpe FakePodmanEngine) Unshare(env map[string]string, command ...string) (*cli.PodmanUnshareReport, error) {
 	return &fpe.UnshareReport, nil
 }
@@ -167,6 +175,14 @@ func (bpe BadPodmanEngine) Mount(containerId string) (*cli.PodmanMountReport, er
 
 func (bpe BadPodmanEngine) Unmount(containerId string) (*cli.PodmanUnmountReport, error) {
 	return nil, errors.New("The Podman Unmount failed")
+}
+
+func (bpe BadPodmanEngine) MountImage(imageID string) (*cli.PodmanMountReport, error) {
+	return nil, errors.New("The Podman Image Mount failed")
+}
+
+func (bpe BadPodmanEngine) UnmountImage(imageID string) (*cli.PodmanUnmountReport, error) {
+	return nil, errors.New("The Podman Image Unmount failed")
 }
 
 func (bpe BadPodmanEngine) Unshare(env map[string]string, command ...string) (*cli.PodmanUnshareReport, error) {

--- a/cli/podman.go
+++ b/cli/podman.go
@@ -103,12 +103,14 @@ type PodmanEngine interface {
 	CopyFrom(containerID, sourcePath, destinationPath string) (*PodmanCopyReport, error)
 	InspectImage(rawImage string, opts ImageInspectOptions) (*ImageInspectReport, error)
 	Mount(containerId string) (*PodmanMountReport, error)
+	MountImage(imageID string) (*PodmanMountReport, error)
 	Pull(rawImage string, opts ImagePullOptions) (*ImagePullReport, error)
 	Remove(containerID string) (*PodmanRemoveReport, error)
 	Run(opts ImageRunOptions) (*ImageRunReport, error)
 	Save(nameOrID string, tags []string, opts ImageSaveOptions) error
 	ScanImage(image string) (*ImageScanReport, error)
 	Unmount(containerId string) (*PodmanUnmountReport, error)
+	UnmountImage(imageID string) (*PodmanUnmountReport, error)
 	Unshare(env map[string]string, command ...string) (*PodmanUnshareReport, error)
 	UnshareWithCheck(check, image string, command ...string) (*PodmanUnshareCheckReport, error)
 }


### PR DESCRIPTION
Fixes #137 
Unblocks #136 

## Context

PR #126 added the ability to mount a container image so that we can directly inspect the container filesystem without having to extract files or exec _into_ the container.

This still requires creating a container, however, which doesn't apply cleanly to operator bundle checks which are non-runnable. We _can_ "run" an operator bundle by faking the entry point, and there is an existing check that does this. With that said, if we could mount the image similarly to how we mount containers, we would no longer need to extract the bundle to disk.

This PR extends the PodmanEngine to have a (Un)MountImage functionality to solve this problem.

## Summary

- Extends `PodmanEngine`, `FakePodmanEngine`, `BadPodmanEngine`, and the related interface to have MountImage and UnmountImage methods.
- ~Introduces an environment variable PREFLIGHT_EXEC_TYPE for the `check run` hidden command that allows callers to identify the _type_ of asset being tested in sub-execution.~ See [design update](https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/139#issuecomment-891120951).
- This PREFLIGHT_EXEC_TYPE value is only used in the mounted engine, and causes the mounted engine to leverage a new helper `RunInsideImageFS`, similar to `RunInsideContainerFS`, in cases where the asset is not a container and therefore doesn't need to be created.
- Extended the PodmanEngine.UnshareWithCheck definition to also accept the image type so that it exports the new environment variable mentioned above.
- Fixed a small bug in our engine code, caused by overloading the variable name `passed` which caused our log output to spit out result=true instead of result=passed

In my testing, the only check utilizing this passes as expected, and this enables the Package Name Uniqueness check which is in the works.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>