### PR TITLE
updating operator sdk to version `1.12.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 # Define versions for dependencies
 ARG OPENSCAP_VERSION=1.3.5
 ARG OPENSHIFT_CLIENT_VERSION=4.7.19
-ARG OPERATOR_SDK_VERSION=1.9.0
+ARG OPERATOR_SDK_VERSION=1.12.0
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.9.0          |
+| OperatorSDK      | `operator-sdk`    | v1.12.0          |
 | OpenShift Client | `oc`              | v4.7.19         |
 | Podman           | `podman`          | v3.0            |
 | Skopeo           | `skopeo`          | v1.2.2          |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.9.0
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.12.0
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -149,14 +149,14 @@ metadata:
 stages:
 - parallel: true
   tests:
-  - image: quay.io/operator-framework/scorecard-test:v1.9.0
+  - image: quay.io/operator-framework/scorecard-test:v1.12.0
     entrypoint:
       - scorecard-test
       - basic-check-spec
     labels:
       suite: basic
       test: basic-check-spec-test
-  - image: quay.io/operator-framework/scorecard-test:v1.9.0
+  - image: quay.io/operator-framework/scorecard-test:v1.12.0
     entrypoint:
       - scorecard-test
       - olm-bundle-validation


### PR DESCRIPTION
Update the docker file, vagrant file, and the scorecard images to use `1.12.0` of operator sdk

fixes #253 