### PR TITLE
Fix differing approaches to writing results file

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -11,8 +11,8 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var checkContainerCmd = &cobra.Command{
@@ -51,7 +51,7 @@ var checkContainerCmd = &cobra.Command{
 		// create the results file early to catch cases where we are not
 		// able to write to the filesystem before we attempt to execute checks.
 		resultsFile, err := os.OpenFile(
-			filepath.Join(viper.GetString("artifacts"), (formatter.FileExtension())),
+			filepath.Join(certutils.ArtifactPath(), resultsFilenameWithExtension(formatter.FileExtension())),
 			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 			0600,
 		)


### PR DESCRIPTION
This PR just syncs the check_container approach to writing the results file so that it matches the check_operator approach.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>