### PR TITLE
Fix nil pointer reference in operatorMetadata

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -37,3 +37,4 @@ var ErrRemovePFromProjectID = errors.New("please remove leading character p from
 var ErrRemoveOSPIDFromProjectID = errors.New("please remove leading character ospid- from project id")
 var ErrRemoveSpecialCharFromProjectID = errors.New("please remove all special characters from project id")
 var ErrPullRequestURL = errors.New("please enter a valid url: including scheme, host, and path to pull request")
+var ErrIndexImageUndefined = errors.New("index image environment variable not set")

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -82,7 +82,7 @@ func (p *DeployableByOlmCheck) operatorMetadata(bundleRef certification.ImageRef
 	catalogImage := viper.GetString(indexImageKey)
 	if len(catalogImage) == 0 {
 		log.Error(fmt.Sprintf("To set the key, export PFLT_%s or add %s:<value> to config.yaml in the current working directory", strings.ToUpper(indexImageKey), indexImageKey))
-		return nil, err
+		return nil, errors.ErrIndexImageUndefined
 	}
 
 	channel, err := annotation(annotations, channelKey)


### PR DESCRIPTION
A subtle bug was introduced in the operatorMetadata function in OLM check.
If the index image envvar was not set, it was returning (nil, err), but err
was not set to anything, so the wrapping check for err != nil was not
succeeding. This ensures an error is returned.

Signed-off-by: Brad P. Crochet <brad@redhat.com>