### PR TITLE
Add support for supplying namespace and service account to scorecard

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -146,6 +146,8 @@ var relatedImageManifestSchemaVersionCheck certification.Check = &operatorpol.Re
 
 var operatorPolicy = map[string]certification.Check{
 	relatedImageManifestSchemaVersionCheck.Name(): relatedImageManifestSchemaVersionCheck,
+	scorecardBasicSpecCheck.Name():                scorecardBasicSpecCheck,
+	scorecardOlmSuiteCheck.Name():                 scorecardOlmSuiteCheck,
 }
 
 var containerPolicy = map[string]certification.Check{
@@ -169,8 +171,6 @@ var oldOperatorPolicy = map[string]certification.Check{
 	scorecardOlmSuiteCheck.Name():                           scorecardOlmSuiteCheck,
 	deprecatedRelatedImageManifestSchemaVersionCheck.Name(): deprecatedRelatedImageManifestSchemaVersionCheck,
 	validateOperatorBundle.Name():                           validateOperatorBundle,
-	scorecardBasicSpecCheck.Name():                          scorecardBasicSpecCheck,
-	scorecardOlmSuiteCheck.Name():                           scorecardOlmSuiteCheck,
 	operatorPkgNameIsUniqueCheck.Name():                     operatorPkgNameIsUniqueCheck,
 }
 

--- a/certification/internal/shell/operatorsdk.go
+++ b/certification/internal/shell/operatorsdk.go
@@ -27,6 +27,15 @@ func (o OperatorSdkCLIEngine) Scorecard(image string, opts cli.OperatorSdkScorec
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--selector=%s", selector))
 		}
 	}
+	if opts.Kubeconfig != "" {
+		cmdArgs = append(cmdArgs, "--kubeconfig", opts.Kubeconfig)
+	}
+	if opts.Namespace != "" {
+		cmdArgs = append(cmdArgs, "--namespace", opts.Namespace)
+	}
+	if opts.ServiceAccount != "" {
+		cmdArgs = append(cmdArgs, "--service-account", opts.ServiceAccount)
+	}
 	cmdArgs = append(cmdArgs, image)
 
 	cmd := exec.Command("operator-sdk", cmdArgs...)

--- a/certification/internal/shell/scorecard_check.go
+++ b/certification/internal/shell/scorecard_check.go
@@ -1,10 +1,12 @@
 package shell
 
 import (
+	"os"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 type scorecardCheck struct{}
@@ -27,11 +29,17 @@ func (p *scorecardCheck) validate(items []cli.OperatorSdkScorecardItem) (bool, e
 }
 
 func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string, resultFile string) (*cli.OperatorSdkScorecardReport, error) {
+	namespace := viper.GetString("namespace")
+	serviceAccount := viper.GetString("serviceaccount")
+	kubeconfig := os.Getenv("KUBECONFIG")
 	opts := cli.OperatorSdkScorecardOptions{
-		LogLevel:     "warning",
-		OutputFormat: "json",
-		Selector:     selector,
-		ResultFile:   resultFile,
+		LogLevel:       "warning",
+		OutputFormat:   "json",
+		Selector:       selector,
+		ResultFile:     resultFile,
+		Kubeconfig:     kubeconfig,
+		Namespace:      namespace,
+		ServiceAccount: serviceAccount,
 	}
 	return operatorSdkEngine.Scorecard(bundleImage, opts)
 }

--- a/cli/operatorsdk.go
+++ b/cli/operatorsdk.go
@@ -1,10 +1,13 @@
 package cli
 
 type OperatorSdkScorecardOptions struct {
-	LogLevel     string
-	OutputFormat string
-	Selector     []string
-	ResultFile   string
+	LogLevel       string
+	OutputFormat   string
+	Selector       []string
+	ResultFile     string
+	Kubeconfig     string
+	Namespace      string
+	ServiceAccount string
 }
 
 type OperatorSdkScorecardReport struct {

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -1,8 +1,10 @@
 package cmd
 
 var (
-	DefaultOutputFormat = "json"
-	DefaultLogFile      = "preflight.log"
-	DefaultLogLevel     = "warn"
-	DefaultArtifactsDir = "artifacts"
+	DefaultOutputFormat   = "json"
+	DefaultLogFile        = "preflight.log"
+	DefaultLogLevel       = "warn"
+	DefaultArtifactsDir   = "artifacts"
+	DefaultNamespace      = "default"
+	DefaultServiceAccount = "default"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,10 @@ func initConfig() {
 	viper.SetDefault("loglevel", DefaultLogLevel)
 	viper.SetDefault("artifacts", DefaultArtifactsDir)
 
+	// Set up cluster defaults
+	viper.SetDefault("namespace", DefaultNamespace)
+	viper.SetDefault("serviceaccount", DefaultServiceAccount)
+
 	// set up logging
 	logname := viper.GetString("logfile")
 	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)


### PR DESCRIPTION
In order to support using a secure registry, the ability to pass a
namespace and a serviceaccount are necessary. This adds those params,
as well as kubeconfig if that is set.

Fixes: #172 

Signed-off-by: Brad P. Crochet <brad@redhat.com>