### PR TITLE
Move OperatorPkgNameUnique check to CraneEngine

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -137,8 +137,8 @@ var scorecardBasicSpecCheck certification.Check = &shell.ScorecardBasicSpecCheck
 var scorecardOlmSuiteCheck certification.Check = &shell.ScorecardOlmSuiteCheck{}
 var hasNoProhibitedMountedCheck certification.Check = &shell.HasNoProhibitedPackagesMountedCheck{}
 var deprecatedRelatedImageManifestSchemaVersionCheck certification.Check = &shell.RelatedImagesAreSchemaVersion2Check{}
-var operatorPkgNameIsUniqueMountedCheck certification.Check = &shell.OperatorPkgNameIsUniqueMountedCheck{}
-var operatorPkgNameIsUniqueCheck certification.Check = &shell.OperatorPkgNameIsUniqueCheck{}
+var deprecatedOperatorPkgNameIsUniqueMountedCheck certification.Check = &shell.OperatorPkgNameIsUniqueMountedCheck{}
+var deprecatedOperatorPkgNameIsUniqueCheck certification.Check = &shell.OperatorPkgNameIsUniqueCheck{}
 var hasMinimalVulnerabilitiesUnshareCheck certification.Check = &shell.HasMinimalVulnerabilitiesUnshareCheck{}
 var deployableByOlmCheck certification.Check = &k8s.DeployableByOlmCheck{}
 var deployableByOlmMountedCheck certification.Check = &k8s.DeployableByOlmMountedCheck{}
@@ -146,8 +146,10 @@ var deployableByOlmMountedCheck certification.Check = &k8s.DeployableByOlmMounte
 // new checks for CraneEngine
 var hasLicenseCheck certification.Check = &containerpol.HasLicenseCheck{}
 var relatedImageManifestSchemaVersionCheck certification.Check = &operatorpol.RelatedImagesAreSchemaVersion2Check{}
