### PR TITLE
adding stdout to operatorsdk's output

### DIFF
--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -117,7 +117,8 @@ func (o operatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBund
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		log.Debugf("Stderr: %s", stderr.String())
-		return &cli.OperatorSdkBundleValidateReport{Stderr: stderr.String()}, fmt.Errorf("%w: %s", errors.ErrOperatorSdkBundleValidateFailed, err)
+		log.Debugf("Stdout: %s", stdout.String())
+		return &cli.OperatorSdkBundleValidateReport{Stderr: stderr.String(), Stdout: stdout.String()}, fmt.Errorf("%w: %s", errors.ErrOperatorSdkBundleValidateFailed, err)
 	}
 
 	var bundleValidateData cli.OperatorSdkBundleValidateReport


### PR DESCRIPTION
Currently the user is not presented with why `ValidateOperatorBundle` failed since this check is run by operator-sdk. This PR adds `stdout` to the log and what is displayed to the preflight user.

fixes #249 