### PR TITLE
add PreRun to all subcommands to load configurations

### DIFF
--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -7,9 +7,10 @@ import (
 )
 
 var certifyCmd = &cobra.Command{
-	Use:   "certify",
-	Short: "Submits check results to Red Hat",
-	Long:  `This command will run all the checks for a container or operator and submit the results to Red Hat for Certification consideration `,
+	Use:    "certify",
+	Short:  "Submits check results to Red Hat",
+	Long:   `This command will run all the checks for a container or operator and submit the results to Red Hat for Certification consideration `,
+	PreRun: preRunConfig,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Certify command not implemented")
 	},

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -25,6 +25,7 @@ var checkContainerCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PreRun: preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect exactly one positional arg. Check here instead of using builtin Args key
 		// so that we can get a more user-friendly error message

--- a/cmd/check_container_old.go
+++ b/cmd/check_container_old.go
@@ -23,6 +23,7 @@ var oldCheckContainerCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PreRun: preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect exactly one positional arg. Check here instead of using builtin Args key
 		// so that we can get a more user-friendly error message

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -25,6 +25,7 @@ var checkOperatorCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PreRun: preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect exactly one positional arg. Check here instead of using builtin Args key
 		// so that we can get a more user-friendly error message

--- a/cmd/check_operator_old.go
+++ b/cmd/check_operator_old.go
@@ -23,6 +23,7 @@ var oldCheckOperatorCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PreRun: preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect exactly one positional arg. Check here instead of using builtin Args key
 		// so that we can get a more user-friendly error message

--- a/cmd/check_run.go
+++ b/cmd/check_run.go
@@ -19,6 +19,7 @@ var checkRunCmd = &cobra.Command{
 It is an internal command, and is not meant to be called by the user.
 It takes its input from environment variables only.`,
 	Hidden: true,
+	PreRun: preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect an environment variable named PREFLIGHT_CHECK_EXEC
 		// It will specify the one check to execute inside of the podman unshare

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,14 +2,11 @@
 package cmd
 
 import (
-	"io"
 	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
@@ -17,60 +14,12 @@ var rootCmd = &cobra.Command{
 	Short:   "Preflight Red Hat certification prep tool.",
 	Long:    "A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification.",
 	Version: version.Version.String(),
+	Args:    cobra.MinimumNArgs(1),
 }
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 		os.Exit(-1)
-	}
-}
-
-func init() {
-	cobra.OnInitialize(initConfig)
-}
-
-func initConfig() {
-	// set up ENV var support
-	viper.SetEnvPrefix("pflt")
-	viper.AutomaticEnv()
-
-	// set up optional config file support
-	viper.SetConfigName("config")
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath(".")
-
-	configFileUsed := true
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			configFileUsed = false
-		}
-	}
-
-	// Set up logging config defaults
-	viper.SetDefault("logfile", DefaultLogFile)
-	viper.SetDefault("loglevel", DefaultLogLevel)
-	viper.SetDefault("artifacts", DefaultArtifactsDir)
-
-	// Set up cluster defaults
-	viper.SetDefault("namespace", DefaultNamespace)
-	viper.SetDefault("serviceaccount", DefaultServiceAccount)
-
-	// set up logging
-	logname := viper.GetString("logfile")
-	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err == nil {
-		mw := io.MultiWriter(os.Stderr, logFile)
-		log.SetOutput(mw)
-	} else {
-		log.Info("Failed to log to file, using default stderr")
-	}
-	if ll, err := log.ParseLevel(viper.GetString("loglevel")); err == nil {
-		log.SetLevel(ll)
-	}
-
-	log.SetFormatter(&log.TextFormatter{})
-	if !configFileUsed {
-		log.Info("config file not found, proceeding without it")
 	}
 }

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -27,6 +27,7 @@ var supportCmd = &cobra.Command{
 	Short: "Submits a support request",
 	Long: `This interactive command will generate a URL; based on user input which can then be used to create a Red Hat Support Ticket.
 	This command can be used when you'd like assistance from Red Hat Support when attempting to pass your certification checks. `,
+	PreRun: preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		certProjectTypeLabel := promptui.Select{

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,7 +1,61 @@
 package cmd
 
-import "strings"
+import (
+	"io"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
 
 func resultsFilenameWithExtension(ext string) string {
 	return strings.Join([]string{"results", ext}, ".")
+}
+
+// preRunConfig is used by cobra.PreRun in all non-root commands to load all necessary configurations
+func preRunConfig(cmd *cobra.Command, args []string) {
+	// set up ENV var support
+	viper.SetEnvPrefix("pflt")
+	viper.AutomaticEnv()
+
+	// set up optional config file support
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".")
+
+	configFileUsed := true
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			configFileUsed = false
+		}
+	}
+
+	// Set up logging config defaults
+	viper.SetDefault("logfile", DefaultLogFile)
+	viper.SetDefault("loglevel", DefaultLogLevel)
+	viper.SetDefault("artifacts", DefaultArtifactsDir)
+
+	// Set up cluster defaults
+	viper.SetDefault("namespace", DefaultNamespace)
+	viper.SetDefault("serviceaccount", DefaultServiceAccount)
+
+	// set up logging
+	logname := viper.GetString("logfile")
+	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err == nil {
+		mw := io.MultiWriter(os.Stderr, logFile)
+		log.SetOutput(mw)
+	} else {
+		log.Info("Failed to log to file, using default stderr")
+	}
+	if ll, err := log.ParseLevel(viper.GetString("loglevel")); err == nil {
+		log.SetLevel(ll)
+	}
+
+	log.SetFormatter(&log.TextFormatter{})
+	if !configFileUsed {
+		log.Info("config file not found, proceeding without it")
+	}
 }


### PR DESCRIPTION
This PR will add PreRun to all subcommands to load configurations, and remove `init()` from the root cmd to insure that configurations are only loaded when a given `subcommand` is executed.

fixes #119 