### PR TITLE
Run make fmt and make vet as part of the GH action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,12 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: Vet
+      run: make vet
+
+    - name: Format
+      run: make fmt
+
     - name: Build
       run: make build
 


### PR DESCRIPTION
Just as an extra sanity check (and a way to fail faster before running
tests) this adds the make vet and make fmt commands to be run against
a pending commit.

Signed-off-by: Brad P. Crochet <brad@redhat.com>