### PR TITLE
Fix the timeouts in DeployableByOLM check

### DIFF
--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -32,8 +32,8 @@ type DeployableByOlmCheck struct {
 }
 
 var (
-	subscriptionTimeout time.Duration = 180
-	csvTimeout          time.Duration = 90
+	subscriptionTimeout time.Duration = 180 * time.Second
+	csvTimeout          time.Duration = 90 * time.Second
 )
 
 func NewDeployableByOlmCheck(openshiftEngine *cli.OpenshiftEngine) *DeployableByOlmCheck {

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo"
@@ -27,8 +28,8 @@ var _ = Describe("DeployableByOLMCheck", func() {
 	)
 	BeforeEach(func() {
 		// override default timeout
-		subscriptionTimeout = 1
-		csvTimeout = 1
+		subscriptionTimeout = 1 * time.Second
+		csvTimeout = 1 * time.Second
 
 		// mock bundle directory
 		tmpDir, err := os.MkdirTemp("", "bundle-metadata-*")


### PR DESCRIPTION
The timeouts were made into variables (for testing purposes). When this
was changed, the "*time.Second" was not added, so the context was timing
out basically immediately.

Signed-off-by: Brad P. Crochet <brad@redhat.com>