### PR TITLE
Make 'go mod tidy' fail checks if it is not up-to-date

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         go-version: 1.16
 
+    - name: Tidy
+      run: make tidy
+
     - name: Vet
       run: make vet
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ fmt:
 	go fmt ./...
 	git diff --exit-code
 
+.PHONY: tidy
+tidy:
+	go mod tidy
+	git diff --exit-code
+
 .PHONY: image-build
 image-build:
 	$(IMAGE_BUILDER) build -t $(IMAGE_REPO)/preflight:$(VERSION) .


### PR DESCRIPTION
In order to keep the go.mod in proper form, we should check on each PR
that 'go mod tidy' doesn't change anything.

Signed-off-by: Brad P. Crochet <brad@redhat.com>