### PR TITLE
Migrate DeployableByOLM to Crane

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -140,19 +140,21 @@ var deprecatedRelatedImageManifestSchemaVersionCheck certification.Check = &shel
 var deprecatedOperatorPkgNameIsUniqueMountedCheck certification.Check = &shell.OperatorPkgNameIsUniqueMountedCheck{}
 var deprecatedOperatorPkgNameIsUniqueCheck certification.Check = &shell.OperatorPkgNameIsUniqueCheck{}
 var hasMinimalVulnerabilitiesUnshareCheck certification.Check = &shell.HasMinimalVulnerabilitiesUnshareCheck{}
-var deployableByOlmCheck certification.Check = &k8s.DeployableByOlmCheck{}
-var deployableByOlmMountedCheck certification.Check = &k8s.DeployableByOlmMountedCheck{}
+var deprecatedDeployableByOlmCheck certification.Check = &k8s.DeployableByOlmCheck{}
+var deprecatedDeployableByOlmMountedCheck certification.Check = &k8s.DeployableByOlmMountedCheck{}
 
 // new checks for CraneEngine
 var hasLicenseCheck certification.Check = &containerpol.HasLicenseCheck{}
 var relatedImageManifestSchemaVersionCheck certification.Check = &operatorpol.RelatedImagesAreSchemaVersion2Check{}
 var operatorPkgNameIsUniqueCheck certification.Check = &operatorpol.OperatorPkgNameIsUniqueMountedCheck{}
