### PR TITLE
Write the results.json to the artifacts directory

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
@@ -11,6 +12,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var checkContainerCmd = &cobra.Command{
@@ -48,7 +50,7 @@ var checkContainerCmd = &cobra.Command{
 		// create the results file early to catch cases where we are not
 		// able to write to the filesystem before we attempt to execute checks.
 		resultsFile, err := os.OpenFile(
-			resultsFilenameWithExtension(formatter.FileExtension()),
+			filepath.Join(viper.GetString("artifacts"), (formatter.FileExtension())),
 			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 			0600,
 		)

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
@@ -11,6 +12,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var checkOperatorCmd = &cobra.Command{
@@ -53,7 +55,7 @@ var checkOperatorCmd = &cobra.Command{
 		// create the results file early to catch cases where we are not
 		// able to write to the filesystem before we attempt to execute checks.
 		resultsFile, err := os.OpenFile(
-			resultsFilenameWithExtension(formatter.FileExtension()),
+			filepath.Join(viper.GetString("artifacts"), resultsFilenameWithExtension(formatter.FileExtension())),
 			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 			0600,
 		)


### PR DESCRIPTION
By default, write the results.json to the artifacts directory. This should
keep everything in the same place without having to actually change
directories.

Signed-off-by: Brad P. Crochet <brad@redhat.com>