### PR TITLE
Implement initial crane policies into cmd chain and migrate to that as the primary path of execution

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -1,11 +1,15 @@
 package certification
 
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
 // Check as an interface containing all methods necessary
 // to use and identify a given check.
 type Check interface {
 	// Validate will test the provided image and determine whether the
 	// image complies with the check's requirements.
-	Validate(image string) (result bool, err error)
+	Validate(imageReference ImageReference) (result bool, err error)
 	// Name returns the name of the check.
 	Name() string
 	// Metadata returns the check's metadata.
@@ -38,4 +42,10 @@ type HelpText struct {
 	// Suggestion is text provided to the user indicating what might need to
 	// change in order to pass a check.
 	Suggestion string `json:"suggestion" xml:"suggestion"`
+}
+
+type ImageReference struct {
+	ImageURI    string
+	ImageFSPath string
+	ImageInfo   *v1.Image
 }

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	internal "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/engine"
+	containerpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/container"
+	operatorpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/operator"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/shell"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 )
@@ -23,6 +26,34 @@ type CheckEngine interface {
 }
 
 func NewForConfig(config runtime.Config) (CheckEngine, error) {
+	if len(config.EnabledChecks) == 0 {
+		// refuse to run if the user has not specified any checks
+		return nil, errors.ErrNoChecksEnabled
+	}
+
+	checks := make([]certification.Check, len(config.EnabledChecks))
+	for i, checkString := range config.EnabledChecks {
+		check := queryNewChecks(checkString)
+		if check == nil {
+			err := fmt.Errorf("%w: %s",
+				errors.ErrRequestedCheckNotFound,
+				checkString)
+			return nil, err
+		}
+
+		checks[i] = check
+	}
+
+	engine := &internal.CraneEngine{
+		Image:    config.Image,
+		Checks:   checks,
+		IsBundle: config.Bundle,
+	}
+
+	return engine, nil
+}
+
+func NewShellEngineForConfig(config runtime.Config) (CheckEngine, error) {
 	if len(config.EnabledChecks) == 0 {
 		// refuse to run if the user has not specified any checks
 		return nil, errors.ErrNoChecksEnabled
@@ -60,15 +91,31 @@ func NewForConfig(config runtime.Config) (CheckEngine, error) {
 // if found; nil otherwise
 func queryChecks(checkName string) certification.Check {
 	// query Operator checks
+	if check, exists := oldOperatorPolicy[checkName]; exists {
+		return check
+	}
+	// if not found in Operator Policy, query container policy
+	if check, exists := oldContainerPolicy[checkName]; exists {
+		return check
+	}
+
+	// Lastly, look at the mounted checks
+	if check, exists := unshareChecks[checkName]; exists {
+		return check
+	}
+
+	return nil
+}
+
+// queryNewChecks queries Operator and Container checks by name, and return certification.Check
+// if found; nil otherwise. This will be collapsed when old checks are all deprecated.
+func queryNewChecks(checkName string) certification.Check {
+	// query Operator checks
 	if check, exists := operatorPolicy[checkName]; exists {
 		return check
 	}
 	// if not found in Operator Policy, query container policy
 	if check, exists := containerPolicy[checkName]; exists {
-		return check
-	}
-	// Lastly, look at the mounted checks
-	if check, exists := unshareChecks[checkName]; exists {
 		return check
 	}
 
@@ -80,7 +127,7 @@ var runAsNonRootCheck certification.Check = &shell.RunAsNonRootCheck{}
 var underLayerMaxCheck certification.Check = &shell.UnderLayerMaxCheck{}
 var hasRequiredLabelCheck certification.Check = &shell.HasRequiredLabelsCheck{}
 var basedOnUbiCheck certification.Check = &shell.BaseOnUBICheck{}
-var hasLicenseCheck certification.Check = &shell.HasLicenseCheck{}
+var deprecatedHasLicenseCheck certification.Check = &shell.HasLicenseCheck{}
 var hasMinimalVulnerabilitiesCheck certification.Check = &shell.HasMinimalVulnerabilitiesCheck{}
 var hasUniqueTagCheck certification.Check = &shell.HasUniqueTagCheck{}
 var hasNoProhibitedCheck certification.Check = &shell.HasNoProhibitedPackagesCheck{}
@@ -88,31 +135,43 @@ var validateOperatorBundle certification.Check = &shell.ValidateOperatorBundleCh
 var scorecardBasicSpecCheck certification.Check = &shell.ScorecardBasicSpecCheck{}
 var scorecardOlmSuiteCheck certification.Check = &shell.ScorecardOlmSuiteCheck{}
 var hasNoProhibitedMountedCheck certification.Check = &shell.HasNoProhibitedPackagesMountedCheck{}
-var relatedImageManifestSchemaVersionCheck certification.Check = &shell.RelatedImagesAreSchemaVersion2Check{}
+var deprecatedRelatedImageManifestSchemaVersionCheck certification.Check = &shell.RelatedImagesAreSchemaVersion2Check{}
 var operatorPkgNameIsUniqueMountedCheck certification.Check = &shell.OperatorPkgNameIsUniqueMountedCheck{}
 var operatorPkgNameIsUniqueCheck certification.Check = &shell.OperatorPkgNameIsUniqueCheck{}
 var hasMinimalVulnerabilitiesUnshareCheck certification.Check = &shell.HasMinimalVulnerabilitiesUnshareCheck{}
 
+// new checks for CraneEngine
+var hasLicenseCheck certification.Check = &containerpol.HasLicenseCheck{}
+var relatedImageManifestSchemaVersionCheck certification.Check = &operatorpol.RelatedImagesAreSchemaVersion2Check{}
+
+var operatorPolicy = map[string]certification.Check{
+	relatedImageManifestSchemaVersionCheck.Name(): relatedImageManifestSchemaVersionCheck,
+}
+
 var containerPolicy = map[string]certification.Check{
+	hasLicenseCheck.Name(): hasLicenseCheck,
+}
+
+var oldContainerPolicy = map[string]certification.Check{
 	runAsNonRootCheck.Name():              runAsNonRootCheck,
 	underLayerMaxCheck.Name():             underLayerMaxCheck,
 	hasRequiredLabelCheck.Name():          hasRequiredLabelCheck,
 	basedOnUbiCheck.Name():                basedOnUbiCheck,
-	hasLicenseCheck.Name():                hasLicenseCheck,
+	deprecatedHasLicenseCheck.Name():      deprecatedHasLicenseCheck,
 	hasMinimalVulnerabilitiesCheck.Name(): hasMinimalVulnerabilitiesCheck,
 	hasUniqueTagCheck.Name():              hasUniqueTagCheck,
 	hasNoProhibitedCheck.Name():           hasNoProhibitedCheck,
 }
 
-var operatorPolicy = map[string]certification.Check{
-	validateOperatorBundle.Name():                 validateOperatorBundle,
-	scorecardBasicSpecCheck.Name():                scorecardBasicSpecCheck,
-	scorecardOlmSuiteCheck.Name():                 scorecardOlmSuiteCheck,
-	relatedImageManifestSchemaVersionCheck.Name(): relatedImageManifestSchemaVersionCheck,
-	validateOperatorBundle.Name():                 validateOperatorBundle,
-	scorecardBasicSpecCheck.Name():                scorecardBasicSpecCheck,
-	scorecardOlmSuiteCheck.Name():                 scorecardOlmSuiteCheck,
-	operatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
+var oldOperatorPolicy = map[string]certification.Check{
+	validateOperatorBundle.Name():                           validateOperatorBundle,
+	scorecardBasicSpecCheck.Name():                          scorecardBasicSpecCheck,
+	scorecardOlmSuiteCheck.Name():                           scorecardOlmSuiteCheck,
+	deprecatedRelatedImageManifestSchemaVersionCheck.Name(): deprecatedRelatedImageManifestSchemaVersionCheck,
+	validateOperatorBundle.Name():                           validateOperatorBundle,
+	scorecardBasicSpecCheck.Name():                          scorecardBasicSpecCheck,
+	scorecardOlmSuiteCheck.Name():                           scorecardOlmSuiteCheck,
+	operatorPkgNameIsUniqueCheck.Name():                     operatorPkgNameIsUniqueCheck,
 }
 
 var unshareChecks = map[string]certification.Check{
@@ -131,6 +190,14 @@ func makeCheckList(checkMap map[string]certification.Check) []string {
 	}
 
 	return checks
+}
+
+func OldOperatorPolicy() []string {
+	return makeCheckList(oldOperatorPolicy)
+}
+
+func OldContainerPolicy() []string {
+	return makeCheckList(oldContainerPolicy)
 }
 
 func OperatorPolicy() []string {

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Engine Creation", func() {
 			}
 
 			It("should return an engine and no error", func() {
-				engine, err := NewForConfig(cfg)
+				engine, err := NewShellEngineForConfig(cfg)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(engine).ToNot(BeNil())
 			})
@@ -60,7 +60,7 @@ var _ = Describe("Engine Creation", func() {
 			}
 
 			It("should return an error indicating no checks were provided", func() {
-				engine, err := NewForConfig(cfg)
+				engine, err := NewShellEngineForConfig(cfg)
 				Expect(err).To(HaveOccurred())
 				Expect(engine).To(BeNil())
 			})
@@ -74,7 +74,7 @@ var _ = Describe("Engine Creation", func() {
 			}
 
 			It("should return an error indicating no checks were provided", func() {
-				engine, err := NewForConfig(cfg)
+				engine, err := NewShellEngineForConfig(cfg)
 				Expect(err).To(HaveOccurred())
 				Expect(engine).To(BeNil())
 			})

--- a/certification/generic_check.go
+++ b/certification/generic_check.go
@@ -2,7 +2,7 @@ package certification
 
 // ValidatorFunc describes a function that, when executed, will check that an
 // artifact (e.g. operator bundle) complies with a given check.
-type ValidatorFunc = func(string) (bool, error)
+type ValidatorFunc = func(ImageReference) (bool, error)
 
 type genericCheckDefinition struct {
 	name        string
@@ -15,8 +15,8 @@ func (pd *genericCheckDefinition) Name() string {
 	return pd.name
 }
 
-func (pd *genericCheckDefinition) Validate(image string) (bool, error) {
-	return pd.validatorFn(image)
+func (pd *genericCheckDefinition) Validate(imgRef ImageReference) (bool, error) {
+	return pd.validatorFn(imgRef)
 }
 
 func (pd *genericCheckDefinition) Metadata() Metadata {

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -32,7 +32,7 @@ type CraneEngine struct {
 	// IsBundle is an indicator that the asset is a bundle.
 	IsBundle bool
 
-	imageRef ImageReference
+	imageRef certification.ImageReference
 	results  runtime.Results
 }
 
@@ -99,7 +99,7 @@ func (c *CraneEngine) ExecuteChecks() error {
 
 	// store the image internals in the engine image reference to pass to validations.
 	// TODO: pass this to validations when the new check interface includes it.
-	c.imageRef = ImageReference{
+	c.imageRef = certification.ImageReference{
 		ImageURI:    c.Image,
 		ImageFSPath: containerFSPath,
 		ImageInfo:   &img,
@@ -109,13 +109,12 @@ func (c *CraneEngine) ExecuteChecks() error {
 	log.Info("executing checks")
 	for _, check := range c.Checks {
 		c.results.TestedImage = c.Image
-		targetImage := c.Image
 
 		log.Info("running check: ", check.Name())
 
 		// run the validation
 		checkStartTime := time.Now()
-		checkPassed, err := check.Validate(targetImage)
+		checkPassed, err := check.Validate(c.imageRef)
 		checkElapsedTime := time.Since(checkStartTime)
 
 		if err != nil {

--- a/certification/internal/engine/types.go
+++ b/certification/internal/engine/types.go
@@ -1,15 +1,5 @@
 package engine
 
-import (
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-)
-
-type ImageReference struct {
-	ImageURI    string
-	ImageFSPath string
-	ImageInfo   *v1.Image
-}
-
 type RegistryCredentials struct {
 	Username string
 	Password string

--- a/certification/internal/policy/container/has_license.go
+++ b/certification/internal/policy/container/has_license.go
@@ -1,11 +1,10 @@
-package shell
+package container
 
 import (
 	"fmt"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -14,7 +13,6 @@ const (
 	newLine             = "\n"
 	minLicenseFileCount = 1
 	//size format string for find command, c denotes bytes
-	minLicenseSize = "+1c"
 )
 
 // HasLicenseCheck evaluates that the image contains a license definition available at
@@ -22,37 +20,8 @@ const (
 type HasLicenseCheck struct{}
 
 func (p *HasLicenseCheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	licenseFileList, err := p.getDataToValidate(imgRef.ImageURI)
-	if err != nil {
-		return false, err
-	}
-	return p.validate(licenseFileList)
-}
-
-func (p *HasLicenseCheck) getDataToValidate(image string) (string, error) {
-	runOpts := cli.ImageRunOptions{
-		EntryPoint:     "stat",
-		EntryPointArgs: []string{licensePath},
-		LogLevel:       "debug",
-		Image:          image,
-	}
-	runReport, err := podmanEngine.Run(runOpts)
-	if err != nil {
-		log.Error(fmt.Sprintf("Error when checking for %s : ", licensePath), err)
-		log.Errorf("Stdout: %s", runReport.Stdout)
-		log.Debugf("Stderr: %s", runReport.Stderr)
-		return "", err
-	}
-	runOpts.EntryPoint = "find"
-	runOpts.EntryPointArgs = []string{licensePath, "-type", "f", "-size", minLicenseSize}
-	runReport, err = podmanEngine.Run(runOpts)
-	if err != nil {
-		log.Error(fmt.Sprintf("Error when listing %s : ", licensePath), err)
-		log.Errorf("Stdout: %s", runReport.Stdout)
-		log.Debugf("Stderr: %s", runReport.Stderr)
-		return "", err
-	}
-	return runReport.Stdout, nil
+	// TODO Implement
+	return false, fmt.Errorf("unimplemented in migration path to crane engine")
 }
 
 func (p *HasLicenseCheck) validate(licenseFileList string) (bool, error) {

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -15,8 +15,8 @@ import (
 // Name value is `Red Hat Enterprise Linux`
 type BaseOnUBICheck struct{}
 
-func (p *BaseOnUBICheck) Validate(image string) (bool, error) {
-	lines, err := p.getDataToValidate(image)
+func (p *BaseOnUBICheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	lines, err := p.getDataToValidate(imgRef.ImageURI)
 	if err != nil {
 		log.Debugf("Stdout: %s", lines)
 		return false, fmt.Errorf("%w: %s", errors.ErrRunContainerFailed, err)

--- a/certification/internal/shell/base_on_ubi_test.go
+++ b/certification/internal/shell/base_on_ubi_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
@@ -32,7 +33,7 @@ NAME="Red Hat Enterprise Linux"
 				podmanEngine = fakeEngine
 			})
 			It("should pass Validate", func() {
-				ok, err := baseOnUbiCheck.Validate("dummy/image")
+				ok, err := baseOnUbiCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -45,7 +46,7 @@ NAME="Red Hat Enterprise Linux"
 			})
 			It("should not pass Validate", func() {
 				log.Errorf("Run Report: %s", podmanEngine)
-				ok, err := baseOnUbiCheck.Validate("dummy/image")
+				ok, err := baseOnUbiCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -58,7 +59,7 @@ NAME="Red Hat Enterprise Linux"
 		})
 		Context("When PodMan throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := baseOnUbiCheck.Validate("dummy/image")
+				ok, err := baseOnUbiCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	containerutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/container"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	log "github.com/sirupsen/logrus"
 )
@@ -57,7 +58,7 @@ func (e *CheckEngine) ExecuteChecks() error {
 		checkStartTime := time.Now()
 
 		// run the validation
-		checkPassed, err := check.Validate(targetImage)
+		checkPassed, err := check.Validate(migration.ImageToImageReference(targetImage))
 
 		checkElapsedTime := time.Since(checkStartTime)
 

--- a/certification/internal/shell/has_license_test.go
+++ b/certification/internal/shell/has_license_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -24,7 +25,7 @@ var _ = Describe("HasLicense", func() {
 				podmanEngine = fakeEngine
 			})
 			It("Should pass Validate", func() {
-				ok, err := HasLicense.Validate("dummy/image")
+				ok, err := HasLicense.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -36,7 +37,7 @@ var _ = Describe("HasLicense", func() {
 				podmanEngine = engine
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate("dummy/image")
+				ok, err := HasLicense.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -48,7 +49,7 @@ var _ = Describe("HasLicense", func() {
 				podmanEngine = engine
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate("dummy/image")
+				ok, err := HasLicense.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -61,7 +62,7 @@ var _ = Describe("HasLicense", func() {
 		})
 		Context("When PodMan throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := HasLicense.Validate("dummy/image")
+				ok, err := HasLicense.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -9,9 +9,9 @@ import (
 // In an Unshare environment. It does not require a mounted image.
 type HasMinimalVulnerabilitiesCheck struct{}
 
-func (p *HasMinimalVulnerabilitiesCheck) Validate(image string) (bool, error) {
+func (p *HasMinimalVulnerabilitiesCheck) Validate(imgRef certification.ImageReference) (bool, error) {
 	mounted := false
-	result, err := podmanEngine.UnshareWithCheck("HasMinimalVulnerabilitiesUnshare", image, mounted)
+	result, err := podmanEngine.UnshareWithCheck("HasMinimalVulnerabilitiesUnshare", imgRef.ImageURI, mounted)
 	if err != nil {
 		log.Trace("unable to execute preflight in the unshare env")
 		log.Debugf("Stdout: %s", result.Stdout)

--- a/certification/internal/shell/has_minimal_vulns_test.go
+++ b/certification/internal/shell/has_minimal_vulns_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
@@ -34,7 +35,7 @@ var _ = Describe("HasMinimalVulns", func() {
 				podmanEngine = engine
 			})
 			It("should pass Validate", func() {
-				ok, err := hasMinimalVulnCheck.Validate("dummy/image")
+				ok, err := hasMinimalVulnCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -47,7 +48,7 @@ var _ = Describe("HasMinimalVulns", func() {
 			})
 			It("should not pass Validate", func() {
 				log.Errorf("Run Report: %s", podmanEngine)
-				ok, err := hasMinimalVulnCheck.Validate("dummy/image")
+				ok, err := hasMinimalVulnCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -60,7 +61,7 @@ var _ = Describe("HasMinimalVulns", func() {
 		})
 		Context("When PodMan throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := hasMinimalVulnCheck.Validate("dummy/image")
+				ok, err := hasMinimalVulnCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/has_minimal_vulns_unshare.go
+++ b/certification/internal/shell/has_minimal_vulns_unshare.go
@@ -15,8 +15,8 @@ import (
 // OVAL definition.
 type HasMinimalVulnerabilitiesUnshareCheck struct{}
 
-func (p *HasMinimalVulnerabilitiesUnshareCheck) Validate(image string) (bool, error) {
-	lines, err := p.scanImage(image)
+func (p *HasMinimalVulnerabilitiesUnshareCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	lines, err := p.scanImage(imgRef.ImageURI)
 	if err != nil {
 		log.Debugf("Stdout: %s", lines)
 		return false, fmt.Errorf("%w: %s", errors.ErrImageScanFailed, err)

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -9,9 +9,9 @@ import (
 // which refers to packages that are not redistributable without an appropriate license.
 type HasNoProhibitedPackagesCheck struct{}
 
-func (p *HasNoProhibitedPackagesCheck) Validate(image string) (bool, error) {
+func (p *HasNoProhibitedPackagesCheck) Validate(imgRef certification.ImageReference) (bool, error) {
 	mounted := true
-	result, err := podmanEngine.UnshareWithCheck("HasNoProhibitedPackagesMounted", image, mounted)
+	result, err := podmanEngine.UnshareWithCheck("HasNoProhibitedPackagesMounted", imgRef.ImageURI, mounted)
 	if err != nil {
 		log.Trace("unable to execute preflight in the unshare env")
 		log.Debugf("Stdout: %s", result.Stdout)

--- a/certification/internal/shell/has_prohibited_packages_mounted.go
+++ b/certification/internal/shell/has_prohibited_packages_mounted.go
@@ -13,8 +13,8 @@ import (
 // which refers to packages that are not redistributable without an appropriate license.
 type HasNoProhibitedPackagesMountedCheck struct{}
 
-func (p *HasNoProhibitedPackagesMountedCheck) Validate(image string) (bool, error) {
-	pkgList, err := p.getDataToValidate(image)
+func (p *HasNoProhibitedPackagesMountedCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	pkgList, err := p.getDataToValidate(imgRef.ImageURI)
 	if err != nil {
 		log.Error("unable to get a list of all packages in the image")
 		return false, err

--- a/certification/internal/shell/has_prohibited_packages_test.go
+++ b/certification/internal/shell/has_prohibited_packages_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -79,7 +80,7 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 		Context("When calling the Unshare", func() {
 			Context("When PodMan throws an error", func() {
 				It("should fail Validate and return an error", func() {
-					ok, err := HasNoProhibitedPackages.Validate("dummy/image")
+					ok, err := HasNoProhibitedPackages.Validate(migration.ImageToImageReference("dummy/image"))
 					Expect(err).To(HaveOccurred())
 					Expect(ok).To(BeFalse())
 				})

--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -12,9 +12,9 @@ var requiredLabels = []string{"name", "vendor", "version", "release", "summary",
 // labels are present on the image asset as it exists in its current container registry.
 type HasRequiredLabelsCheck struct{}
 
-func (p *HasRequiredLabelsCheck) Validate(image string) (bool, error) {
+func (p *HasRequiredLabelsCheck) Validate(imgRef certification.ImageReference) (bool, error) {
 	// TODO: if we're going have the image json on disk already, we should use it here instead of podman inspect-ing.
-	labels, err := p.getDataForValidate(image)
+	labels, err := p.getDataForValidate(imgRef.ImageURI)
 	if err != nil {
 		return false, err
 	}

--- a/certification/internal/shell/has_required_labels_test.go
+++ b/certification/internal/shell/has_required_labels_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -39,7 +40,7 @@ var _ = Describe("HasRequiredLabels", func() {
 	Describe("Checking for required labels", func() {
 		Context("When it has required labels", func() {
 			It("should pass Validate", func() {
-				ok, err := hasRequiredLabelsCheck.Validate("dummy/image")
+				ok, err := hasRequiredLabelsCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -50,7 +51,7 @@ var _ = Describe("HasRequiredLabels", func() {
 				delete(engine.ImageInspectReport.Images[0].Config.Labels, "description")
 			})
 			It("should not succeed the check", func() {
-				ok, err := hasRequiredLabelsCheck.Validate("dummy/image")
+				ok, err := hasRequiredLabelsCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -63,7 +64,7 @@ var _ = Describe("HasRequiredLabels", func() {
 		})
 		Context("When PodMan throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := hasRequiredLabelsCheck.Validate("dummy/image")
+				ok, err := hasRequiredLabelsCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -12,12 +12,12 @@ import (
 // represent the same image over time.
 type HasUniqueTagCheck struct{}
 
-func (p *HasUniqueTagCheck) Validate(image string) (bool, error) {
-	tags, err := p.getDataToValidate(image)
+func (p *HasUniqueTagCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	tags, err := p.getDataToValidate(imgRef.ImageURI)
 	if err != nil {
 		return false, err
 	}
-	return p.validate(image, tags)
+	return p.validate(imgRef.ImageURI, tags)
 }
 
 func (p *HasUniqueTagCheck) getDataToValidate(image string) ([]string, error) {

--- a/certification/internal/shell/has_unique_tag_test.go
+++ b/certification/internal/shell/has_unique_tag_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
@@ -31,7 +32,7 @@ var _ = Describe("UniqueTag", func() {
 				skopeoEngine = fakeEngine
 			})
 			It("should pass Validate", func() {
-				ok, err := hasUniqueTagCheck.Validate("dummy/image")
+				ok, err := hasUniqueTagCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -46,7 +47,7 @@ var _ = Describe("UniqueTag", func() {
 			})
 			It("should not pass Validate", func() {
 				log.Errorf("Run Report: %s", skopeoEngine)
-				ok, err := hasUniqueTagCheck.Validate("dummy/image")
+				ok, err := hasUniqueTagCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -59,7 +60,7 @@ var _ = Describe("UniqueTag", func() {
 		})
 		Context("When Skopeo throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := hasUniqueTagCheck.Validate("dummy/image")
+				ok, err := hasUniqueTagCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -15,9 +15,9 @@ const (
 // UnderLayerMaxCheck ensures that the image has less layers in its assembly than a predefined maximum.
 type UnderLayerMaxCheck struct{}
 
-func (p *UnderLayerMaxCheck) Validate(image string) (bool, error) {
+func (p *UnderLayerMaxCheck) Validate(imageRef certification.ImageReference) (bool, error) {
 	// TODO: if we're going have the image json on disk already, we should use it here instead of podman inspect-ing.
-	layers, err := p.getDataToValidate(image)
+	layers, err := p.getDataToValidate(imageRef.ImageURI)
 	if err != nil {
 		return false, err
 	}

--- a/certification/internal/shell/less_than_max_layers_test.go
+++ b/certification/internal/shell/less_than_max_layers_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -38,7 +39,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 	Describe("Checking for less than max layers", func() {
 		Context("When it has fewer layers than max", func() {
 			It("should pass Validate", func() {
-				ok, err := lessThanMaxLayers.Validate("dummy/image")
+				ok, err := lessThanMaxLayers.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -53,7 +54,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 				engine.ImageInspectReport.Images[0].RootFS.Layers = layers
 			})
 			It("should not succeed the check", func() {
-				ok, err := lessThanMaxLayers.Validate("dummy/image")
+				ok, err := lessThanMaxLayers.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -66,7 +67,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 		})
 		Context("When PodMan throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := lessThanMaxLayers.Validate("dummy/image")
+				ok, err := lessThanMaxLayers.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/operator_pkg_name_uniqueness.go
+++ b/certification/internal/shell/operator_pkg_name_uniqueness.go
@@ -7,9 +7,9 @@ import (
 
 type OperatorPkgNameIsUniqueCheck struct{}
 
-func (p *OperatorPkgNameIsUniqueCheck) Validate(image string) (bool, error) {
+func (p *OperatorPkgNameIsUniqueCheck) Validate(imgRef certification.ImageReference) (bool, error) {
 	mounted := true
-	result, err := podmanEngine.UnshareWithCheck("OperatorPackageNameIsUniqueMounted", image, mounted)
+	result, err := podmanEngine.UnshareWithCheck("OperatorPackageNameIsUniqueMounted", imgRef.ImageURI, mounted)
 	if err != nil {
 		log.Trace("unable to execute preflight in the unshare env")
 		log.Debugf("Stdout: %s", result.Stdout)

--- a/certification/internal/shell/operator_pkg_name_uniqueness_mounted.go
+++ b/certification/internal/shell/operator_pkg_name_uniqueness_mounted.go
@@ -45,8 +45,8 @@ type packageData struct {
 // check.
 type OperatorPkgNameIsUniqueMountedCheck struct{}
 
-func (p *OperatorPkgNameIsUniqueMountedCheck) Validate(bundle string) (bool, error) {
-	annotations, err := p.getAnnotationsFromBundle(bundle)
+func (p *OperatorPkgNameIsUniqueMountedCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	annotations, err := p.getAnnotationsFromBundle(bundleRef.ImageURI)
 	if err != nil {
 		log.Errorf("unable to get annotations.yaml from the bundle")
 		return false, err

--- a/certification/internal/shell/podman.go
+++ b/certification/internal/shell/podman.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/file"
 	fileutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/file"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
@@ -102,7 +101,7 @@ func (pe PodmanCLIEngine) ScanImage(image string) (*cli.ImageScanReport, error) 
 	ovalFilePath := filepath.Join(dir, ovalFilename)
 	log.Debugf("Oval file path: %s", ovalFilePath)
 
-	err = file.DownloadFile(ovalFilePath, ovalFileUrl)
+	err = fileutils.DownloadFile(ovalFilePath, ovalFileUrl)
 	if err != nil {
 		log.Error("Unable to download Oval file", err)
 		return nil, err
@@ -111,7 +110,7 @@ func (pe PodmanCLIEngine) ScanImage(image string) (*cli.ImageScanReport, error) 
 	r := regexp.MustCompile(`(?P<filename>.*).bz2`)
 	ovalFilePathDecompressed := filepath.Join(dir, r.FindStringSubmatch(ovalFilename)[1])
 
-	err = file.Unzip(ovalFilePath, ovalFilePathDecompressed)
+	err = fileutils.Unzip(ovalFilePath, ovalFilePathDecompressed)
 	if err != nil {
 		log.Error("Unable to unzip Oval file: ", err)
 		return nil, err

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -13,9 +13,9 @@ import (
 // which correlates to the root user.
 type RunAsNonRootCheck struct{}
 
-func (p *RunAsNonRootCheck) Validate(image string) (bool, error) {
+func (p *RunAsNonRootCheck) Validate(imgRef certification.ImageReference) (bool, error) {
 
-	line, err := p.getDataToValidate(image)
+	line, err := p.getDataToValidate(imgRef.ImageURI)
 	if err != nil {
 		return false, err
 	}

--- a/certification/internal/shell/runs_as_nonroot_test.go
+++ b/certification/internal/shell/runs_as_nonroot_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -25,7 +26,7 @@ var _ = Describe("RunAsNonRoot", func() {
 				podmanEngine = fakeEngine
 			})
 			It("should pass Validate", func() {
-				ok, err := RunAsNonRoot.Validate("dummy/image")
+				ok, err := RunAsNonRoot.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -37,7 +38,7 @@ var _ = Describe("RunAsNonRoot", func() {
 				podmanEngine = engine
 			})
 			It("should not pass Validate", func() {
-				ok, err := RunAsNonRoot.Validate("dummy/image")
+				ok, err := RunAsNonRoot.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -50,7 +51,7 @@ var _ = Describe("RunAsNonRoot", func() {
 		})
 		Context("When PodMan throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := RunAsNonRoot.Validate("dummy/image")
+				ok, err := RunAsNonRoot.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/scorecard_basic_check_spec.go
+++ b/certification/internal/shell/scorecard_basic_check_spec.go
@@ -13,11 +13,11 @@ type ScorecardBasicSpecCheck struct {
 
 const scorecardBasicCheckResult string = "operator_bundle_scorecard_BasicSpecCheck.json"
 
-func (p *ScorecardBasicSpecCheck) Validate(bundleImage string) (bool, error) {
-	log.Debug("Running operator-sdk scorecard check for ", bundleImage)
+func (p *ScorecardBasicSpecCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	log.Debug("Running operator-sdk scorecard check for ", bundleRef.ImageURI)
 	selector := []string{"test=basic-check-spec-test"}
 	log.Debugf("--selector=%s", selector)
-	scorecardReport, err := p.getDataToValidate(bundleImage, selector, scorecardBasicCheckResult)
+	scorecardReport, err := p.getDataToValidate(bundleRef.ImageURI, selector, scorecardBasicCheckResult)
 	if err != nil {
 		return false, err
 	}

--- a/certification/internal/shell/scorecard_basic_check_test.go
+++ b/certification/internal/shell/scorecard_basic_check_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -71,7 +72,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {
 			It("Should pass Validate", func() {
-				ok, err := scorecardBasicCheck.Validate("dummy/image")
+				ok, err := scorecardBasicCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -83,7 +84,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				operatorSdkEngine = engine
 			})
 			It("Should not pass Validate", func() {
-				ok, err := scorecardBasicCheck.Validate("dummy/image")
+				ok, err := scorecardBasicCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -96,7 +97,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := scorecardBasicCheck.Validate("dummy/image")
+				ok, err := scorecardBasicCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/scorecard_olm_suite.go
+++ b/certification/internal/shell/scorecard_olm_suite.go
@@ -13,11 +13,11 @@ type ScorecardOlmSuiteCheck struct {
 
 const scorecardOlmSuiteResult string = "operator_bundle_scorecard_OlmSuiteCheck.json"
 
-func (p *ScorecardOlmSuiteCheck) Validate(bundleImage string) (bool, error) {
-	log.Debug("Running operator-sdk scorecard Check for ", bundleImage)
+func (p *ScorecardOlmSuiteCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	log.Debug("Running operator-sdk scorecard Check for ", bundleRef.ImageURI)
 	selector := []string{"suite=olm"}
 	log.Debugf("--selector=%s", selector)
-	scorecardReport, err := p.getDataToValidate(bundleImage, selector, scorecardOlmSuiteResult)
+	scorecardReport, err := p.getDataToValidate(bundleRef.ImageURI, selector, scorecardOlmSuiteResult)
 	if err != nil {
 		return false, err
 	}

--- a/certification/internal/shell/scorecard_olm_suite_test.go
+++ b/certification/internal/shell/scorecard_olm_suite_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -71,7 +72,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {
 			It("Should pass Validate", func() {
-				ok, err := scorecardOlmSuiteCheck.Validate("dummy/image")
+				ok, err := scorecardOlmSuiteCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -83,7 +84,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				operatorSdkEngine = engine
 			})
 			It("Should not pass Validate", func() {
-				ok, err := scorecardOlmSuiteCheck.Validate("dummy/image")
+				ok, err := scorecardOlmSuiteCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -96,7 +97,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := scorecardOlmSuiteCheck.Validate("dummy/image")
+				ok, err := scorecardOlmSuiteCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/shell/shell.go
+++ b/certification/internal/shell/shell.go
@@ -3,7 +3,9 @@
 // various shell tools are installed.
 package shell
 
-import "github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+)
 
 // Create a package-level podmanEngine variable, that can be overridden
 // at the test level.

--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -11,8 +11,8 @@ import (
 type ValidateOperatorBundleCheck struct {
 }
 
-func (p ValidateOperatorBundleCheck) Validate(bundle string) (bool, error) {
-	report, err := p.getDataToValidate(bundle)
+func (p ValidateOperatorBundleCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	report, err := p.getDataToValidate(bundleRef.ImageURI)
 	if err != nil {
 		log.Error("Error while executing operator-sdk bundle validate: ", err)
 		return false, err

--- a/certification/internal/shell/validate_operator_bundle_test.go
+++ b/certification/internal/shell/validate_operator_bundle_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
 
@@ -32,7 +33,7 @@ var _ = Describe("BundleValidateCheck", func() {
 	Describe("Operator Bundle Validate", func() {
 		Context("When Operator Bundle Validate passes", func() {
 			It("Should pass Validate", func() {
-				ok, err := bundleValidateCheck.Validate("dummy/image")
+				ok, err := bundleValidateCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -48,7 +49,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				operatorSdkEngine = engine
 			})
 			It("Should not pass Validate", func() {
-				ok, err := bundleValidateCheck.Validate("dummy/image")
+				ok, err := bundleValidateCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -61,7 +62,7 @@ var _ = Describe("BundleValidateCheck", func() {
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := bundleValidateCheck.Validate("dummy/image")
+				ok, err := bundleValidateCheck.Validate(migration.ImageToImageReference("dummy/image"))
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/utils/migration/migration.go
+++ b/certification/internal/utils/migration/migration.go
@@ -1,0 +1,10 @@
+package migration
+
+import "github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+
+// ImageToImageReference converts an image string, used in early Check.Validate
+// interface definitions and replaces it with an ImageReference used in later
+// implementations.
+func ImageToImageReference(image string) certification.ImageReference {
+	return certification.ImageReference{ImageURI: image}
+}

--- a/cmd/check_container_old.go
+++ b/cmd/check_container_old.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var checkContainerCmd = &cobra.Command{
-	Use:   "container",
-	Short: "Run checks for a container",
+var oldCheckContainerCmd = &cobra.Command{
+	Use:   "container-old",
+	Short: "Run checks for a container using the previous engine",
 	Long:  `This command will run the Certification checks for a container image. `,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -31,11 +31,11 @@ var checkContainerCmd = &cobra.Command{
 
 		cfg := runtime.Config{
 			Image:          containerImage,
-			EnabledChecks:  engine.ContainerPolicy(),
+			EnabledChecks:  engine.OldContainerPolicy(),
 			ResponseFormat: DefaultOutputFormat,
 		}
 
-		engine, err := engine.NewForConfig(cfg)
+		engine, err := engine.NewShellEngineForConfig(cfg)
 		if err != nil {
 			return err
 		}
@@ -94,5 +94,5 @@ Flags:
 `
 	checkContainerCmd.SetUsageTemplate(usage)
 
-	checkCmd.AddCommand(checkContainerCmd)
+	checkCmd.AddCommand(oldCheckContainerCmd)
 }

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -87,7 +87,7 @@ var checkOperatorCmd = &cobra.Command{
 }
 
 func init() {
-	checks := strings.Join(engine.OperatorPolicy(), "\n- ")
+	checks := strings.Join(engine.OldOperatorPolicy(), "\n- ")
 
 	usage := "\n" + `The checks that will be executed are the following:` + "\n- " +
 		checks + "\n\n" +

--- a/cmd/check_run.go
+++ b/cmd/check_run.go
@@ -45,7 +45,7 @@ It takes its input from environment variables only.`,
 			Mounted:        mounted == "true",
 		}
 
-		engine, err := engine.NewForConfig(cfg)
+		engine, err := engine.NewShellEngineForConfig(cfg)
 		if err != nil {
 			return err
 		}

--- a/docs/dev/IMPLEMENT_A_CHECK.md
+++ b/docs/dev/IMPLEMENT_A_CHECK.md
@@ -48,7 +48,7 @@ type ValidateThingCheck struct{
     // your struct fields here
 }
 
-func (p *ValidateThingCheck) Validate(image string) (bool, error) {
+func (p *ValidateThingCheck) Validate(image certification.ImageReference) (bool, error) {
     // your logic here ...
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,10 +23,10 @@ var _ = Describe("policy validation", func() {
 
 			cfg := runtime.Config{
 				Image:         goodImage,
-				EnabledChecks: engine.OperatorPolicy(),
+				EnabledChecks: engine.OldOperatorPolicy(),
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			engine, err := engine.NewShellEngineForConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			engine.ExecuteChecks()
@@ -40,10 +40,10 @@ var _ = Describe("policy validation", func() {
 		Context("with a known-bad image", func() {
 			cfg := runtime.Config{
 				Image:         badImage,
-				EnabledChecks: engine.OperatorPolicy(),
+				EnabledChecks: engine.OldOperatorPolicy(),
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			engine, err := engine.NewShellEngineForConfig(cfg)
 			Expect(err).To(BeNil())
 
 			engine.ExecuteChecks()
@@ -68,10 +68,10 @@ var _ = Describe("policy validation", func() {
 
 			cfg := runtime.Config{
 				Image:         goodImage,
-				EnabledChecks: engine.ContainerPolicy(),
+				EnabledChecks: engine.OldContainerPolicy(),
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			engine, err := engine.NewShellEngineForConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			engine.ExecuteChecks()
@@ -90,10 +90,10 @@ var _ = Describe("policy validation", func() {
 		XContext("with a known-bad image", func() {
 			cfg := runtime.Config{
 				Image:         badImage,
-				EnabledChecks: engine.ContainerPolicy(),
+				EnabledChecks: engine.OldContainerPolicy(),
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			engine, err := engine.NewShellEngineForConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			engine.ExecuteChecks()


### PR DESCRIPTION
This is a bit of a hefty PR. My apologies.

This PR defines two initial checks using the new Crane-based CheckEngine. This further enables the execution of preflight on MacOS without the need for a remote podman service[1]  🎉 Woohoo! 🎉  

- The implemented operator check is RelatedImagesAreSchemaVersion2
- The "implemented" container check is HasLicense (this is "implemented", because it's actually just staged to accept the changes made by @bcrochet in #171)

In this work, I needed to
- adjust the definition of a Check so that it used the new certification.ImageReference, which contains a bit more contextual data for the new approach to utilize per-check, such as filesystem mounts, and image metadata such as layers
- updated all the previous checks to use the signature, and then added a small migration function in the shell check engine to accommodate the new signature without breaking everything
- shifted our engine.NewForConfig ==> engine.NewShellEngineForConfig, and moved the policy naming around so that we could keep both sets of policies simultaneously while we finish the migration to crane.
- Moved the commandline invocation using the old engine to `preflight check container-old` and `preflight check operator-old` should we need them.

Happy to add more detail or demo as needed. I'm sure I'll think of more detail/clarity I can add on Monday.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>


[1]
```
18:07:19 ~/.go/src/github.com/redhat-openshift-ecosystem/openshift-preflight ≪ branch=feature/initial-crane-policy-impl ≫
$ PFLT_LOGLEVEL=trace KUBECONFIG=foo ./preflight check operator quay.io/komish/preflight-test-bundle-passes:latest
time="2021-08-20T18:07:26-05:00" level=info msg="config file not found, proceeding without it"
time="2021-08-20T18:07:26-05:00" level=info msg="target image: quay.io/komish/preflight-test-bundle-passes:latest"
time="2021-08-20T18:07:26-05:00" level=info msg="no authentication context derived from execution configuration"
time="2021-08-20T18:07:26-05:00" level=info msg="pulling image from target registry"
time="2021-08-20T18:07:27-05:00" level=debug msg="temporary directory is/var/folders/cn/r49cg2wx5z97qwq_s48f4vm80000gn/T/preflight-453238028"
time="2021-08-20T18:07:27-05:00" level=debug msg="exporting and flattening image"
time="2021-08-20T18:07:27-05:00" level=debug msg="extracting container filesystem to/var/folders/cn/r49cg2wx5z97qwq_s48f4vm80000gn/T/preflight-453238028/fs"
time="2021-08-20T18:07:27-05:00" level=debug msg="writing container filesystem to output dir/var/folders/cn/r49cg2wx5z97qwq_s48f4vm80000gn/T/preflight-453238028/fs"
time="2021-08-20T18:07:28-05:00" level=info msg="executing checks"
time="2021-08-20T18:07:28-05:00" level=info msg="running check: RelatedImagesAreSchemaVersion2"
time="2021-08-20T18:07:28-05:00" level=info msg="check completed: RelatedImagesAreSchemaVersion2" result=PASSED
{
    "image": "quay.io/komish/preflight-test-bundle-passes:latest",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "0.0.0",
        "commit": "af50e97102a32abadafd5f37f76f47497b4e4ace"
    },
    "results": {
        "passed": [
            {
                "name": "RelatedImagesAreSchemaVersion2",
                "elapsed_time": 10,
                "description": "An operator bundle's relatedImages must be accessible at image manifest schema version 2"
            }
        ],
        "failed": [],
        "errors": []
    }
}
```