### PR TITLE
Update hash label in results

### DIFF
--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -48,10 +48,10 @@ func getResponse(r runtime.Results) UserResponse {
 	}
 
 	response := UserResponse{
-		Image:       r.TestedImage,
-		Passed:      r.PassedOverall,
-		LibraryInfo: version.Version,
-		BundleHash:  r.BundleHash,
+		Image:             r.TestedImage,
+		Passed:            r.PassedOverall,
+		LibraryInfo:       version.Version,
+		CertificationHash: r.CertificationHash,
 		Results: resultsText{
 			Passed: passedChecks,
 			Failed: failedChecks,
@@ -64,11 +64,11 @@ func getResponse(r runtime.Results) UserResponse {
 
 // UserResponse is the standard user-facing response.
 type UserResponse struct {
-	Image       string                 `json:"image" xml:"image"`
-	Passed      bool                   `json:"passed" xml:"passed"`
-	BundleHash  string                 `json:"bundle_hash,omitempty" xml:"bundle_hash,omitempty"`
-	LibraryInfo version.VersionContext `json:"test_library" xml:"test_library"`
-	Results     resultsText            `json:"results" xml:"results"`
+	Image             string                 `json:"image" xml:"image"`
+	Passed            bool                   `json:"passed" xml:"passed"`
+	CertificationHash string                 `json:"certification_hash,omitempty" xml:"certification_hash,omitempty"`
+	LibraryInfo       version.VersionContext `json:"test_library" xml:"test_library"`
+	Results           resultsText            `json:"results" xml:"results"`
 }
 
 // resultsText represents the results of check execution against the asset.

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -135,7 +135,7 @@ func (c *CraneEngine) ExecuteChecks() error {
 		if err != nil {
 			log.Debugf("could not generate bundle hash")
 		}
-		c.results.BundleHash = md5sum
+		c.results.CertificationHash = md5sum
 	}
 
 	return nil

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -22,10 +22,10 @@ type Result struct {
 }
 
 type Results struct {
-	TestedImage   string
-	PassedOverall bool
-	BundleHash    string
-	Passed        []Result
-	Failed        []Result
-	Errors        []Result
+	TestedImage       string
+	PassedOverall     bool
+	CertificationHash string
+	Passed            []Result
+	Failed            []Result
+	Errors            []Result
 }


### PR DESCRIPTION
Fixes #225

The bundle_hash key in the result is not a part of the spec for submitting results to pyxis, and it should be certification_hash instead.