### PR TITLE
Write logs to PFLT_ARTIFACTS dir in DeployableByOLM

### DIFF
--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	openshiftengine "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/engine"
 	containerutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/container"
+	fileutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/file"
 	viperutil "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/viper"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
@@ -272,8 +272,9 @@ func (p *DeployableByOlmCheck) writeToFile(data interface{}, resource string, re
 		log.Error("unable to serialize the data")
 	}
 
-	if err = os.WriteFile(filepath.Join("artifacts", fmt.Sprintf("%s-%s.yaml", resource, resourceType)), yamlData, 0644); err != nil {
-		log.Error("failed to write the k8s object to the file")
+	filename := fmt.Sprintf("%s-%s.yaml", resource, resourceType)
+	if _, err := fileutil.WriteFileToArtifactsPath(filename, string(yamlData)); err != nil {
+		log.Error("failed to write the k8s object to the file", err)
 	}
 }
 


### PR DESCRIPTION
**Context**

I observed a bug in the DeployableByOLM check where the resources that were created weren't getting written to the artifacts directory if I customized this location via `$PFLT_ARTIFACTS`.

I saw this log output and no files:

```
time="2021-09-10T16:49:34Z" level=debug msg="Dumping data in artifacts/ directory"
time="2021-09-10T16:49:37Z" level=debug msg="fetching subscription kogito-operator from namespace kogito-operator "
time="2021-09-10T16:49:37Z" level=error msg="failed to write the k8s object to the file"
time="2021-09-10T16:49:40Z" level=debug msg="fetching catalogsource: kogito-operator"
time="2021-09-10T16:49:40Z" level=error msg="failed to write the k8s object to the file"
time="2021-09-10T16:49:42Z" level=debug msg="fetching operatorgroup kogito-operator from namespace kogito-operator "
time="2021-09-10T16:49:42Z" level=error msg="failed to write the k8s object to the file"
time="2021-09-10T16:49:42Z" level=debug msg="fetching namespace: kogito-operator"
time="2021-09-10T16:49:43Z" level=error msg="failed to write the k8s object to the file"
```

Looks like this was caused by the function directly writing to `artifacts/` which didn't exist in the above case because I had customized the path.

**Changes**

This PR just reuses an already-existing function that is `PFLT_ARTIFACTS` aware.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>