### PR TITLE
Remove unwanted log message

### DIFF
--- a/certification/internal/utils/file/helper.go
+++ b/certification/internal/utils/file/helper.go
@@ -126,8 +126,6 @@ func Untar(dst string, r io.Reader) error {
 
 			// if it's a link create it
 		case tar.TypeSymlink:
-			// head, _ := tar.FileInfoHeader(header.FileInfo(), "link")
-			log.Println(fmt.Sprintf("Old: %s, New: %s", header.Linkname, header.Name))
 			err := os.Symlink(header.Linkname, filepath.Join(dst, header.Name))
 			if err != nil {
 				log.Println(fmt.Sprintf("Error creating link: %s. Ignoring.", header.Name))


### PR DESCRIPTION
A log message, at default "info" level (since it was a log.Println)
was in use when first debugging the Untar function, but it was an
extremely verbose log, so even with trace it is overwhelming, and
doesn't add any good info for the end user. So, this removes it.

Signed-off-by: Brad P. Crochet <brad@redhat.com>