### PR TITLE
log the version info immediately

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -12,6 +12,8 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +31,8 @@ var checkContainerCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect exactly one positional arg. Check here instead of using builtin Args key
 		// so that we can get a more user-friendly error message
+
+		log.Info("certification library version ", version.Version.String())
 
 		containerImage := args[0]
 

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -11,6 +11,8 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
@@ -30,6 +32,8 @@ var checkOperatorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Expect exactly one positional arg. Check here instead of using builtin Args key
 		// so that we can get a more user-friendly error message
+
+		log.Info("certification library version ", version.Version.String())
 
 		operatorImage := args[0]
 


### PR DESCRIPTION
If we happen to run into an issue with the preflight execution, we may not get the version of preflight that experienced the issue which is normally stored in results (e.g. if we run into a panic at runtime). 

This adds a log line right away that logs the version context to both the `check operator` and `check container` runs.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>