### PR TITLE
Add doc on building an index image

### DIFF
--- a/docs/BUILDING_AN_INDEX.md
+++ b/docs/BUILDING_AN_INDEX.md
@@ -1,0 +1,61 @@
+# Building an Index Image
+
+Preflight's Operator policy (i.e. `preflight check operator ...`) requires
+access to an index image containing the Operator bundle under test.
+
+The fastest way to do this is to utilize the `opm` tool to build an index image,
+publish that image, and then provide that to Preflight when executing your
+checks. To install the `opm` cli, visit the
+[operator-framework/operator-registry
+releases](https://github.com/operator-framework/operator-registry/releases) page
+and download an appropriate binary for your system.
+
+## Building an Index With Your Bundle
+
+For reference, the below instructions were executed using `opm` at the following
+version:
+
+```shell
+$ opm version
+Version: version.Version{OpmVersion:"v1.18.0", GitCommit:"b826849", BuildDate:"2021-08-11T19:07:57Z", GoOs:"darwin", GoArch:"amd64"}
+```
+
+Your bundle must already be published to a registry in order to build your index
+image with that bundle.
+
+Run the following command to create an index with the specified bundle,
+substituting your bundle's registry path, and the desired registry path of your
+index. 
+
+(NOTE: Docker users may need to specify the `--container-tool=docker` flag to
+this command)
+
+```shell
+opm index add --bundles registry.example.org/your-namespace/your-bundle:0.0.1 --tag registry.example.org/your-namespace/your-index:0.0.1
+```
+
+(sample output)
+
+```shell
+INFO[0000] building the index                            bundles="[registry.example.org/your-namespace/your-bundle:0.0.1]"
+... truncated
+INFO[0002] [podman build -f index.Dockerfile359827617 -t registry.example.org/your-namespace/your-index:0.0.1 .]  bundles="[registry.example.org/your-namespace/your-bundle:0.0.1]"
+```
+
+Then push this bundle to your registry of choice. This registry must be
+accessible to Preflight as well as the target cluster.
+
+```shell
+podman push registry.example.org/your-namespace/your-index:0.0.1
+```
+
+Finally, set the value of `PFLT_INDEXIMAGE` to this value and run preflight:
+
+```shell
+export PFLT_INDEXIMAGE=registry.example.org/your-namespace/your-index:0.0.1
+preflight check operator registry.example.org/your-namespace/your-bundle:0.0.1
+```
+
+For detailed information on how to use the `opm` tool, see [Building an Index of
+Operators using
+opm](https://github.com/operator-framework/operator-registry#building-an-index-of-operators-using-opm)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -23,6 +23,8 @@ is called.
 |`PFLT_SERVICEACCOUNT`|env|The service account to use when running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/)|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L9)|
 |`PFLT_INDEXIMAGE`|env|The index image to use when testing that an operator is `DeployableByOLM`|required|-|
 
+For information on how to build an index image, see [BUILDING_AN_INDEX.md](BUILDING_AN_INDEX.md).
+
 ## Container Policy Configuration
 
 There are no configurables specific to the container policy (i.e. when running `preflight check container ...`).


### PR DESCRIPTION
The Preflight operator checks require that we provide an index image at `PFLT_INDEXIMAGE` for the DeployableByOLM check to run. This PR includes a docs on how to build one using `opm`.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>