### PR TITLE
Fix service account in bundle-passes

### DIFF
--- a/test/containerfiles/successful-bundle-assets/manifests/sample-operator-controller-manager_v1_serviceaccount.yaml
+++ b/test/containerfiles/successful-bundle-assets/manifests/sample-operator-controller-manager_v1_serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
-  name: sample-operator-controller-manager
+  name: sample-operator-controller-manager-sa


### PR DESCRIPTION
The latest operator-sdk bundle validate requires that the service account
not be the same as what's in the CSV. This fixes that.

Signed-off-by: Brad P. Crochet <brad@redhat.com>