### PR TITLE
Move the scorecard checks to use the crane engine

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -132,8 +132,8 @@ var deprecatedHasLicenseCheck certification.Check = &shell.HasLicenseCheck{}
 var hasUniqueTagCheck certification.Check = &shell.HasUniqueTagCheck{}
 var hasNoProhibitedCheck certification.Check = &shell.HasNoProhibitedPackagesCheck{}
 var deprecatedValidateOperatorBundle certification.Check = &shell.ValidateOperatorBundleCheck{}
-var scorecardBasicSpecCheck certification.Check = &shell.ScorecardBasicSpecCheck{}
-var scorecardOlmSuiteCheck certification.Check = &shell.ScorecardOlmSuiteCheck{}
+var deprecatedScorecardBasicSpecCheck certification.Check = &shell.ScorecardBasicSpecCheck{}
+var deprecatedScorecardOlmSuiteCheck certification.Check = &shell.ScorecardOlmSuiteCheck{}
 var hasNoProhibitedMountedCheck certification.Check = &shell.HasNoProhibitedPackagesMountedCheck{}
 var deprecatedRelatedImageManifestSchemaVersionCheck certification.Check = &shell.RelatedImagesAreSchemaVersion2Check{}
 var deprecatedOperatorPkgNameIsUniqueMountedCheck certification.Check = &shell.OperatorPkgNameIsUniqueMountedCheck{}
@@ -150,7 +150,9 @@ var hasLicenseCheck certification.Check = &containerpol.HasLicenseCheck{}
 var relatedImageManifestSchemaVersionCheck certification.Check = &operatorpol.RelatedImagesAreSchemaVersion2Check{}
 var deployableByOlmCheck certification.Check = &operatorpol.DeployableByOlmCheck{}
 var operatorPkgNameIsUniqueCheck certification.Check = &operatorpol.OperatorPkgNameIsUniqueCheck{}
-var validateOperatorBundle certification.Check = operatorpol.NewValidateOperatorBundleCheck(NewOperatorSdkEngine())
+var validateOperatorBundle certification.Check = operatorpol.NewValidateOperatorBundleCheck(internal.NewOperatorSdkEngine())
+var scorecardBasicSpecCheck certification.Check = operatorpol.NewScorecardBasicSpecCheck(internal.NewOperatorSdkEngine())
+var scorecardOlmSuiteCheck certification.Check = operatorpol.NewScorecardOlmSuiteCheck(internal.NewOperatorSdkEngine())
 
 var operatorPolicy = map[string]certification.Check{
 	operatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
@@ -179,10 +181,9 @@ var oldContainerPolicy = map[string]certification.Check{
 
 var oldOperatorPolicy = map[string]certification.Check{
 	deprecatedValidateOperatorBundle.Name():                 deprecatedValidateOperatorBundle,
-	scorecardBasicSpecCheck.Name():                          scorecardBasicSpecCheck,
-	scorecardOlmSuiteCheck.Name():                           scorecardOlmSuiteCheck,
+	deprecatedScorecardBasicSpecCheck.Name():                deprecatedScorecardBasicSpecCheck,
+	deprecatedScorecardOlmSuiteCheck.Name():                 deprecatedScorecardOlmSuiteCheck,
 	deprecatedRelatedImageManifestSchemaVersionCheck.Name(): deprecatedRelatedImageManifestSchemaVersionCheck,
-	validateOperatorBundle.Name():                           validateOperatorBundle,
 	deprecatedOperatorPkgNameIsUniqueCheck.Name():           operatorPkgNameIsUniqueCheck,
 	deployableByOlmCheck.Name():                             deployableByOlmCheck,
 }

--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -49,6 +49,9 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 		return nil, err
 	}
 	cmdArgs = append(cmdArgs, "--config", configFile)
+	if opts.Verbose {
+		cmdArgs = append(cmdArgs, "--verbose")
+	}
 
 	cmdArgs = append(cmdArgs, image)
 
@@ -67,7 +70,8 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 		// We also conclude/assume that anything being in stderr would indicate an error in the
 		// check execution itself.
 		if stderr.Len() != 0 {
-			log.Error("stderr: ", stdout.String())
+			log.Error("stdout: ", stdout.String())
+			log.Error("stderr: ", stderr.String())
 			return nil, fmt.Errorf("%w: %s", errors.ErrOperatorSdkScorecardFailed, err)
 		}
 	}
