### PR TITLE
updating vagrant file to include crun

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure("2") do |config|
     bzip2 \
     go-md2man \
     runc \
+    crun \
     containers-common \
     openscap-containers
   


### PR DESCRIPTION
Adding `crun` to vagrant so that `make build-image` does not throw any errors and completes successfully.