+var operatorPkgNameIsUniqueCheck certification.Check = &operatorpol.OperatorPkgNameIsUniqueMountedCheck{}
 
 var operatorPolicy = map[string]certification.Check{
+	operatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
 	relatedImageManifestSchemaVersionCheck.Name(): relatedImageManifestSchemaVersionCheck,
 	scorecardBasicSpecCheck.Name():                scorecardBasicSpecCheck,
 	scorecardOlmSuiteCheck.Name():                 scorecardOlmSuiteCheck,
@@ -174,15 +176,15 @@ var oldOperatorPolicy = map[string]certification.Check{
 	scorecardOlmSuiteCheck.Name():                           scorecardOlmSuiteCheck,
 	deprecatedRelatedImageManifestSchemaVersionCheck.Name(): deprecatedRelatedImageManifestSchemaVersionCheck,
 	validateOperatorBundle.Name():                           validateOperatorBundle,
-	operatorPkgNameIsUniqueCheck.Name():                     operatorPkgNameIsUniqueCheck,
+	deprecatedOperatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
 	deployableByOlmCheck.Name():                             deployableByOlmCheck,
 }
 
 var unshareChecks = map[string]certification.Check{
-	hasNoProhibitedMountedCheck.Name():           hasNoProhibitedMountedCheck,
-	operatorPkgNameIsUniqueMountedCheck.Name():   operatorPkgNameIsUniqueMountedCheck,
-	hasMinimalVulnerabilitiesUnshareCheck.Name(): hasMinimalVulnerabilitiesUnshareCheck,
-	deployableByOlmMountedCheck.Name():           deployableByOlmMountedCheck,
+	hasNoProhibitedMountedCheck.Name():                   hasNoProhibitedMountedCheck,
+	deprecatedOperatorPkgNameIsUniqueMountedCheck.Name(): deprecatedOperatorPkgNameIsUniqueMountedCheck,
+	hasMinimalVulnerabilitiesUnshareCheck.Name():         hasMinimalVulnerabilitiesUnshareCheck,
+	deployableByOlmMountedCheck.Name():                   deployableByOlmMountedCheck,
 }
 
 func makeCheckList(checkMap map[string]certification.Check) []string {

--- a/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
+++ b/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
@@ -1,0 +1,195 @@
+package operator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	containerutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/container"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// apiEndpoint is the endpoint used to query for package uniqueness.
+	apiEndpoint = "https://catalog.redhat.com/api/containers/v1/operators/packages"
+
+	// packageKey is the packageKey in annotations.yaml that contains the package name.
+	packageKey = "operators.operatorframework.io.bundle.package.v1"
+)
+
+// apiRespondData is the response received from the defined API
+type apiResponseData struct {
+	Data     []packageData `json:"data"`
+	Page     int           `json:"page"`
+	PageSize int           `json:"page_size"`
+	Total    int           `json:"total"`
+}
+
+// packageData represents a single package entry in the API response.
+type packageData struct {
+	Id             string `json:"_id"`
+	Association    string `json:"association"`
+	CreateDate     string `json:"creation_date"`
+	LastUpdateTime string `json:"last_update_date"`
+	PackageName    string `json:"package_name"`
+	Source         string `json:"source"`
+}
+
+// OperatorPkgNameIsUniqueMountedCheck finds the package name as defined in the operator bundle's annotations
+// and checks it against Red Hat APIs to confirm that the package name is unique at the time of the
+// check.
+type OperatorPkgNameIsUniqueMountedCheck struct{}
+
+func (p *OperatorPkgNameIsUniqueMountedCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	annotations, err := containerutils.GetAnnotationsFromBundle(bundleRef.ImageFSPath)
+	if err != nil {
+		log.Errorf("unable to get annotations.yaml from the bundle")
+		return false, err
+	}
+
+	packageName, err := p.getPackageName(annotations)
+	if err != nil {
+		log.Error("unable to extract package name from ClusterServicVersion", err)
+		return false, err
+	}
+
+	log.Debugf("operator package name is %s", packageName)
+
+	req, err := p.buildRequest(apiEndpoint, packageName)
+	if err != nil {
+		log.Error("unable to build API request structure", err)
+		return false, err
+	}
+
+	resp, err := p.queryAPI(http.DefaultClient, req)
+	if err != nil {
+		log.Error("unable to query package name validation API for uniqueness check", err)
+		return false, err
+	}
+
+	data, err := p.parseAPIResponse(resp)
+	if err != nil {
+		log.Error("unable to parse response provided by package name validation API", err)
+		return false, err
+	}
+
+	return p.validate(data)
+}
+
+// getPackageName accepts the annotations map and searches for the specified annotation corresponding
+// with the complete bundle name for an operator, which is then returned.
+func (p *OperatorPkgNameIsUniqueMountedCheck) getPackageName(annotations map[string]string) (string, error) {
+	log.Tracef("searching for package key (%s) in bundle", packageKey)
+	log.Trace("bundle data: ", annotations)
+	pkg, found := annotations[packageKey]
+	if !found {
+		return "", fmt.Errorf("did not find package name at the key %s in the annotations.yaml", packageKey)
+	}
+
+	return pkg, nil
+}
+
+// buildRequest builds the http.Request using the input parameters and returns a client.
+func (p *OperatorPkgNameIsUniqueMountedCheck) buildRequest(apiURL, packageName string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// this endpoint supports a query string, and we use that to determine if a
+	// package with the name already exists.
+	queryString := req.URL.Query()
+	queryString.Add("filter", fmt.Sprintf("package_name==%s", packageName))
+	req.URL.RawQuery = queryString.Encode()
+
+	return req, nil
+}
+
+// queryAPI uses the provided client to query the remote API, and returns the response if it
+// response is successful, or an error if the response was unexpected in any way.
+func (p *OperatorPkgNameIsUniqueMountedCheck) queryAPI(client apiClient, request *http.Request) (*http.Response, error) {
+	log.Trace("making API request to ", request.URL.String())
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Trace("response code: ", resp.Status)
+
+	// The Connect API returns a 200 regardless of whether the package was found or not. Until this
+	// assumption changes, we assume any non-200 response is invalid, or due to a malformed request.
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("received an unexpected status code for the request")
+	}
+
+	return resp, nil
+}
+
+// parseAPIResponse reads the response and checks the body for the expected contents, and then
+// returns the body content as apiResponseData.
+func (p *OperatorPkgNameIsUniqueMountedCheck) parseAPIResponse(resp *http.Response) (*apiResponseData, error) {
+	var data apiResponseData
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Trace("response body: ", string(body))
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// validate checks the apiResponseData and confirms that the package is unique by confirming that the
+// API returned no packages using the same name.
+func (p *OperatorPkgNameIsUniqueMountedCheck) validate(resp *apiResponseData) (bool, error) {
+	// success case - the API returned no entries
+	if len(resp.Data) == 0 {
+		return true, nil
+	}
+
+	log.Error("a package already exists in the Red Hat ecosystem using the same name")
+	// we don't expect multiple entries, but resp.Data is a list so we will iterate.
+	for _, v := range resp.Data {
+		log.Error("found the following entry: ", v)
+	}
+
+	return false, nil
+}
+
+func (p *OperatorPkgNameIsUniqueMountedCheck) Name() string {
+	return "OperatorPackageNameIsUniqueMounted"
+}
+
+func (p *OperatorPkgNameIsUniqueMountedCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Validating Bundle image package name uniqueness",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *OperatorPkgNameIsUniqueMountedCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check encountered an error. It is possible that the bundle package name already exist in the RedHat Catalog registry.",
+		Suggestion: "Bundle package name must be unique meaning that it doesn't already exist in the RedHat Catalog registry",
+	}
+}
+
+// apiClient is a simple interface encompassing the only http.Client method we utilize for preflight checks. This exists to
+// enable mock implementations for testing purposes.
+type apiClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type metadata struct {
+	Annotations map[string]string
+}

