### PR TITLE
split build action to tag and main

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,18 +1,15 @@
-name: Build
+name: Build Main
 
 on:
   push:
     branches: [ main ]
-  release:
-    types: [ published, created, edited ]
 
 jobs:
-  build:
-    name: Build and push image
+  build-main:
+    name: Build and push a main snapshot image
     runs-on: ubuntu-latest
     env:
       IMAGE_REGISTRY: quay.io/opdev
-      RELEASE_TAG: "0.0.0"
     steps:
     - uses: actions/checkout@v2
 
@@ -21,7 +18,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_REGISTRY }}/preflight
-        tags: ${{ github.sha }} ${{ env.RELEASE_TAG }}
+        tags: ${{ github.sha }}
         dockerfiles: |
           ./Dockerfile
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,39 @@
+name: Build Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-release:
+    name: Build and push a tag image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REGISTRY: quay.io/opdev
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Env Tags
+      run: echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/preflight
+        tags: ${{ env.RELEASE_TAG }}
+        dockerfiles: |
+          ./Dockerfile
+
+    - name: Push Image
+      id: push-image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: preflight
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-image.outputs.registry-paths }}"


### PR DESCRIPTION
Previously the Image Build action was triggered on every push to Main,  and produced a dual-tagged image.
This is now split into 2 separate triggers:  on push to Main, and on push to Tag.
each will be tagging the image according to the version it represents.

Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>