### PR TITLE
Implement support command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Preflight** is a commandline interface for validating if
 [OpenShift](https://www.openshift.com/) operator bundles and containers meet minimum
-reqiurements for [Red Hat OpenShift
+requirements for [Red Hat OpenShift
 Certification](https://connect.redhat.com/en/partner-with-us/red-hat-openshift-certification).
 
 This project is in active and rapid development! Many facets of this project are

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -10,7 +10,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 )
 
-// CheckEngine defines the functonality necessary to run all checks for a policy,
+// CheckEngine defines the functionality necessary to run all checks for a policy,
 // and return the results of that check execution.
 type CheckEngine interface {
 	// ExecuteChecks should execute all checks in a policy and internally

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// BasedOnUBICheck evaluates if the provided image is based on the Red Hat Univeral Base Image
+// BasedOnUBICheck evaluates if the provided image is based on the Red Hat Universal Base Image
 // by inspecting the contents of the `/etc/os-release` and identifying if the ID is `rhel` and the
 // Name value is `Red Hat Enterprise Linux`
 type BaseOnUBICheck struct{}

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -79,7 +79,7 @@ func (e *CheckEngine) ExecuteChecks() error {
 
 	// 2 possible status codes
 	// 1. PassedOverall=true - all checks have passed successfully
-	// 2. PassedOverall=false - At least one check failed or an error occured in one of the checks
+	// 2. PassedOverall=false - At least one check failed or an error occurred in one of the checks
 	if len(e.results.Errors) > 0 || len(e.results.Failed) > 0 {
 		e.results.PassedOverall = false
 	} else {

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -28,7 +28,7 @@ func (p *HasMinimalVulnerabilitiesCheck) Name() string {
 
 func (p *HasMinimalVulnerabilitiesCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking container image does not contain any critical or important security vulnerabilites, as defined at https://access.redhat.com/security/updates/classification.",
+		Description:      "Checking container image does not contain any critical or important security vulnerabilities, as defined at https://access.redhat.com/security/updates/classification.",
 		Level:            "good",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -38,6 +38,6 @@ func (p *HasMinimalVulnerabilitiesCheck) Metadata() certification.Metadata {
 func (p *HasMinimalVulnerabilitiesCheck) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "Check HasMinimalVulnerabilities encountered an error. Please review the preflight.log file for more information.",
-		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distrubuted by Red Hat.",
+		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distributed by Red Hat.",
 	}
 }

--- a/certification/internal/shell/has_minimal_vulns_unshare.go
+++ b/certification/internal/shell/has_minimal_vulns_unshare.go
@@ -60,7 +60,7 @@ func (p *HasMinimalVulnerabilitiesUnshareCheck) Name() string {
 
 func (p *HasMinimalVulnerabilitiesUnshareCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking container image does not contain any critical or important security vulnerabilites, as defined at https://access.redhat.com/security/updates/classification.",
+		Description:      "Checking container image does not contain any critical or important security vulnerabilities, as defined at https://access.redhat.com/security/updates/classification.",
 		Level:            "good",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
@@ -70,6 +70,6 @@ func (p *HasMinimalVulnerabilitiesUnshareCheck) Metadata() certification.Metadat
 func (p *HasMinimalVulnerabilitiesUnshareCheck) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "Check HasMinimalVulnerabilities encountered an error. Please review the preflight.log file for more information.",
-		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distrubuted by Red Hat.",
+		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distributed by Red Hat.",
 	}
 }

--- a/certification/internal/shell/has_prohibited_packages_mounted.go
+++ b/certification/internal/shell/has_prohibited_packages_mounted.go
@@ -86,7 +86,7 @@ func (p *HasNoProhibitedPackagesMountedCheck) Help() certification.HelpText {
 	}
 }
 
-// prohibitedPackageList is a list of packages commonly present in the RHEL contianer images that are not redistributable
+// prohibitedPackageList is a list of packages commonly present in the RHEL container images that are not redistributable
 // without proper licensing (i.e. packages that are not under the same availability as those found in UBI).
 // Implementation detail: Use a map[string]struct{} so that lookups can be done, and determine their existence
 // in the map without having to do nested iteration.

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -46,7 +46,7 @@ func (p *HasUniqueTagCheck) Name() string {
 
 func (p *HasUniqueTagCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking if container has a tag other than 'latest', so that the image can be uniquely identfied.",
+		Description:      "Checking if container has a tag other than 'latest', so that the image can be uniquely identified.",
 		Level:            "best",
 		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
 		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",

--- a/certification/internal/shell/has_v2_related_image_schema_version.go
+++ b/certification/internal/shell/has_v2_related_image_schema_version.go
@@ -121,7 +121,7 @@ func (p *RelatedImagesAreSchemaVersion2Check) getRelatedImagesForCSV(csv *operat
 }
 
 // inspectSchemaVersionForImages will inspect each input image using skopeo and returns a map of each image
-// with its corresponding schemaVersion. It is expeted that len(images) > 0.
+// with its corresponding schemaVersion. It is expected that len(images) > 0.
 func (p *RelatedImagesAreSchemaVersion2Check) inspectSchemaVersionForImage(images []string) (map[string]int, error) {
 	inspectOpts := cli.SkopeoInspectOptions{Raw: true}
 
@@ -165,7 +165,7 @@ func (p *RelatedImagesAreSchemaVersion2Check) getSchemaVersionFromRawManifest(ma
 		return 0, fmt.Errorf("rawManifest is an unexpected format")
 	}
 
-	// when unmarshaled by json, number will be a float64
+	// when unmarshalled by json, number will be a float64
 	schemaVersionf64, ok := schemaVersionIface.(float64)
 	if !ok {
 		return 0, fmt.Errorf("schemaVersion value is an unexpected type")

--- a/certification/internal/shell/mounted_engine.go
+++ b/certification/internal/shell/mounted_engine.go
@@ -43,7 +43,7 @@ func (e *MountedCheckEngine) ExecuteChecks() error {
 
 	// 2 possible status codes
 	// 1. PASSED - all checks have passed successfully
-	// 2. FAILED - At least one check failed or an error occured in one of the checks
+	// 2. FAILED - At least one check failed or an error occurred in one of the checks
 	if len(e.results.Errors) > 0 || len(e.results.Failed) > 0 {
 		e.results.PassedOverall = false
 	} else {

--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -67,6 +67,6 @@ func (p ValidateOperatorBundleCheck) Metadata() certification.Metadata {
 func (p ValidateOperatorBundleCheck) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "Check ValidateOperatorBundle encountered an error. Please review the preflight.log file for more information.",
-		Suggestion: "Valid bundles are definied by bundle spec, so make sure that this bundle conforms to that spec. More Information: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md",
+		Suggestion: "Valid bundles are defined by bundle spec, so make sure that this bundle conforms to that spec. More Information: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md",
 	}
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,7 +7,7 @@ import (
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Run checks for an operator or container",
-	Long:  "This command will allow you to execute the Red Hat Certificaiton tests for an operator or a container.",
+	Long:  "This command will allow you to execute the Red Hat Certification tests for an operator or a container.",
 }
 
 func init() {

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -1,63 +1,82 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
+	"net/url"
+
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"strconv"
 )
 
-//todo-adam add the query params and static values here
-var (
-	name = false
+const (
+	baseURL              = "https://connect.dev.redhat.com/support/technology-partner/#/case/new?"
+	typeParam            = "type"
+	typeValue            = "CERT"
+	sourceParam          = "source"
+	sourceValue          = "preflight"
+	certProjectTypeParam = "cert_project_type"
+	certProjectIDParam   = "cert_project_id"
+	pullRequestURLParam  = "pull_request_url"
 )
 
 var supportCmd = &cobra.Command{
 	Use:   "support",
 	Short: "Submits a support request",
-	Long: `This command will submit a support request to Red Hat along with the logs from the latest Preflight checck.
+	Long: `This command will submit a support request to Red Hat along with the logs from the latest Preflight check.
 	This command can be used when you'd like assistance from Red Hat Support when attempting to pass your certification checks. `,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 
-		//todo-adam update the selector for the command type
-		prompt1 := promptui.Select{
-			Label: "Select Day",
-			Items: []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
-				"Saturday", "Sunday"},
+		certProjectTypeLabel := promptui.Select{
+			Label: "Select a Certification Project Type",
+			Items: []string{"Container Image", "Operator Bundle Image"},
 		}
 
-		_, result, err := prompt1.Run()
+		_, certProjectTypeValue, err := certProjectTypeLabel.Run()
 
 		if err != nil {
-			fmt.Printf("Prompt failed %v\n", err)
-			return
+			fmt.Println("Prompt Failed, Please Try re-running support command.")
+			return err
 		}
 
-		fmt.Printf("You choose %q\n", result)
+		fmt.Printf("You Selected:  %q\n", certProjectTypeValue)
 
-		//todo-adam this would be for text input
-		validate := func(input string) error {
-			_, err := strconv.ParseFloat(input, 64)
-			if err != nil {
-				return errors.New("Invalid number")
-			}
-			return nil
+		certProjectIDLabel := promptui.Prompt{
+			Label: "Please Enter Connect Certification Project ID",
 		}
 
-		prompt := promptui.Prompt{
-			Label:    "Number",
-			Validate: validate,
-		}
-
-		result, err = prompt.Run()
+		certProjectIDValue, err := certProjectIDLabel.Run()
 
 		if err != nil {
-			fmt.Printf("Prompt failed %v\n", err)
-			return
+			fmt.Println("Prompt Failed, Please Try re-running support command.")
+			return err
 		}
 
-		fmt.Printf("You choose %q\n", result)
+		fmt.Printf("You Entered: %q\n", certProjectIDValue)
+
+		pullRequestURLLabel := promptui.Prompt{
+			Label: "Please Enter Your Pull Request URL",
+		}
+
+		pullRequestURLValue, err := pullRequestURLLabel.Run()
+
+		if err != nil {
+			fmt.Println("Prompt Failed, Please Try re-running support command.")
+			return err
+		}
+
+		fmt.Printf("You Entered: %q\n", pullRequestURLValue)
+
+		// building and encoding query params
+		queryParams := url.Values{}
+		queryParams.Add(typeParam, typeValue)
+		queryParams.Add(sourceParam, sourceValue)
+		queryParams.Add(certProjectTypeParam, certProjectTypeValue)
+		queryParams.Add(certProjectIDParam, certProjectIDValue)
+		queryParams.Add(pullRequestURLParam, pullRequestURLValue)
+
+		fmt.Printf("URL to Create Support Desk Ticket: %q\n", baseURL+queryParams.Encode())
+
+		return nil
 	},
 }
 

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -1,9 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-
+	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"strconv"
+)
+
+//todo-adam add the query params and static values here
+var (
+	name = false
 )
 
 var supportCmd = &cobra.Command{
@@ -12,7 +19,45 @@ var supportCmd = &cobra.Command{
 	Long: `This command will submit a support request to Red Hat along with the logs from the latest Preflight checck.
 	This command can be used when you'd like assistance from Red Hat Support when attempting to pass your certification checks. `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Support command not implemented")
+
+		//todo-adam update the selector for the command type
+		prompt1 := promptui.Select{
+			Label: "Select Day",
+			Items: []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+				"Saturday", "Sunday"},
+		}
+
+		_, result, err := prompt1.Run()
+
+		if err != nil {
+			fmt.Printf("Prompt failed %v\n", err)
+			return
+		}
+
+		fmt.Printf("You choose %q\n", result)
+
+		//todo-adam this would be for text input
+		validate := func(input string) error {
+			_, err := strconv.ParseFloat(input, 64)
+			if err != nil {
+				return errors.New("Invalid number")
+			}
+			return nil
+		}
+
+		prompt := promptui.Prompt{
+			Label:    "Number",
+			Validate: validate,
+		}
+
+		result, err = prompt.Run()
+
+		if err != nil {
+			fmt.Printf("Prompt failed %v\n", err)
+			return
+		}
+
+		fmt.Printf("You choose %q\n", result)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/containers/podman/v3 v3.2.2
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1
+	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0


### PR DESCRIPTION
- fixed some spelling mistakes in the project
- implemented support command to generate/output a support ticket url for a user to copy/paste into a browser

note: url package was not used to generate the URL, since the base URL has a '#' in it, which was also getting encoded along with the query params.