### PR TITLE
Add generation of a "bundle hash"

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -45,6 +45,7 @@ func NewForConfig(config runtime.Config) (CheckEngine, error) {
 	engine = &shell.CheckEngine{
 		Image:  config.Image,
 		Checks: checks,
+		Bundle: config.Bundle,
 	}
 	if config.Mounted {
 		engine = &shell.MountedCheckEngine{

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -51,6 +51,7 @@ func getResponse(r runtime.Results) UserResponse {
 		Image:       r.TestedImage,
 		Passed:      r.PassedOverall,
 		LibraryInfo: version.Version,
+		BundleHash:  r.BundleHash,
 		Results: resultsText{
 			Passed: passedChecks,
 			Failed: failedChecks,
@@ -65,6 +66,7 @@ func getResponse(r runtime.Results) UserResponse {
 type UserResponse struct {
 	Image       string                 `json:"image" xml:"image"`
 	Passed      bool                   `json:"passed" xml:"passed"`
+	BundleHash  string                 `json:"bundle_hash,omitempty" xml:"bundle_hash,omitempty"`
 	LibraryInfo version.VersionContext `json:"test_library" xml:"test_library"`
 	Results     resultsText            `json:"results" xml:"results"`
 }

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -21,6 +21,7 @@ const (
 type CheckEngine struct {
 	Image  string
 	Checks []certification.Check
+	Bundle bool
 
 	results      runtime.Results
 	isDownloaded bool
@@ -83,6 +84,14 @@ func (e *CheckEngine) ExecuteChecks() error {
 		e.results.PassedOverall = false
 	} else {
 		e.results.PassedOverall = true
+	}
+
+	if e.Bundle {
+		md5sum, err := containerutil.GenerateBundleHash(podmanEngine, e.Image)
+		if err != nil {
+			log.Debugf("could not generate bundle hash")
+		}
+		e.results.BundleHash = md5sum
 	}
 
 	return nil

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -13,6 +13,7 @@ type Config struct {
 	EnabledChecks  []string
 	ResponseFormat string
 	Mounted        bool
+	Bundle         bool
 }
 
 type Result struct {
@@ -23,6 +24,7 @@ type Result struct {
 type Results struct {
 	TestedImage   string
 	PassedOverall bool
+	BundleHash    string
 	Passed        []Result
 	Failed        []Result
 	Errors        []Result

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -33,6 +33,7 @@ var checkOperatorCmd = &cobra.Command{
 			Image:          operatorImage,
 			EnabledChecks:  engine.OperatorPolicy(),
 			ResponseFormat: DefaultOutputFormat,
+			Bundle:         true,
 		}
 
 		engine, err := engine.NewForConfig(cfg)


### PR DESCRIPTION
This creates a hashfile containing the md5sum output of the files contained
in the bundle image. This is not meant to be a secure hash. It is meant
to be used for identifying a particular bundle within the pipeline.

Fixes #60

Signed-off-by: Brad P. Crochet <brad@redhat.com>