+var deployableByOlmCheck certification.Check = &operatorpol.DeployableByOlmCheck{}
 
 var operatorPolicy = map[string]certification.Check{
 	operatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
 	relatedImageManifestSchemaVersionCheck.Name(): relatedImageManifestSchemaVersionCheck,
 	scorecardBasicSpecCheck.Name():                scorecardBasicSpecCheck,
 	scorecardOlmSuiteCheck.Name():                 scorecardOlmSuiteCheck,
+	deployableByOlmCheck.Name():                   deployableByOlmCheck,
 }
 
 var containerPolicy = map[string]certification.Check{
@@ -185,7 +187,7 @@ var unshareChecks = map[string]certification.Check{
 	hasNoProhibitedMountedCheck.Name():                   hasNoProhibitedMountedCheck,
 	deprecatedOperatorPkgNameIsUniqueMountedCheck.Name(): deprecatedOperatorPkgNameIsUniqueMountedCheck,
 	hasMinimalVulnerabilitiesUnshareCheck.Name():         hasMinimalVulnerabilitiesUnshareCheck,
-	deployableByOlmMountedCheck.Name():                   deployableByOlmMountedCheck,
+	deprecatedDeployableByOlmCheck.Name():                deprecatedDeployableByOlmCheck,
 }
 
 func makeCheckList(checkMap map[string]certification.Check) []string {

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -63,7 +63,7 @@ func (c *CraneEngine) ExecuteChecks() error {
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrCreateTempDir, err)
 	}
-	log.Debug("temporary directory is", tmpdir)
+	log.Debug("temporary directory is ", tmpdir)
 	defer func() {
 		if err := os.RemoveAll(tmpdir); err != nil {
 			log.Error("unable to clean up tmpdir", tmpdir, err)
@@ -91,7 +91,7 @@ func (c *CraneEngine) ExecuteChecks() error {
 		}
 	}()
 
-	log.Debug("extracting container filesystem to", containerFSPath)
+	log.Debug("extracting container filesystem to ", containerFSPath)
 	err = fileutils.Untar(containerFSPath, r)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)

--- a/certification/internal/engine/openshift.go
+++ b/certification/internal/engine/openshift.go
@@ -1,0 +1,313 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	client "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/client"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+)
+
+type OpenshiftEngine struct {
+	KubeConfig *rest.Config
+}
+
+func (pe OpenshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+
+	k8sClientset, err := kubernetes.NewForConfig(pe.KubeConfig)
+
+	if err != nil {
+		log.Error("unable to obtain k8s client: ", err)
+		return nil, err
+	}
+
+	nsSpec := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: opts.Labels,
+		},
+	}
+
+	resp, err := k8sClientset.CoreV1().
+		Namespaces().
+		Create(context.Background(), nsSpec, metav1.CreateOptions{})
+
+	if err != nil {
+		log.Error(fmt.Sprintf("error while creating Namespace %s:", name), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+
+	log.Debug("Namespace created: ", name)
+	log.Trace("Received Namespace object from API server: ", resp)
+
+	return &cli.OpenshiftReport{
+		Stdout: nsSpec.String(),
+		Stderr: "",
+	}, nil
+}
+
+func (pe OpenshiftEngine) DeleteNamespace(name string, opts cli.OpenshiftOptions) error {
+	k8sClientset, err := kubernetes.NewForConfig(pe.KubeConfig)
+
+	if err != nil {
+		log.Error("unable to obtain k8s client: ", err)
+		return err
+	}
+	log.Debug("Deleting namespace: " + name)
+	return k8sClientset.CoreV1().
+		Namespaces().
+		Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+func (pe OpenshiftEngine) GetNamespace(name string) (*corev1.Namespace, error) {
+	k8sClientset, err := kubernetes.NewForConfig(pe.KubeConfig)
+
+	if err != nil {
+		log.Error("unable to obtain k8s client: ", err)
+		return nil, err
+	}
+	log.Debug("fetching namespace: " + name)
+	return k8sClientset.CoreV1().
+		Namespaces().
+		Get(context.Background(), name, metav1.GetOptions{})
+}
+
+func (pe OpenshiftEngine) CreateOperatorGroup(data cli.OperatorGroupData, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+
+	crdClient, err := client.OperatorGroupClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for OperatorGroup: ", err)
+		return nil, err
+	}
+
+	log.Debug(fmt.Sprintf("Creating OperatorGroup %s in namespace %s", data.Name, opts.Namespace))
+	resp, err := crdClient.Create(data, opts)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("error while creating OperatorGroup: %s", data.Name), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("OperatorGroup %s is created successfully in namespace %s", data.Name, opts.Namespace))
+
+	return &cli.OpenshiftReport{
+		Stdout: fmt.Sprintf("%#v", resp),
+		Stderr: "",
+	}, nil
+}
+
+func (pe OpenshiftEngine) DeleteOperatorGroup(name string, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+	crdClient, err := client.OperatorGroupClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for OperatorGroup: ", err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("Deleting OperatorGroup %s in namespace %s", name, opts.Namespace))
+
+	err = crdClient.Delete(name, opts)
+	if err != nil {
+		log.Error(fmt.Sprintf("error while deleting OperatorGroup %s in namespace %s: ", name, opts.Namespace), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("OperatorGroup %s is deleted successfully from namespace %s", name, opts.Namespace))
+
+	cs, err := pe.GetOperatorGroup(name, opts)
+	if err != nil {
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+
+	return &cli.OpenshiftReport{
+		Stdout: fmt.Sprintf("%#v", cs),
+		Stderr: "",
+	}, nil
+
+}
+
+func (pe OpenshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftOptions) (*operatorv1.OperatorGroup, error) {
+	crdClient, err := client.OperatorGroupClient(pe.KubeConfig, opts.Namespace)
+
+	if err != nil {
+		log.Error("unable to obtain k8s client: ", err)
+		return nil, err
+	}
+	log.Debug(fmt.Sprintf("fetching operatorgroup %s from namespace %s ", name, opts.Namespace))
+	return crdClient.Get(name, opts.Namespace)
+}
+
+func (pe OpenshiftEngine) CreateCatalogSource(data cli.CatalogSourceData, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+
+	crdClient, err := client.CatalogSourceClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for CatalogSource: ", err)
+		return nil, err
+	}
+
+	log.Debug(fmt.Sprintf("Creating CatalogSource %s in namespace %s", data.Name, opts.Namespace))
+	resp, err := crdClient.Create(data, opts)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("error while creating CatalogSource %s: ", data.Name), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("CatalogSource %s is created successfully in namespace %s", data.Name, opts.Namespace))
+
+	return &cli.OpenshiftReport{
+		Stdout: fmt.Sprintf("%#v", resp),
+		Stderr: "",
+	}, nil
+}
+
+func (pe OpenshiftEngine) DeleteCatalogSource(name string, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+	crdClient, err := client.CatalogSourceClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for CatalogSource: ", err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("Deleting CatalogSource %s in namespace %s", name, opts.Namespace))
+
+	err = crdClient.Delete(name, opts)
+	if err != nil {
+		log.Error(fmt.Sprintf("error while deleting CatalogSource %s in namespace %s: ", name, opts.Namespace), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("CatalogSource %s is deleted successfully from namespace %s", name, opts.Namespace))
+
+	cs, err := pe.GetCatalogSource(name, opts)
+	if err != nil {
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+
+	return &cli.OpenshiftReport{
+		Stdout: fmt.Sprintf("%#v", cs),
+		Stderr: "",
+	}, nil
+}
+
+func (pe OpenshiftEngine) GetCatalogSource(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
+
+	crdClient, err := client.CatalogSourceClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for CatalogSource: ", err)
+		return nil, err
+	}
+	log.Debug("fetching catalogsource: " + name)
+	return crdClient.Get(name, opts.Namespace)
+}
+
+func (pe OpenshiftEngine) CreateSubscription(data cli.SubscriptionData, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+
+	crdClient, err := client.SubscriptionClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for Subscription: ", err)
+		return nil, err
+	}
+
+	log.Debug(fmt.Sprintf("Creating Subscription %s in namespace %s", data.Name, opts.Namespace))
+	resp, err := crdClient.Create(data, opts)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("error while creating Subscription %s: ", data.Name), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("Subscription %s is created successfully in namespace %s", data.Name, opts.Namespace))
+
+	return &cli.OpenshiftReport{
+		Stdout: fmt.Sprintf("%#v", resp),
+		Stderr: "",
+	}, nil
+}
+
+func (pe OpenshiftEngine) GetSubscription(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.Subscription, error) {
+	crdClient, err := client.SubscriptionClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for Subscription: ", err)
+		return nil, err
+	}
+	log.Debug(fmt.Sprintf("fetching subscription %s from namespace %s ", name, opts.Namespace))
+	return crdClient.Get(name, opts.Namespace)
+}
+
+func (pe OpenshiftEngine) DeleteSubscription(name string, opts cli.OpenshiftOptions) (*cli.OpenshiftReport, error) {
+
+	crdClient, err := client.SubscriptionClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for Subscription: ", err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("Deleting Subscription %s in namespace %s", name, opts.Namespace))
+
+	err = crdClient.Delete(name, opts)
+	if err != nil {
+		log.Error(fmt.Sprintf("error while deleting Subscription %s in namespace %s: ", name, opts.Namespace), err)
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+	log.Debug(fmt.Sprintf("Subscription %s is deleted successfully from namespace %s", name, opts.Namespace))
+
+	cs, err := pe.GetSubscription(name, opts)
+	if err != nil {
+		return &cli.OpenshiftReport{
+			Stdout: "",
+			Stderr: err.Error(),
+		}, err
+	}
+
+	return &cli.OpenshiftReport{
+		Stdout: fmt.Sprintf("%#v", cs),
+		Stderr: "",
+	}, nil
+}
+
+func (pe OpenshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.ClusterServiceVersion, error) {
+
+	crdClient, err := client.CsvClient(pe.KubeConfig, opts.Namespace)
+	if err != nil {
+		log.Error("unable to create a client for csv: ", err)
+		return nil, err
+	}
+	log.Debug(fmt.Sprintf("fetching csv %s from namespace %s ", name, opts.Namespace))
+	return crdClient.Get(name, opts.Namespace)
+}

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -1,0 +1,18 @@
+package operator
+
+const (
+	// catalogSourceNS is the namespace in which the CatalogSource CR is installed
+	catalogSourceNS = "openshift-marketplace"
+
+	// packageKey is the packageKey in annotations.yaml that contains the package name.
+	packageKey = "operators.operatorframework.io.bundle.package.v1"
+
+	// channelKey is the channel in annotations.yaml that contains the channel name.
+	channelKey = "operators.operatorframework.io.bundle.channel.default.v1"
+
+	// IndexImageKey is the key in viper that contains the index (catalog) image URI
+	indexImageKey = "indexImage"
+
+	// apiEndpoint is the endpoint used to query for package uniqueness.
+	apiEndpoint = "https://catalog.redhat.com/api/containers/v1/operators/packages"
+)

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -1,0 +1,273 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	openshiftengine "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/engine"
+	containerutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/container"
+	viperutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/viper"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	log "github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+	kubeErr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type OperatorData struct {
+	CatalogImage     string
+	Channel          string
+	PackageName      string
+	App              string
+	InstallNamespace string
+}
+
+type DeployableByOlmCheck struct{}
+
+func (p *DeployableByOlmCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+
+	// create a new instance of openshift engine
+	openshiftEngine, err := p.newOpenshiftEngine()
+	if err != nil {
+		return false, err
+	}
+
+	// retrieve the required data
+	operatorData, err := p.operatorMetadata(bundleRef)
+	if err != nil {
+		return false, err
+	}
+
+	// create k8s custom resources for the operator deployment
+	err = p.setUp(*operatorData, *openshiftEngine)
+	defer p.cleanUp(*operatorData, *openshiftEngine)
+
+	if err != nil {
+		return false, err
+	}
+
+	installedCSV, err := p.installedCSV(*operatorData, *openshiftEngine)
+	if err != nil {
+		return false, err
+	}
+
+	return p.isCSVReady(installedCSV, *operatorData, *openshiftEngine)
+}
+
+func (p *DeployableByOlmCheck) newOpenshiftEngine() (*openshiftengine.OpenshiftEngine, error) {
+	k8sconfig, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		log.Error("unable to create a kubernetes client: ", err)
+		return nil, err
+	}
+
+	return &openshiftengine.OpenshiftEngine{
+		KubeConfig: k8sconfig,
+	}, nil
+}
+
+func (p *DeployableByOlmCheck) operatorMetadata(bundleRef certification.ImageReference) (*OperatorData, error) {
+	// retrieve the operator metadata from bundle image
+	annotations, err := containerutil.GetAnnotationsFromBundle(bundleRef.ImageFSPath)
+
+	if err != nil {
+		log.Errorf("unable to get annotations.yaml from the bundle")
+		return nil, err
+	}
+
+	catalogImage, err := viperutil.GetString(indexImageKey)
+	if err != nil {
+		log.Error(fmt.Sprintf("To set the key, export PFLT_%s or add %s:<value> to config.yaml in the current working directory", strings.ToUpper(indexImageKey), indexImageKey))
+		return nil, err
+	}
+
+	channel, err := containerutil.Annotation(annotations, channelKey)
+	if err != nil {
+		log.Error("unable to extract channel name from ClusterServicVersion", err)
+		return nil, err
+	}
+
+	packageName, err := containerutil.Annotation(annotations, packageKey)
+	if err != nil {
+		log.Error("unable to extract package name from ClusterServicVersion", err)
+		return nil, err
+	}
+
+	return &OperatorData{
+		CatalogImage:     catalogImage,
+		Channel:          channel,
+		PackageName:      packageName,
+		App:              packageName,
+		InstallNamespace: packageName,
+	}, nil
+}
+
+func (p *DeployableByOlmCheck) setUp(operatorData OperatorData, openshiftengine openshiftengine.OpenshiftEngine) error {
+
+	if _, err := openshiftengine.CreateNamespace(operatorData.InstallNamespace, cli.OpenshiftOptions{}); err != nil && !kubeErr.IsAlreadyExists(err) {
+		return err
+	}
+
+	if _, err := openshiftengine.CreateCatalogSource(cli.CatalogSourceData{Name: operatorData.App, Image: operatorData.CatalogImage}, cli.OpenshiftOptions{Namespace: catalogSourceNS}); err != nil && !kubeErr.IsAlreadyExists(err) {
+		return err
+	}
+
+	targetNamespaces := []string{operatorData.InstallNamespace}
+	if _, err := openshiftengine.CreateOperatorGroup(cli.OperatorGroupData{Name: operatorData.App, TargetNamespaces: targetNamespaces}, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace}); err != nil && !kubeErr.IsAlreadyExists(err) {
+		return err
+	}
+
+	subscriptionData := cli.SubscriptionData{
+		Name:                   operatorData.App,
+		Channel:                operatorData.Channel,
+		CatalogSource:          operatorData.App,
+		CatalogSourceNamespace: catalogSourceNS,
+		Package:                operatorData.PackageName,
+	}
+	if _, err := openshiftengine.CreateSubscription(subscriptionData, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace}); err != nil && !kubeErr.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func (p *DeployableByOlmCheck) isCSVReady(installedCSV string, operatorData OperatorData, openshiftengine openshiftengine.OpenshiftEngine) (bool, error) {
+
+	log.Trace(fmt.Sprintf("Looking for csv %s in namespace %s", installedCSV, operatorData.InstallNamespace))
+
+	// query API server for CSV by name
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	csvReadyDone := make(chan string, 1)
+
+	go func() {
+		defer close(csvReadyDone)
+		for {
+			log.Debug("Waiting for ClusterServiceVersion to become ready...")
+			csv, _ := openshiftengine.GetCSV(installedCSV, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace})
+			// if the CSV phase is succeeded, stop the querying
+			if csv.Status.Phase == operatorv1alpha1.CSVPhaseSucceeded {
+				log.Debug("CSV is created successfully: ", installedCSV)
+				csvReadyDone <- fmt.Sprintf("%#v", csv)
+			}
+			log.Debug("CSV is not ready yet, retrying...")
+			time.Sleep(2 * time.Second)
+		}
+	}()
+
+	select {
+	case csv := <-csvReadyDone:
+		return len(csv) > 0, nil
+	case <-ctx.Done():
+		log.Error(fmt.Sprintf("failed to fetch the csv %s: ", installedCSV), ctx.Err())
+		return false, nil
+	}
+}
+
+func (p *DeployableByOlmCheck) installedCSV(operatorData OperatorData, openshiftengine openshiftengine.OpenshiftEngine) (string, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	installedCSVDone := make(chan string, 1)
+
+	// query API server for the installed CSV field of the created subscription
+	go func() {
+		defer close(installedCSVDone)
+		for {
+			time.Sleep(2 * time.Second)
+			log.Debug("Waiting for Subscription.status.installedCSV to become ready...")
+			subs, _ := openshiftengine.GetSubscription(operatorData.App, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace})
+			installedCSV := subs.Status.InstalledCSV
+			// if the installedCSV field is present, stop the querying
+			if len(installedCSV) > 0 {
+				log.Debug(fmt.Sprintf("Subscription.status.installedCSV is %s", installedCSV))
+				installedCSVDone <- installedCSV
+			}
+			log.Debug("Subscription.status.installedCSV is not set yet, retrying...")
+		}
+	}()
+
+	select {
+	case installedCSV := <-installedCSVDone:
+		return installedCSV, nil
+	case <-ctx.Done():
+		log.Error("failed to fetch Subscription.status.installedCSV: ", ctx.Err())
+		return "", errors.ErrK8sAPICallFailed
+	}
+}
+
+func (p *DeployableByOlmCheck) cleanUp(operatorData OperatorData, openshiftengine openshiftengine.OpenshiftEngine) {
+
+	log.Debug("Dumping data in artifacts/ directory")
+
+	subs, err := openshiftengine.GetSubscription(operatorData.App, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace})
+	if err != nil {
+		log.Error("unable to retrieve the subscription")
+	}
+	p.writeToFile(subs, operatorData.App, "subscription")
+
+	cs, err := openshiftengine.GetCatalogSource(operatorData.App, cli.OpenshiftOptions{Namespace: catalogSourceNS})
+	if err != nil {
+		log.Error("unable to retrieve the catalogsource")
+	}
+	p.writeToFile(cs, operatorData.App, "catalogsource")
+
+	og, err := openshiftengine.GetOperatorGroup(operatorData.App, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace})
+	if err != nil {
+		log.Error("unable to retrieve the operatorgroup")
+	}
+	p.writeToFile(og, operatorData.App, "operatorgroup")
+
+	ns, err := openshiftengine.GetNamespace(operatorData.InstallNamespace)
+	if err != nil {
+		log.Error("unable to retrieve the namespace")
+	}
+	p.writeToFile(ns, operatorData.InstallNamespace, "namespace")
+
+	log.Trace("Deleting the resources created by Check")
+	openshiftengine.DeleteSubscription(operatorData.App, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace})
+	openshiftengine.DeleteCatalogSource(operatorData.App, cli.OpenshiftOptions{Namespace: catalogSourceNS})
+	openshiftengine.DeleteOperatorGroup(operatorData.App, cli.OpenshiftOptions{Namespace: operatorData.InstallNamespace})
+	openshiftengine.DeleteNamespace(operatorData.InstallNamespace, cli.OpenshiftOptions{})
+}
+
+func (p *DeployableByOlmCheck) writeToFile(data interface{}, resource string, resourceType string) {
+	yamlData, err := yaml.Marshal(data)
+	if err != nil {
+		log.Error("unable to serialize the data")
+	}
+
+	if err = ioutil.WriteFile(filepath.Join("artifacts", fmt.Sprintf("%s-%s.yaml", resource, resourceType)), yamlData, 0644); err != nil {
+		log.Error("failed to write the k8s object to the file")
+	}
+}
+
+func (p *DeployableByOlmCheck) Name() string {
+	return "DeployableByOLM"
+}
+
+func (p *DeployableByOlmCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checking if the operator could be deployed by OLM",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide", // Placeholder
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *DeployableByOlmCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "It is required that your operator could be deployed by OLM",
+		Suggestion: "Follow the guidelines on the operatorsdk website to learn how to package your operator https://sdk.operatorframework.io/docs/olm-integration/cli-overview/",
+	}
+}

