### PR TITLE
Fix image-push target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ image-build:
 
 .PHONY: image-push
 image-push:
-	$(IMAGE_BUILDER) push $(IMAGE_REPO)/preflight:$(VERSION) .
+	$(IMAGE_BUILDER) push $(IMAGE_REPO)/preflight:$(VERSION)
 
 .PHONY: test
 test:


### PR DESCRIPTION
There was a trailing '.' at the end of the push command. This doesn't work.

Signed-off-by: Brad P. Crochet <brad@redhat.com>