### PR TITLE
Implement the bundle hash in golang - Simplified

### DIFF
--- a/certification/internal/utils/container/helper.go
+++ b/certification/internal/utils/container/helper.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"crypto/md5"
 	"fmt"
+	"io/fs"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
@@ -16,34 +17,53 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func GenerateBundleHash(image string) (string, error) {
-	// TODO: Convert this to regular Go commands
-	hashCmd := fmt.Sprintf(`cd %s && find . -not -name "Dockerfile" -type f -printf '%%f\t%%p\n' | sort -V -k1 | cut -d$'\t' -f2 | tr '\n' '\0' | xargs -r0 -I {} md5sum "{}"`, image) // >> $HOME/hashes.txt`
+func GenerateBundleHash(bundlePath string) (string, error) {
+	files := make(map[string]string)
+	fileSystem := os.DirFS(bundlePath)
 
-	cmd := exec.Command("/bin/bash", "-c", hashCmd)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
+	hashBuffer := bytes.Buffer{}
+
+	fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Errorf("could not read bundle directory: %s", path)
+			return err
+		}
+		if d.Name() == "Dockerfile" {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		filebytes, err := fs.ReadFile(fileSystem, path)
+		if err != nil {
+			log.Errorf("could not read file: %s", path)
+			return err
+		}
+		md5sum := fmt.Sprintf("%x", md5.Sum(filebytes))
+		files[md5sum] = fmt.Sprintf("./%s", path)
+		return nil
+	})
+
+	keys := make([]string, 0, len(files))
+	for k := range files {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	for _, k := range keys {
+		hashBuffer.WriteString(fmt.Sprintf("%s  %s\n", k, files[k]))
+	}
+
+	err := os.WriteFile(filepath.Join(certutils.ArtifactPath(), "hashes.txt"), hashBuffer.Bytes(), 0644)
 	if err != nil {
-		log.Error("could not generate bundle hash")
-		log.Debugf(fmt.Sprintf("Stdout: %s", stdout.String()))
-		log.Debugf(fmt.Sprintf("Stderr: %s", stderr.String()))
 		return "", err
 	}
 
-	log.Tracef(fmt.Sprintf("Hash is: %s", stdout.String()))
-	err = os.WriteFile(filepath.Join(certutils.ArtifactPath(), "hashes.txt"), stdout.Bytes(), 0644)
-	if err != nil {
-		log.Error("could not write bundle hash file")
-		return "", err
-	}
+	sum := fmt.Sprintf("%x", md5.Sum(hashBuffer.Bytes()))
 
-	sum := md5.Sum(stdout.Bytes())
+	log.Debugf("md5 sum: %s", sum)
 
-	log.Debugf("md5 sum: %s", fmt.Sprintf("%x", sum))
-
-	return fmt.Sprintf("%x", sum), nil
+	return sum, nil
 }
 
 func GetAnnotationsFromBundle(mountedDir string) (map[string]string, error) {


### PR DESCRIPTION
Relates to redhat-openshift-ecosystem/operator-pipelines#57. This simplifies the sorting, and
fully implements the bundle hash generation in golang.

This should not be merged until redhat-openshift-ecosystem/operator-pipelines#57 lands.

Fixes #235 

Signed-off-by: Brad P. Crochet <brad@redhat.com>