### PR TITLE
Deprecate ioutil for Go 1.16

### DIFF
--- a/certification/internal/k8s/deployable_by_olm_mounted.go
+++ b/certification/internal/k8s/deployable_by_olm_mounted.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -251,7 +250,7 @@ func (p *DeployableByOlmMountedCheck) writeToFile(data interface{}, resource str
 	if err != nil {
 		log.Error("unable to serialize the data")
 	}
-	err = ioutil.WriteFile(filepath.Join("artifacts", fmt.Sprintf("%s-%s.yaml", resource, resourceType)), yamlData, 0644)
+	err = os.WriteFile(filepath.Join("artifacts", fmt.Sprintf("%s-%s.yaml", resource, resourceType)), yamlData, 0644)
 	if err != nil {
 		log.Error("failed to write the k8s object to the file")
 	}

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -247,7 +246,7 @@ func (p *DeployableByOlmCheck) writeToFile(data interface{}, resource string, re
 		log.Error("unable to serialize the data")
 	}
 
-	if err = ioutil.WriteFile(filepath.Join("artifacts", fmt.Sprintf("%s-%s.yaml", resource, resourceType)), yamlData, 0644); err != nil {
+	if err = os.WriteFile(filepath.Join("artifacts", fmt.Sprintf("%s-%s.yaml", resource, resourceType)), yamlData, 0644); err != nil {
 		log.Error("failed to write the k8s object to the file")
 	}
 }

--- a/certification/internal/shell/operatorsdk.go
+++ b/certification/internal/shell/operatorsdk.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -136,7 +135,7 @@ func (o OperatorSdkCLIEngine) BundleValidate(image string, opts cli.OperatorSdkB
 func (o OperatorSdkCLIEngine) writeScorecardFile(resultFile, stdout string) error {
 	scorecardFile := fileutils.ArtifactPath(resultFile)
 
-	err := ioutil.WriteFile(scorecardFile, []byte(stdout), 0644)
+	err := os.WriteFile(scorecardFile, []byte(stdout), 0644)
 	if err != nil {
 		return err
 	}

--- a/certification/internal/shell/podman.go
+++ b/certification/internal/shell/podman.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -89,7 +88,7 @@ func (pe PodmanCLIEngine) InspectImage(rawImage string, opts cli.ImageInspectOpt
 // for the end users' reference.
 func (pe PodmanCLIEngine) ScanImage(image string) (*cli.ImageScanReport, error) {
 	ovalFileUrl := fmt.Sprintf("%s%s", ovalUrl, ovalFilename)
-	dir, err := ioutil.TempDir(".", "oval-")
+	dir, err := os.MkdirTemp(".", "oval-")
 
 	if err != nil {
 		log.Error("Unable to create temp dir", err)


### PR DESCRIPTION
Per the change log for Go 1.16, the `ioutil` library has some routines being deprecated/moved: https://golang.org/doc/go1.16#ioutil