### PR TITLE
Fix the license check so that failures vs errors are correct

### DIFF
--- a/certification/internal/policy/container/has_license.go
+++ b/certification/internal/policy/container/has_license.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	stdliberrors "errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -24,6 +25,9 @@ type HasLicenseCheck struct{}
 func (p *HasLicenseCheck) Validate(imgRef certification.ImageReference) (bool, error) {
 	licenseFileList, err := p.getDataToValidate(imgRef.ImageFSPath)
 	if err != nil {
+		if stdliberrors.Is(err, fs.ErrNotExist) || stdliberrors.Is(err, errors.ErrLicensesNotADir) {
+			return false, nil
+		}
 		return false, err
 	}
 	return p.validate(licenseFileList)

--- a/certification/internal/policy/container/has_license_test.go
+++ b/certification/internal/policy/container/has_license_test.go
@@ -49,7 +49,7 @@ var _ = Describe("HasLicense", func() {
 			})
 			It("Should not pass Validate", func() {
 				ok, err := HasLicense.Validate(imgRef)
-				Expect(err).To(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
 		})


### PR DESCRIPTION
If the license dir did not exist, it was being reports as an error. It
is supposed to be a failure. If /licenses is not a dir, that a failure,
not an error. If the dir can't be read, then that's treated as a failure.

Signed-off-by: Brad P. Crochet <brad@redhat.com>