### PR TITLE
Fix container-passes licenses copy

### DIFF
--- a/test/containerfiles/container-passes.Dockerfile
+++ b/test/containerfiles/container-passes.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN useradd preflightuser
 
-COPY --chown=preflightuser:preflightuser example-license.txt /licenses
+COPY --chown=preflightuser:preflightuser example-license.txt /licenses/
 
 LABEL name="preflight test image" \ 
       vendor="preflight test vendor" \


### PR DESCRIPTION
The COPY line in the Dockerfile was copying to a file, not a directory.
This adds a trailing '/' so that it copies to a directory.

Fixes #187 

Signed-off-by: Brad P. Crochet <brad@redhat.com>