### PR TITLE
No logs found under artifacts when scorecard fails to run

### DIFF
--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
-	fileutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/file"
-	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -74,13 +72,13 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 		if stderr.Len() != 0 {
 			log.Error("stdout: ", stdout.String())
 			log.Error("stderr: operator-sdk scorecard failed to run properly. " +
-			          "Please review the " + certutils.ArtifactPath() + "/" + opts.ResultFile + " file for more information. ")
+				"Please review the " + artifacts.Path() + "/" + opts.ResultFile + " file for more information. ")
 
 			if err := o.writeScorecardFile(opts.ResultFile, stderr.String()); err != nil {
 				log.Error("unable to copy result to artifacts directory: ", err)
 				return nil, err
 			}
-			
+
 			return nil, fmt.Errorf("%w: %s", errors.ErrOperatorSdkScorecardFailed, err)
 		}
 	}

--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	fileutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/utils/file"
+	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -71,7 +73,14 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 		// check execution itself.
 		if stderr.Len() != 0 {
 			log.Error("stdout: ", stdout.String())
-			log.Error("stderr: ", stderr.String())
+			log.Error("stderr: operator-sdk scorecard failed to run properly. " +
+			          "Please review the " + certutils.ArtifactPath() + "/" + opts.ResultFile + " file for more information. ")
+
+			if err := o.writeScorecardFile(opts.ResultFile, stderr.String()); err != nil {
+				log.Error("unable to copy result to artifacts directory: ", err)
+				return nil, err
+			}
+			
 			return nil, fmt.Errorf("%w: %s", errors.ErrOperatorSdkScorecardFailed, err)
 		}
 	}

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -4,6 +4,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
+	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
 )
 
 // ScorecardBasicSpecCheck evaluates the image to ensure it passes the operator-sdk
@@ -47,7 +48,8 @@ func (p *ScorecardBasicSpecCheck) Metadata() certification.Metadata {
 
 func (p *ScorecardBasicSpecCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Check ScorecardBasicSpecCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_BasicSpecCheck.json file for more information.",
+		Message:    "Check ScorecardBasicSpecCheck encountered an error. Please review the " +
+		certutils.ArtifactPath() + "/" + scorecardBasicCheckResult + " file for more information.",
 		Suggestion: "Make sure that all CRs have a spec block",
 	}
 }

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -4,7 +4,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
-	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 )
 
 // ScorecardBasicSpecCheck evaluates the image to ensure it passes the operator-sdk
@@ -49,7 +49,7 @@ func (p *ScorecardBasicSpecCheck) Metadata() certification.Metadata {
 func (p *ScorecardBasicSpecCheck) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "Check ScorecardBasicSpecCheck encountered an error. Please review the " +
-		certutils.ArtifactPath() + "/" + scorecardBasicCheckResult + " file for more information.",
+		artifacts.Path() + "/" + scorecardBasicCheckResult + " file for more information.",
 		Suggestion: "Make sure that all CRs have a spec block",
 	}
 }

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -2,7 +2,8 @@ package operator
 
 import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -47,7 +48,8 @@ func (p *ScorecardOlmSuiteCheck) Metadata() certification.Metadata {
 
 func (p *ScorecardOlmSuiteCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Check ScorecardOlmSuiteCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_OlmSuiteCheck.json file for more information.",
+		Message: "Check ScorecardOlmSuiteCheck encountered an error. Please review the " +
+			certutils.ArtifactPath() + "/" + scorecardOlmSuiteResult + " file for more information.",
 		Suggestion: "See scorecard output for details, artifacts/operator_bundle_scorecard_OlmSuiteCheck.json",
 	}
 }

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -2,8 +2,8 @@ package operator
 
 import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	certutils "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/utils"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -49,7 +49,7 @@ func (p *ScorecardOlmSuiteCheck) Metadata() certification.Metadata {
 func (p *ScorecardOlmSuiteCheck) Help() certification.HelpText {
 	return certification.HelpText{
 		Message: "Check ScorecardOlmSuiteCheck encountered an error. Please review the " +
-			certutils.ArtifactPath() + "/" + scorecardOlmSuiteResult + " file for more information.",
+			artifacts.Path() + "/" + scorecardOlmSuiteResult + " file for more information.",
 		Suggestion: "See scorecard output for details, artifacts/operator_bundle_scorecard_OlmSuiteCheck.json",
 	}
 }


### PR DESCRIPTION
fix #169 
By appending scorecard stderr to artifacts/*.json 