### PR TITLE
Leverage controller-manager GetConfigOrDie() to parse kubeconfig

### DIFF
--- a/certification/internal/cli/openshift.go
+++ b/certification/internal/cli/openshift.go
@@ -30,8 +30,6 @@ type OperatorGroupData struct {
 }
 
 type OpenshiftEngine interface {
-	Setup() error
-
 	CreateNamespace(name string, opts OpenshiftOptions) (*corev1.Namespace, error)
 	DeleteNamespace(name string, opts OpenshiftOptions) error
 	GetNamespace(name string) (*corev1.Namespace, error)

--- a/certification/internal/client/catalogsource.go
+++ b/certification/internal/client/catalogsource.go
@@ -7,7 +7,6 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -99,7 +98,7 @@ func (c catalogSourceClient) convert(u *unstructured.Unstructured) (*operatorv1a
 	return &obj, nil
 }
 
-func CatalogSourceClient(cfg *rest.Config, namespace string) (*catalogSourceClient, error) {
+func CatalogSourceClient(namespace string) (*catalogSourceClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
 	kubeconfig := ctrl.GetConfigOrDie()

--- a/certification/internal/client/csv.go
+++ b/certification/internal/client/csv.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -58,7 +57,7 @@ func (c csvClient) convert(u *unstructured.Unstructured) (*operatorv1alpha1.Clus
 	return &obj, nil
 }
 
-func CsvClient(cfg *rest.Config, namespace string) (*csvClient, error) {
+func CsvClient(namespace string) (*csvClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
 	kubeconfig := ctrl.GetConfigOrDie()

--- a/certification/internal/client/operatorgroup.go
+++ b/certification/internal/client/operatorgroup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -97,7 +96,7 @@ func (c operatorGroupClient) convert(u *unstructured.Unstructured) (*operatorv1.
 	return &obj, nil
 }
 
-func OperatorGroupClient(cfg *rest.Config, namespace string) (*operatorGroupClient, error) {
+func OperatorGroupClient(namespace string) (*operatorGroupClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
 	kubeconfig := ctrl.GetConfigOrDie()

--- a/certification/internal/client/subscription.go
+++ b/certification/internal/client/subscription.go
@@ -7,7 +7,6 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -100,7 +99,7 @@ func (c subscriptionClient) convert(u *unstructured.Unstructured) (*operatorv1al
 	return &obj, nil
 }
 
-func SubscriptionClient(cfg *rest.Config, namespace string) (*subscriptionClient, error) {
+func SubscriptionClient(namespace string) (*subscriptionClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
 	kubeconfig := ctrl.GetConfigOrDie()

--- a/certification/internal/engine/openshift.go
+++ b/certification/internal/engine/openshift.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -11,36 +10,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	client "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/client"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
-type openshiftEngine struct {
-	KubeConfig *rest.Config
-}
+type openshiftEngine struct{}
 
 func NewOpenshiftEngine() *cli.OpenshiftEngine {
 	var engine cli.OpenshiftEngine = &openshiftEngine{}
 	return &engine
 }
 
-func (oe *openshiftEngine) Setup() error {
-	k8sconfig, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-	if err != nil {
-		log.Error("unable to parse kubecofig: ", err)
-		return err
-	}
-	oe.KubeConfig = k8sconfig
-	return nil
-}
-
 func (oe *openshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOptions) (*corev1.Namespace, error) {
 
-	k8sClientset, err := kubernetes.NewForConfig(oe.KubeConfig)
+	kubeconfig := ctrl.GetConfigOrDie()
+	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
 		log.Error("unable to obtain k8s client: ", err)
@@ -70,7 +57,8 @@ func (oe *openshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOption
 }
 
 func (oe *openshiftEngine) DeleteNamespace(name string, opts cli.OpenshiftOptions) error {
-	k8sClientset, err := kubernetes.NewForConfig(oe.KubeConfig)
+	kubeconfig := ctrl.GetConfigOrDie()
+	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
 		log.Error("unable to obtain k8s client: ", err)
@@ -83,7 +71,9 @@ func (oe *openshiftEngine) DeleteNamespace(name string, opts cli.OpenshiftOption
 }
 
 func (oe *openshiftEngine) GetNamespace(name string) (*corev1.Namespace, error) {
-	k8sClientset, err := kubernetes.NewForConfig(oe.KubeConfig)
+
+	kubeconfig := ctrl.GetConfigOrDie()
+	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
 		log.Error("unable to obtain k8s client: ", err)
@@ -97,7 +87,7 @@ func (oe *openshiftEngine) GetNamespace(name string) (*corev1.Namespace, error) 
 
 func (oe *openshiftEngine) CreateOperatorGroup(data cli.OperatorGroupData, opts cli.OpenshiftOptions) (*operatorv1.OperatorGroup, error) {
 
-	ogClient, err := client.OperatorGroupClient(oe.KubeConfig, opts.Namespace)
+	ogClient, err := client.OperatorGroupClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for OperatorGroup: ", err)
 		return nil, err
@@ -116,7 +106,7 @@ func (oe *openshiftEngine) CreateOperatorGroup(data cli.OperatorGroupData, opts 
 }
 
 func (oe *openshiftEngine) DeleteOperatorGroup(name string, opts cli.OpenshiftOptions) error {
-	ogClient, err := client.OperatorGroupClient(oe.KubeConfig, opts.Namespace)
+	ogClient, err := client.OperatorGroupClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for OperatorGroup: ", err)
 		return err
@@ -135,7 +125,7 @@ func (oe *openshiftEngine) DeleteOperatorGroup(name string, opts cli.OpenshiftOp
 }
 
 func (oe *openshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftOptions) (*operatorv1.OperatorGroup, error) {
-	ogClient, err := client.OperatorGroupClient(oe.KubeConfig, opts.Namespace)
+	ogClient, err := client.OperatorGroupClient(opts.Namespace)
 
 	if err != nil {
 		log.Error("unable to obtain k8s client: ", err)
@@ -147,7 +137,7 @@ func (oe *openshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftOptio
 
 func (oe openshiftEngine) CreateCatalogSource(data cli.CatalogSourceData, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
 
-	csClient, err := client.CatalogSourceClient(oe.KubeConfig, opts.Namespace)
+	csClient, err := client.CatalogSourceClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for CatalogSource: ", err)
 		return nil, err
@@ -166,7 +156,7 @@ func (oe openshiftEngine) CreateCatalogSource(data cli.CatalogSourceData, opts c
 }
 
 func (oe *openshiftEngine) DeleteCatalogSource(name string, opts cli.OpenshiftOptions) error {
-	csClient, err := client.CatalogSourceClient(oe.KubeConfig, opts.Namespace)
+	csClient, err := client.CatalogSourceClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for CatalogSource: ", err)
 		return err
@@ -185,7 +175,7 @@ func (oe *openshiftEngine) DeleteCatalogSource(name string, opts cli.OpenshiftOp
 
 func (oe *openshiftEngine) GetCatalogSource(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
 
-	csClient, err := client.CatalogSourceClient(oe.KubeConfig, opts.Namespace)
+	csClient, err := client.CatalogSourceClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for CatalogSource: ", err)
 		return nil, err
@@ -196,7 +186,7 @@ func (oe *openshiftEngine) GetCatalogSource(name string, opts cli.OpenshiftOptio
 
 func (oe openshiftEngine) CreateSubscription(data cli.SubscriptionData, opts cli.OpenshiftOptions) (*operatorv1alpha1.Subscription, error) {
 
-	subsClient, err := client.SubscriptionClient(oe.KubeConfig, opts.Namespace)
+	subsClient, err := client.SubscriptionClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for Subscription: ", err)
 		return nil, err
@@ -215,7 +205,7 @@ func (oe openshiftEngine) CreateSubscription(data cli.SubscriptionData, opts cli
 }
 
 func (oe *openshiftEngine) GetSubscription(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.Subscription, error) {
-	subsClient, err := client.SubscriptionClient(oe.KubeConfig, opts.Namespace)
+	subsClient, err := client.SubscriptionClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for Subscription: ", err)
 		return nil, err
@@ -226,7 +216,7 @@ func (oe *openshiftEngine) GetSubscription(name string, opts cli.OpenshiftOption
 
 func (oe openshiftEngine) DeleteSubscription(name string, opts cli.OpenshiftOptions) error {
 
-	subsClient, err := client.SubscriptionClient(oe.KubeConfig, opts.Namespace)
+	subsClient, err := client.SubscriptionClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for Subscription: ", err)
 		return err
@@ -245,7 +235,7 @@ func (oe openshiftEngine) DeleteSubscription(name string, opts cli.OpenshiftOpti
 
 func (oe *openshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.ClusterServiceVersion, error) {
 
-	csvClient, err := client.CsvClient(oe.KubeConfig, opts.Namespace)
+	csvClient, err := client.CsvClient(opts.Namespace)
 	if err != nil {
 		log.Error("unable to create a client for csv: ", err)
 		return nil, err

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -49,11 +49,6 @@ func (p *DeployableByOlmCheck) Validate(bundleRef certification.ImageReference) 
 		return false, err
 	}
 
-	err = p.OpenshiftEngine.Setup()
-	if err != nil {
-		return false, err
-	}
-
 	// create k8s custom resources for the operator deployment
 	err = p.setUp(*operatorData)
 	defer p.cleanUp(*operatorData)

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -64,10 +64,6 @@ func (bose BadOperatorSdkEngine) BundleValidate(bundleImage string, opts cli.Ope
 
 type FakeOpenshiftEngine struct{}
 
-func (foe FakeOpenshiftEngine) Setup() error {
-	return nil
-}
-
 func (foe FakeOpenshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOptions) (*corev1.Namespace, error) {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -192,10 +188,6 @@ func (foe FakeOpenshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*
 }
 
 type BadOpenshiftEngine struct{}
-
-func (foe BadOpenshiftEngine) Setup() error {
-	return nil
-}
 
 func (foe BadOpenshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOptions) (*corev1.Namespace, error) {
 	return &corev1.Namespace{


### PR DESCRIPTION
This PR removes the logic that fetches kubeconfig from environment variable and parse Kubeconfig file.