### PR TITLE
switch from podman to none in operator sdk bundle validate cmd

### DIFF
--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -93,7 +93,7 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 func (o operatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
 	cmdArgs := []string{"bundle", "validate"}
 	if opts.ContainerEngine == "" {
-		opts.ContainerEngine = "podman"
+		opts.ContainerEngine = "none"
 	}
 	cmdArgs = append(cmdArgs, "-b", opts.ContainerEngine)
 	if opts.OutputFormat == "" {

--- a/certification/internal/policy/operator/validate_operator_bundle.go
+++ b/certification/internal/policy/operator/validate_operator_bundle.go
@@ -33,7 +33,7 @@ func (p ValidateOperatorBundleCheck) getDataToValidate(imagePath string) (*cli.O
 	opts := cli.OperatorSdkBundleValidateOptions{
 		Selector:        selector,
 		Verbose:         true,
-		ContainerEngine: "podman",
+		ContainerEngine: "none",
 		OutputFormat:    "json-alpha1",
 	}
 


### PR DESCRIPTION
Since we already pulled and extracted the bundle file, we can pass `none` as a cmd argument to `operator-sdk` and get the same results. Thus, one step closer to potentially removing podman from the docker image.

Test Results
```
time="2021-09-14T17:39:08Z" level=info msg="running check: ValidateOperatorBundle"
time="2021-09-14T17:39:08Z" level=debug msg="Command being run: [operator-sdk bundle validate -b none --output json-alpha1 --select-optional name=community --select-optional name=operatorhub --verbose /tmp/preflight-3006179402/fs]"
time="2021-09-14T17:39:09Z" level=info msg="check completed: ValidateOperatorBundle" result=PASSED
```

fixes #256 