--- a/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
+++ b/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
@@ -11,14 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	// apiEndpoint is the endpoint used to query for package uniqueness.
-	apiEndpoint = "https://catalog.redhat.com/api/containers/v1/operators/packages"
-
-	// packageKey is the packageKey in annotations.yaml that contains the package name.
-	packageKey = "operators.operatorframework.io.bundle.package.v1"
-)
-
 // apiRespondData is the response received from the defined API
 type apiResponseData struct {
 	Data     []packageData `json:"data"`

--- a/certification/internal/utils/container/helper.go
+++ b/certification/internal/utils/container/helper.go
@@ -170,6 +170,19 @@ func extractAnnotationsBytes(annotationBytes []byte) (map[string]string, error) 
 	return bundleMeta.Annotations, nil
 }
 
+// Annotation() accepts the annotations map and searches for the specified annotation corresponding
+// with the key, which is then returned.
+func Annotation(annotations map[string]string, key string) (string, error) {
+	log.Tracef("searching for key (%s) in bundle", key)
+	log.Trace("bundle data: ", annotations)
+	value, found := annotations[key]
+	if !found {
+		return "", fmt.Errorf("did not find value at the key %s in the annotations.yaml", key)
+	}
+
+	return value, nil
+}
+
 type metadata struct {
 	Annotations map[string]string
 }


### PR DESCRIPTION
This PR migrates the DeployableByOLM to Crane. Also refactoring has been done to improve the code readability.

* Previously, the operator data were defined as globals vars. This PR introduces a new type, `OperatorData`, that stores the data that the check needs for the successful deployment of an operator. `OperatorData` is the arg that will be passed to the downstream methods that need these info.
* A new method has been created to fetch operator data from viper and bundle image and return a reference to`OperatorData`. 
* The new OpenshiftEngine has a `*rest.Config` as a field. The check does not pass the `*rest.Config` as a method arg, any longer. 
* All bundle-related constants are moved to default.go

Fixes #184 