### PR TITLE
Run minimal vulnerabilities check in an unshare environment

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -68,7 +68,7 @@ func queryChecks(checkName string) certification.Check {
 		return check
 	}
 	// Lastly, look at the mounted checks
-	if check, exists := mountedChecks[checkName]; exists {
+	if check, exists := unshareChecks[checkName]; exists {
 		return check
 	}
 
@@ -91,6 +91,7 @@ var hasNoProhibitedMountedCheck certification.Check = &shell.HasNoProhibitedPack
 var relatedImageManifestSchemaVersionCheck certification.Check = &shell.RelatedImagesAreSchemaVersion2Check{}
 var operatorPkgNameIsUniqueMountedCheck certification.Check = &shell.OperatorPkgNameIsUniqueMountedCheck{}
 var operatorPkgNameIsUniqueCheck certification.Check = &shell.OperatorPkgNameIsUniqueCheck{}
+var hasMinimalVulnerabilitiesUnshareCheck certification.Check = &shell.HasMinimalVulnerabilitiesUnshareCheck{}
 
 var containerPolicy = map[string]certification.Check{
 	runAsNonRootCheck.Name():              runAsNonRootCheck,
@@ -114,9 +115,10 @@ var operatorPolicy = map[string]certification.Check{
 	operatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
 }
 
-var mountedChecks = map[string]certification.Check{
-	hasNoProhibitedMountedCheck.Name():         hasNoProhibitedMountedCheck,
-	operatorPkgNameIsUniqueMountedCheck.Name(): operatorPkgNameIsUniqueMountedCheck,
+var unshareChecks = map[string]certification.Check{
+	hasNoProhibitedMountedCheck.Name():           hasNoProhibitedMountedCheck,
+	operatorPkgNameIsUniqueMountedCheck.Name():   operatorPkgNameIsUniqueMountedCheck,
+	hasMinimalVulnerabilitiesUnshareCheck.Name(): hasMinimalVulnerabilitiesUnshareCheck,
 }
 
 func makeCheckList(checkMap map[string]certification.Check) []string {

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -1,57 +1,25 @@
 package shell
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-// HasMinimalVulnerabilitiesCheck evaluates the image to confirm that only vulnerabilities
-// below the Critical or Important severities, using oscap-podman and a corresponding
-// OVAL definition.
+// HasMinimalVulnerabilitiesCheck calls the HasMinimalVulnerabilitiesUnshareCheck
+// In an Unshare environment. It does not require a mounted image.
 type HasMinimalVulnerabilitiesCheck struct{}
 
 func (p *HasMinimalVulnerabilitiesCheck) Validate(image string) (bool, error) {
-	lines, err := p.getDataToValidate(image)
+	mounted := false
+	result, err := podmanEngine.UnshareWithCheck("HasMinimalVulnerabilitiesUnshare", image, mounted)
 	if err != nil {
-		log.Debugf("Stdout: %s", lines)
-		return false, fmt.Errorf("%w: %s", errors.ErrImageScanFailed, err)
+		log.Trace("unable to execute preflight in the unshare env")
+		log.Debugf("Stdout: %s", result.Stdout)
+		log.Debugf("Stderr: %s", result.Stderr)
+		return false, err
 	}
 
-	return p.validate(lines)
-}
-
-func (p *HasMinimalVulnerabilitiesCheck) getDataToValidate(image string) ([]string, error) {
-	imageScanReport, err := podmanEngine.ScanImage(image)
-	if err != nil {
-		log.Error("unable to scan the image: ", err)
-		return nil, err
-	}
-
-	return strings.Split(imageScanReport.Stdout, "\n"), nil
-}
-
-func (p *HasMinimalVulnerabilitiesCheck) validate(lines []string) (bool, error) {
-
-	// oscap-podman writes `Definition oval:com.redhat.<CVE#>: true` to stdout
-	// if the vulnerability exist in the container, and `Definition oval:com.redhat.<CVE#>: false`
-	// if the vulnerability does not exist
-	r := regexp.MustCompile("Definition oval:com.redhat.*: true")
-
-	numOfVulns := 0
-	for _, line := range lines {
-		if r.MatchString(line) {
-			numOfVulns++
-		}
-	}
-	// count the number of matches
-	log.Debugf("The number of found vulnerabilities: %d", numOfVulns)
-
-	return numOfVulns == 0, nil
+	return result.PassedOverall, nil
 }
 
 func (p *HasMinimalVulnerabilitiesCheck) Name() string {

--- a/certification/internal/shell/has_minimal_vulns_test.go
+++ b/certification/internal/shell/has_minimal_vulns_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("HasMinimalVulns", func() {
 	var (
-		hasMinimalVulnCheck HasMinimalVulnerabilitiesCheck
+		hasMinimalVulnCheck HasMinimalVulnerabilitiesUnshareCheck
 		fakeEngine          cli.PodmanEngine
 	)
 

--- a/certification/internal/shell/has_minimal_vulns_unshare.go
+++ b/certification/internal/shell/has_minimal_vulns_unshare.go
@@ -1,0 +1,75 @@
+package shell
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// HasMinimalVulnerabilitiesUnshareCheck evaluates the image to confirm that only vulnerabilities
+// below the Critical or Important severities, using oscap-podman and a corresponding
+// OVAL definition.
+type HasMinimalVulnerabilitiesUnshareCheck struct{}
+
+func (p *HasMinimalVulnerabilitiesUnshareCheck) Validate(image string) (bool, error) {
+	lines, err := p.scanImage(image)
+	if err != nil {
+		log.Debugf("Stdout: %s", lines)
+		return false, fmt.Errorf("%w: %s", errors.ErrImageScanFailed, err)
+	}
+
+	return p.validate(lines)
+}
+
+func (p *HasMinimalVulnerabilitiesUnshareCheck) scanImage(image string) ([]string, error) {
+	imageScanReport, err := podmanEngine.ScanImage(image)
+	if err != nil {
+		log.Error("unable to scan the image: ", err)
+		return nil, err
+	}
+
+	return strings.Split(imageScanReport.Stdout, "\n"), nil
+}
+
+func (p *HasMinimalVulnerabilitiesUnshareCheck) validate(lines []string) (bool, error) {
+
+	// oscap-podman writes `Definition oval:com.redhat.<CVE#>: true` to stdout
+	// if the vulnerability exist in the container, and `Definition oval:com.redhat.<CVE#>: false`
+	// if the vulnerability does not exist
+	r := regexp.MustCompile("Definition oval:com.redhat.*: true")
+
+	numOfVulns := 0
+	for _, line := range lines {
+		if r.MatchString(line) {
+			numOfVulns++
+		}
+	}
+	// count the number of matches
+	log.Debugf("The number of found vulnerabilities: %d", numOfVulns)
+
+	return numOfVulns == 0, nil
+}
+
+func (p *HasMinimalVulnerabilitiesUnshareCheck) Name() string {
+	return "HasMinimalVulnerabilitiesUnshare"
+}
+
+func (p *HasMinimalVulnerabilitiesUnshareCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checking container image does not contain any critical or important security vulnerabilites, as defined at https://access.redhat.com/security/updates/classification.",
+		Level:            "good",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *HasMinimalVulnerabilitiesUnshareCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check HasMinimalVulnerabilities encountered an error. Please review the preflight.log file for more information.",
+		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distrubuted by Red Hat.",
+	}
+}

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -1,8 +1,6 @@
 package shell
 
 import (
-	"os"
-
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
 )
@@ -12,7 +10,8 @@ import (
 type HasNoProhibitedPackagesCheck struct{}
 
 func (p *HasNoProhibitedPackagesCheck) Validate(image string) (bool, error) {
-	result, err := podmanEngine.UnshareWithCheck("HasNoProhibitedPackagesMounted", image, os.Args[0], "check", "run")
+	mounted := true
+	result, err := podmanEngine.UnshareWithCheck("HasNoProhibitedPackagesMounted", image, mounted)
 	if err != nil {
 		log.Trace("unable to execute preflight in the unshare env")
 		log.Debugf("Stdout: %s", result.Stdout)

--- a/certification/internal/shell/operator_pkg_name_uniqueness.go
+++ b/certification/internal/shell/operator_pkg_name_uniqueness.go
@@ -1,8 +1,6 @@
 package shell
 
 import (
-	"os"
-
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
 )
@@ -10,7 +8,8 @@ import (
 type OperatorPkgNameIsUniqueCheck struct{}
 
 func (p *OperatorPkgNameIsUniqueCheck) Validate(image string) (bool, error) {
-	result, err := podmanEngine.UnshareWithCheck("OperatorPackageNameIsUniqueMounted", image, os.Args[0], "check", "run")
+	mounted := true
+	result, err := podmanEngine.UnshareWithCheck("OperatorPackageNameIsUniqueMounted", image, mounted)
 	if err != nil {
 		log.Trace("unable to execute preflight in the unshare env")
 		log.Debugf("Stdout: %s", result.Stdout)

--- a/certification/internal/shell/podman.go
+++ b/certification/internal/shell/podman.go
@@ -320,14 +320,18 @@ func (pe PodmanCLIEngine) Unshare(env map[string]string, command ...string) (*cl
 	return &cli.PodmanUnshareReport{Stdout: stdout.String(), Stderr: stderr.String()}, err
 }
 
-func (pe PodmanCLIEngine) UnshareWithCheck(check, image string, command ...string) (*cli.PodmanUnshareCheckReport, error) {
+func (pe PodmanCLIEngine) UnshareWithCheck(check, image string, mounted bool) (*cli.PodmanUnshareCheckReport, error) {
 	env := map[string]string{
 		"PATH":                 os.Getenv("PATH"),
 		"PREFLIGHT_EXEC_CHECK": check,
 		"PREFLIGHT_EXEC_IMAGE": image,
 	}
 
-	unshareReport, err := pe.Unshare(env, command...)
+	if mounted {
+		env["PREFLIGHT_EXEC_MOUNTED"] = fmt.Sprintf("%t", mounted)
+	}
+
+	unshareReport, err := pe.Unshare(env, os.Args[0], "check", "run")
 	if err != nil {
 		return &cli.PodmanUnshareCheckReport{PodmanUnshareReport: *unshareReport, PassedOverall: false}, err
 	}

--- a/certification/internal/shell/shell_suite_test.go
+++ b/certification/internal/shell/shell_suite_test.go
@@ -123,7 +123,7 @@ func (fpe FakePodmanEngine) Unshare(env map[string]string, command ...string) (*
 	return &fpe.UnshareReport, nil
 }
 
-func (fpe FakePodmanEngine) UnshareWithCheck(check, image string, command ...string) (*cli.PodmanUnshareCheckReport, error) {
+func (fpe FakePodmanEngine) UnshareWithCheck(check, image string, mounted bool) (*cli.PodmanUnshareCheckReport, error) {
 	return &fpe.UnshareCheckReport, nil
 }
 
@@ -189,7 +189,7 @@ func (bpe BadPodmanEngine) Unshare(env map[string]string, command ...string) (*c
 	return nil, errors.New("The Podman Unshare operation has failed")
 }
 
-func (bpe BadPodmanEngine) UnshareWithCheck(check, image string, command ...string) (*cli.PodmanUnshareCheckReport, error) {
+func (bpe BadPodmanEngine) UnshareWithCheck(check, image string, mounted bool) (*cli.PodmanUnshareCheckReport, error) {
 	return nil, errors.New("The Podman Unshare With Check operation has failed")
 }
 

--- a/cli/podman.go
+++ b/cli/podman.go
@@ -112,5 +112,5 @@ type PodmanEngine interface {
 	Unmount(containerId string) (*PodmanUnmountReport, error)
 	UnmountImage(imageID string) (*PodmanUnmountReport, error)
 	Unshare(env map[string]string, command ...string) (*PodmanUnshareReport, error)
-	UnshareWithCheck(check, image string, command ...string) (*PodmanUnshareCheckReport, error)
+	UnshareWithCheck(check, image string, mounted bool) (*PodmanUnshareCheckReport, error)
 }

--- a/cmd/check_run.go
+++ b/cmd/check_run.go
@@ -33,12 +33,16 @@ It takes its input from environment variables only.`,
 			log.Error("Operator image envvar not specified")
 			return errors.New("required environment variable PREFLIGHT_EXEC_IMAGE not specified")
 		}
+		mounted, ok := os.LookupEnv("PREFLIGHT_EXEC_MOUNTED")
+		if !ok {
+			mounted = "false"
+		}
 
 		cfg := runtime.Config{
 			Image:          image,
 			EnabledChecks:  []string{enabledCheck},
 			ResponseFormat: DefaultOutputFormat,
-			Mounted:        true,
+			Mounted:        mounted == "true",
 		}
 
 		engine, err := engine.NewForConfig(cfg)


### PR DESCRIPTION
Besides making the minimal vulnerabilities check to run in an
unshare, this patch also changes the UnshareWithCheck signature to
simplify it, so that the "preflight check run" command does not have
to be specified each time, but it also specifies whether the check
should have the passed image mounted, then run the check, or just
have the check run in the unshare env.

Fixes #49

Signed-off-by: Brad P. Crochet <brad@redhat.com>