--- a/certification/internal/policy/operator/operator_pkg_name_uniqueness_test.go
+++ b/certification/internal/policy/operator/operator_pkg_name_uniqueness_test.go
@@ -1,0 +1,145 @@
+package operator
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// fakeAPIClient implements the necessary methods to test API query logic for this check, which includes
+// implementing the local apiClient interface as well as the io.ReadCloser, used for http.Response.Body.
+type fakeAPIClient struct {
+	response http.Response
+}
+
+func (c *fakeAPIClient) Do(req *http.Request) (*http.Response, error) {
+	return &c.response, nil
+}
+
+var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
+	check := OperatorPkgNameIsUniqueMountedCheck{}
+
+	Describe("While ensuring that an operator's package is unique", func() {
+		// tests: getPackageNAme
+		Context("with the annotations map", func() {
+			key := "operators.operatorframework.io.bundle.package.v1"
+			pkg := "my-custom-operator"
+
+			Context("that has the expected package key", func() {
+				goodMap := map[string]string{key: pkg}
+
+				It("should return the package name and no error", func() {
+					pkgName, err := check.getPackageName(goodMap)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pkgName).To(Equal(pkg))
+				})
+			})
+
+			Context("that does not have the expected key", func() {
+				mapWithoutKey := map[string]string{}
+
+				It("should return an error", func() {
+					_, err := check.getPackageName(mapWithoutKey)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("that is nil", func() {
+				var nilMap map[string]string
+
+				It("should return an error", func() {
+					_, err := check.getPackageName(nilMap)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+
+		// tests: buildRequest
+		Context("and building the HTTP request parameters", func() {
+			url := "https://example.com"
+			packageName := "my-custom-package"
+
+			It("should accurately reflect the input url and package name in the request data", func() {
+				request, err := check.buildRequest(url, packageName)
+				Expect(fmt.Sprintf("%s://%s", request.URL.Scheme, request.URL.Host)).To(Equal(url))
+				Expect(request.URL.RawQuery).To(ContainSubstring(packageName))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// tests: queryAPI, parseAPIResponse, validate
+		Context("and making requests to the package uniqueness API", func() {
+			fakeRequest := http.Request{
+				URL: &url.URL{},
+			}
+
+			Context("and receiving a response that no package exists with the defined name", func() {
+				fakeRequest := http.Request{
+					URL: &url.URL{},
+				}
+				successBody := `{"data":[],"page":0,"page_size":100,"total":0}`
+
+				goodClient := fakeAPIClient{
+					response: http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(successBody)),
+					},
+				}
+
+				It("should not throw an error when the api responses with a 200 ok", func() {
+					goodResp, goodErr := check.queryAPI(&goodClient, &fakeRequest)
+					Expect(goodErr).ToNot(HaveOccurred())
+
+					data, err := check.parseAPIResponse(goodResp)
+					Expect(err).ToNot(HaveOccurred())
+
+					isValid, err := check.validate(data)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(isValid).To(BeTrue())
+				})
+			})
+
+			Context("and receiving a response that no a exists with the defined name", func() {
+				failBody := `{"data":[{"_id":"someID","association":"some association","creation_date":"2021-08-02","last_update_date":"2021-08-02","package_name":"some-package","source":"some source"}],"page":0,"page_size":100,"total":1}`
+
+				failClient := fakeAPIClient{
+					response: http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(failBody)),
+					},
+				}
+
+				It("should not throw an error when the api responses with a 200 ok, but should not validate", func() {
+					failResp, failErr := check.queryAPI(&failClient, &fakeRequest)
+					Expect(failErr).ToNot(HaveOccurred())
+
+					data, err := check.parseAPIResponse(failResp)
+					Expect(err).ToNot(HaveOccurred())
+
+					isValid, err := check.validate(data)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(isValid).To(BeFalse())
+				})
+			})
+
+			Context("and receiving a non-200 response", func() {
+				errClient := fakeAPIClient{
+					response: http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       io.NopCloser(strings.NewReader("")),
+					},
+				}
+
+				It("should throw an error", func() {
+					_, err := check.queryAPI(&errClient, &fakeRequest)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -1,0 +1,19 @@
+package operator
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Suite")
+}
+
+func init() {
+	log.SetFormatter(&log.TextFormatter{})
+	log.SetLevel(log.TraceLevel)
+}


### PR DESCRIPTION
This enables the test suite under policy/operators, and moves the package
name uniqueness check to under policy/operators, and marks the shell
check as deprecated.

Fixes #181

Signed-off-by: Brad P. Crochet <brad@redhat.com>