### PR TITLE
Upgrade Vagrantfile to 1.16.8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,9 +25,9 @@ Vagrant.configure("2") do |config|
     containers-common \
     openscap-containers
   
-    curl -L https://golang.org/dl/go1.16.3.linux-amd64.tar.gz --output go1.16.3.linux-amd64.tar.gz
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
-    rm go1.16.3.linux-amd64.tar.gz
+    curl -L https://golang.org/dl/go1.16.8.linux-amd64.tar.gz --output go1.16.8.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.8.linux-amd64.tar.gz
+    rm go1.16.8.linux-amd64.tar.gz
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz --output oc.tar.gz
     tar -C /usr/local/bin -xzf oc.tar.gz
     rm oc.tar.gz


### PR DESCRIPTION
1.16.8 is available now: https://golang.org/dl/