### PR TITLE
Disable the HasMinimalVulnerabilities check

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -153,14 +153,15 @@ var containerPolicy = map[string]certification.Check{
 }
 
 var oldContainerPolicy = map[string]certification.Check{
-	runAsNonRootCheck.Name():              runAsNonRootCheck,
-	underLayerMaxCheck.Name():             underLayerMaxCheck,
-	hasRequiredLabelCheck.Name():          hasRequiredLabelCheck,
-	basedOnUbiCheck.Name():                basedOnUbiCheck,
-	deprecatedHasLicenseCheck.Name():      deprecatedHasLicenseCheck,
-	hasMinimalVulnerabilitiesCheck.Name(): hasMinimalVulnerabilitiesCheck,
-	hasUniqueTagCheck.Name():              hasUniqueTagCheck,
-	hasNoProhibitedCheck.Name():           hasNoProhibitedCheck,
+	runAsNonRootCheck.Name():         runAsNonRootCheck,
+	underLayerMaxCheck.Name():        underLayerMaxCheck,
+	hasRequiredLabelCheck.Name():     hasRequiredLabelCheck,
+	basedOnUbiCheck.Name():           basedOnUbiCheck,
+	deprecatedHasLicenseCheck.Name(): deprecatedHasLicenseCheck,
+	hasUniqueTagCheck.Name():         hasUniqueTagCheck,
+	hasNoProhibitedCheck.Name():      hasNoProhibitedCheck,
+	// Disabled due to issue #99 and discussions in community meeting
+	// hasMinimalVulnerabilitiesCheck.Name(): hasMinimalVulnerabilitiesCheck,
 }
 
 var oldOperatorPolicy = map[string]certification.Check{


### PR DESCRIPTION
Due to issue #99 and discussions on whether this check should be run
on the community meeting, disabling this check until such a time as
it becomes an explicit requirement again.

Related: #99

Signed-off-by: Brad P. Crochet <brad@redhat.com>