### PR TITLE
Fix the RelateImages test

### DIFF
--- a/certification/internal/policy/operator/has_v2_related_image_schema_version_test.go
+++ b/certification/internal/policy/operator/has_v2_related_image_schema_version_test.go
@@ -64,7 +64,7 @@ var _ = Describe("RelatedImagesAreSchemaVersion2", func() {
 			csvWithoutRelatedImages := operatorsv1alpha1.ClusterServiceVersion{}
 			images, err := check.getRelatedImagesForCSV(&csvWithoutRelatedImages)
 			It("should successfully return the related images", func() {
-				Expect(images).To(BeNil())
+				Expect(images).To(BeEmpty())
 				// not having related images does not constitute an error case
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
Somewhere along the line, an assertion in the test became incorrect. This changes
the assertion from BeNil to BeEmpty.

Fixes #189

Signed-off-by: Brad P. Crochet <brad@redhat.com>