@@ -139,26 +143,26 @@ func (o operatorSdkEngine) writeScorecardFile(resultFile, stdout string) error {
 
 func createScorecardConfigFile() (string, error) {
 	configTemplate := `kind: Configuration
-	apiversion: scorecard.operatorframework.io/v1alpha3
-	metadata:
-	  name: config
-	stages:
-	  - parallel: true
-		tests:
-		  - image: quay.io/operator-framework/scorecard-test:v1.9.0
-			entrypoint:
-			  - scorecard-test
-			  - basic-check-spec
-			labels:
-			  suite: basic
-			  test: basic-check-spec-test
-		  - image: quay.io/operator-framework/scorecard-test:v1.9.0
-			entrypoint:
-			  - scorecard-test
-			  - olm-bundle-validation
-			labels:
-			  suite: olm
-			  test: olm-bundle-validation-test
+apiversion: scorecard.operatorframework.io/v1alpha3
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - image: quay.io/operator-framework/scorecard-test:v1.9.0
+    entrypoint:
+      - scorecard-test
+      - basic-check-spec
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - image: quay.io/operator-framework/scorecard-test:v1.9.0
+    entrypoint:
+      - scorecard-test
+      - olm-bundle-validation
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
 `
 
 	tempConfigFile, err := os.CreateTemp("", "scorecard-test-config-*.yaml")

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -1,10 +1,12 @@
 package operator
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -16,4 +18,38 @@ func TestOperator(t *testing.T) {
 func init() {
 	log.SetFormatter(&log.TextFormatter{})
 	log.SetLevel(log.TraceLevel)
+}
+
+type FakeOperatorSdkEngine struct {
+	OperatorSdkReport   cli.OperatorSdkScorecardReport
+	OperatorSdkBVReport cli.OperatorSdkBundleValidateReport
+}
+
+func (f FakeOperatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
+	return &f.OperatorSdkBVReport, nil
+}
+
+func (f FakeOperatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
+	return &f.OperatorSdkReport, nil
+}
+
+type BadOperatorSdkEngine struct{}
+
+func (bose BadOperatorSdkEngine) Scorecard(bundleImage string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
+	operatorSdkReport := cli.OperatorSdkScorecardReport{
+		Stdout: "Bad Stdout",
+		Stderr: "Bad Stderr",
+		Items:  []cli.OperatorSdkScorecardItem{},
+	}
+	return &operatorSdkReport, errors.New("the Operator Sdk Scorecard has failed")
+}
+
+func (bose BadOperatorSdkEngine) BundleValidate(bundleImage string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
+	operatorSdkReport := cli.OperatorSdkBundleValidateReport{
+		Stdout:  "Bad Stdout",
+		Stderr:  "Bad Stderr",
+		Passed:  false,
+		Outputs: []cli.OperatorSdkBundleValidateOutput{},
+	}
+	return &operatorSdkReport, errors.New("the Operator Sdk Bundle Validate has failed")
 }

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -1,0 +1,53 @@
+package operator
+
+import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	log "github.com/sirupsen/logrus"
+)
+
+// ScorecardBasicSpecCheck evaluates the image to ensure it passes the operator-sdk
+// scorecard check with the basic-check-spec-test suite selected.
+type ScorecardBasicSpecCheck struct {
+	scorecardCheck
+}
+
+const scorecardBasicCheckResult string = "operator_bundle_scorecard_BasicSpecCheck.json"
+
+func NewScorecardBasicSpecCheck(operatorSdkEngine *cli.OperatorSdkEngine) *ScorecardBasicSpecCheck {
+	return &ScorecardBasicSpecCheck{
+		scorecardCheck{OperatorSdkEngine: *operatorSdkEngine},
+	}
+}
+
+func (p *ScorecardBasicSpecCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	log.Debug("Running operator-sdk scorecard check for ", bundleRef.ImageURI)
+	selector := []string{"test=basic-check-spec-test"}
+	log.Debugf("--selector=%s", selector)
+	scorecardReport, err := p.getDataToValidate(bundleRef.ImageFSPath, selector, scorecardBasicCheckResult)
+	if err != nil {
+		return false, err
+	}
+
+	return p.validate(scorecardReport.Items)
+}
+
+func (p *ScorecardBasicSpecCheck) Name() string {
+	return "ScorecardBasicSpecCheck"
+}
+
+func (p *ScorecardBasicSpecCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Check to make sure that all CRs have a spec block.",
+		Level:            "best",
+		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#overview", // Placeholder
+		CheckURL:         "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#basic-test-suite",
+	}
+}
+
+func (p *ScorecardBasicSpecCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check ScorecardBasicSpecCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_BasicSpecCheck.json file for more information.",
+		Suggestion: "Make sure that all CRs have a spec block",
+	}
+}

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -1,0 +1,107 @@
+package operator
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+)
+
+var _ = Describe("ScorecardBasicCheck", func() {
+	var (
+		scorecardBasicCheck ScorecardBasicSpecCheck
+		fakeEngine          cli.OperatorSdkEngine
+	)
+
+	BeforeEach(func() {
+		stdout := `{
+			"apiVersion": "scorecard.operatorframework.io/v1alpha3",
+			"kind": "TestList",
+			"items": [
+			  {
+				"kind": "Test",
+				"apiVersion": "scorecard.operatorframework.io/v1alpha3",
+				"spec": {
+				  "image": "quay.io/operator-framework/scorecard-test:latest",
+				  "entrypoint": [
+					"scorecard-test",
+					"olm-bundle-validation"
+				  ],
+				  "labels": {
+					"suite": "olm",
+					"test": "olm-bundle-validation-test"
+				  }
+				},
+				"status": {
+				  "results": [
+					{
+					  "name": "olm-bundle-validation",
+					  "log": "time=\"2020-06-10T19:02:49Z\" level=debug msg=\"Found manifests directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=debug msg=\"Found metadata directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=debug msg=\"Getting mediaType info from manifests directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=info msg=\"Found annotations file\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=info msg=\"Could not find optional dependencies file\" name=bundle-test\n",
+					  "state": "pass"
+					}
+				  ]
+				}
+			  }
+			]
+		  }
+		  `
+		stderr := ""
+		items := []cli.OperatorSdkScorecardItem{
+			{
+				Status: cli.OperatorSdkScorecardStatus{
+					Results: []cli.OperatorSdkScorecardResult{
+						{
+							Name:  "olm-bundle-validation",
+							Log:   "log",
+							State: "pass",
+						},
+					},
+				},
+			},
+		}
+		report := cli.OperatorSdkScorecardReport{
+			Stdout: stdout,
+			Stderr: stderr,
+			Items:  items,
+		}
+		fakeEngine = FakeOperatorSdkEngine{
+			OperatorSdkReport: report,
+		}
+		scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
+	})
+	Describe("Operator Bundle Scorecard", func() {
+		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {
+			It("Should pass Validate", func() {
+				ok, err := scorecardBasicCheck.Validate(migration.ImageToImageReference("dummy/image"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When Operator Bundle Scorecard Basic Check has a fail", func() {
+			BeforeEach(func() {
+				engine := fakeEngine.(FakeOperatorSdkEngine)
+				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
+				fakeEngine = engine
+				scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
+			})
+			It("Should not pass Validate", func() {
+				ok, err := scorecardBasicCheck.Validate(migration.ImageToImageReference("dummy/image"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+	Describe("Checking that OperatorSdkEngine errors are handled correctly", func() {
+		BeforeEach(func() {
+			fakeEngine = BadOperatorSdkEngine{}
+			scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
+		})
+		Context("When OperatorSdk throws an error", func() {
+			It("should fail Validate and return an error", func() {
+				ok, err := scorecardBasicCheck.Validate(migration.ImageToImageReference("dummy/image"))
+				Expect(err).To(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})

--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -1,4 +1,4 @@
-package shell
+package operator
 
 import (
 	"os"
@@ -9,7 +9,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-type scorecardCheck struct{}
+type scorecardCheck struct {
+	OperatorSdkEngine cli.OperatorSdkEngine
+}
 
 func (p *scorecardCheck) validate(items []cli.OperatorSdkScorecardItem) (bool, error) {
 	foundTestFailed := false
@@ -40,5 +42,5 @@ func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string
 		Namespace:      namespace,
 		ServiceAccount: serviceAccount,
 	}
-	return operatorSdkEngine.Scorecard(bundleImage, opts)
+	return p.OperatorSdkEngine.Scorecard(bundleImage, opts)
 }

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -1,0 +1,53 @@
+package operator
+
+import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	log "github.com/sirupsen/logrus"
+)
+
+// ScorecardOlmSuiteCheck evaluates the image to ensure it passes the operator-sdk
+// scorecard check with the olm suite selected.
+type ScorecardOlmSuiteCheck struct {
+	scorecardCheck
+}
+
+const scorecardOlmSuiteResult string = "operator_bundle_scorecard_OlmSuiteCheck.json"
+
+func NewScorecardOlmSuiteCheck(operatorSdkEngine *cli.OperatorSdkEngine) *ScorecardOlmSuiteCheck {
+	return &ScorecardOlmSuiteCheck{
+		scorecardCheck{OperatorSdkEngine: *operatorSdkEngine},
+	}
+}
+
+func (p *ScorecardOlmSuiteCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+	log.Debug("Running operator-sdk scorecard Check for ", bundleRef.ImageURI)
+	selector := []string{"suite=olm"}
+	log.Debugf("--selector=%s", selector)
+	scorecardReport, err := p.getDataToValidate(bundleRef.ImageFSPath, selector, scorecardOlmSuiteResult)
+	if err != nil {
+		return false, err
+	}
+
+	return p.validate(scorecardReport.Items)
+}
+
+func (p *ScorecardOlmSuiteCheck) Name() string {
+	return "ScorecardOlmSuiteCheck"
+}
+
+func (p *ScorecardOlmSuiteCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Operator-sdk scorecard OLM Test Suite Check",
+		Level:            "best",
+		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#overview", // Placeholder
+		CheckURL:         "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#olm-test-suite",
+	}
+}
+
+func (p *ScorecardOlmSuiteCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check ScorecardOlmSuiteCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_OlmSuiteCheck.json file for more information.",
+		Suggestion: "See scorecard output for details, artifacts/operator_bundle_scorecard_OlmSuiteCheck.json",
+	}
+}

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -1,0 +1,107 @@
+package operator
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+)
+
+var _ = Describe("ScorecardBasicCheck", func() {
+	var (
+		scorecardOlmSuiteCheck ScorecardOlmSuiteCheck
+		fakeEngine             cli.OperatorSdkEngine
+	)
+
+	BeforeEach(func() {
+		stdout := `{
+			"apiVersion": "scorecard.operatorframework.io/v1alpha3",
+			"kind": "TestList",
+			"items": [
+			  {
+				"kind": "Test",
+				"apiVersion": "scorecard.operatorframework.io/v1alpha3",
+				"spec": {
+				  "image": "quay.io/operator-framework/scorecard-test:latest",
+				  "entrypoint": [
+					"scorecard-test",
+					"olm-bundle-validation"
+				  ],
+				  "labels": {
+					"suite": "olm",
+					"test": "olm-bundle-validation-test"
+				  }
+				},
+				"status": {
+				  "results": [
+					{
+					  "name": "olm-bundle-validation",
+					  "log": "time=\"2020-06-10T19:02:49Z\" level=debug msg=\"Found manifests directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=debug msg=\"Found metadata directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=debug msg=\"Getting mediaType info from manifests directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=info msg=\"Found annotations file\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=info msg=\"Could not find optional dependencies file\" name=bundle-test\n",
+					  "state": "pass"
+					}
+				  ]
+				}
+			  }
+			]
+		  }
+		  `
+		stderr := ""
+		items := []cli.OperatorSdkScorecardItem{
+			{
+				Status: cli.OperatorSdkScorecardStatus{
+					Results: []cli.OperatorSdkScorecardResult{
+						{
+							Name:  "olm-bundle-validation",
+							Log:   "log",
+							State: "pass",
+						},
+					},
+				},
+			},
+		}
+		report := cli.OperatorSdkScorecardReport{
+			Stdout: stdout,
+			Stderr: stderr,
+			Items:  items,
+		}
+		fakeEngine = FakeOperatorSdkEngine{
+			OperatorSdkReport: report,
+		}
+		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
+	})
+	Describe("Operator Bundle Scorecard", func() {
+		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {
+			It("Should pass Validate", func() {
+				ok, err := scorecardOlmSuiteCheck.Validate(migration.ImageToImageReference("dummy/image"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When Operator Bundle Scorecard OLM Suite Check has a fail", func() {
+			BeforeEach(func() {
+				engine := fakeEngine.(FakeOperatorSdkEngine)
+				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
+				fakeEngine = engine
+				scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
+			})
+			It("Should not pass Validate", func() {
+				ok, err := scorecardOlmSuiteCheck.Validate(migration.ImageToImageReference("dummy/image"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+	Describe("Checking that OperatorSdkEngine errors are handled correctly", func() {
+		BeforeEach(func() {
+			fakeEngine = BadOperatorSdkEngine{}
+			scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
+		})
+		Context("When OperatorSdk throws an error", func() {
+			It("should fail Validate and return an error", func() {
+				ok, err := scorecardOlmSuiteCheck.Validate(migration.ImageToImageReference("dummy/image"))
+				Expect(err).To(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})

--- a/certification/internal/policy/operator/validate_operator_bundle_test.go
+++ b/certification/internal/policy/operator/validate_operator_bundle_test.go
@@ -1,47 +1,11 @@
 package operator
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/migration"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 )
-
-type FakeOperatorSdkEngine struct {
-	OperatorSdkReport   cli.OperatorSdkScorecardReport
-	OperatorSdkBVReport cli.OperatorSdkBundleValidateReport
-}
-
-func (f FakeOperatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
-	return &f.OperatorSdkBVReport, nil
-}
-
-func (f FakeOperatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
-	return &f.OperatorSdkReport, nil
-}
-
-type BadOperatorSdkEngine struct{}
-
-func (bose BadOperatorSdkEngine) Scorecard(bundleImage string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
-	operatorSdkReport := cli.OperatorSdkScorecardReport{
-		Stdout: "Bad Stdout",
-		Stderr: "Bad Stderr",
-		Items:  []cli.OperatorSdkScorecardItem{},
-	}
-	return &operatorSdkReport, errors.New("the Operator Sdk Scorecard has failed")
-}
-
-func (bose BadOperatorSdkEngine) BundleValidate(bundleImage string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
-	operatorSdkReport := cli.OperatorSdkBundleValidateReport{
-		Stdout:  "Bad Stdout",
-		Stderr:  "Bad Stderr",
-		Passed:  false,
-		Outputs: []cli.OperatorSdkBundleValidateOutput{},
-	}
-	return &operatorSdkReport, errors.New("the Operator Sdk Bundle Validate has failed")
-}
 
 var _ = Describe("BundleValidateCheck", func() {
 	var (

--- a/cli/operatorsdk.go
+++ b/cli/operatorsdk.go
@@ -1,13 +1,13 @@
 package cli
 
 type OperatorSdkScorecardOptions struct {
-	LogLevel       string
 	OutputFormat   string
 	Selector       []string
 	ResultFile     string
 	Kubeconfig     string
 	Namespace      string
 	ServiceAccount string
+	Verbose        bool
 }
 
 type OperatorSdkScorecardReport struct {


### PR DESCRIPTION
The scorecard checks were already enabled, but still pulling an image via podman. This now just uses the on-disk bundle.

Depends-on: #188 
Fixes #165 

Signed-off-by: Brad P. Crochet <brad@redhat.com>