### PR TITLE
removing skopeo from readme and code since it was removed previously

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@ functional, and in your path.
 |----------------- |:-----------------:| ---------------:|
 | OperatorSDK      | `operator-sdk`    | v1.12.0          |
 | OpenShift Client | `oc`              | v4.7.19         |
-| Podman           | `podman`          | v3.0            |
-| Skopeo           | `skopeo`          | v1.2.2          |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
-development environment. Some checks may also requires access to an OpenShift
+development environment. Some checks may also require access to an OpenShift
 cluster. which is not provided by the Vagrantfile
 
 ## Usage

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,6 @@ Vagrant.configure("2") do |config|
     dnf -y install \
     podman \
     buildah \
-    skopeo \
     jq \
     make \
     bats \

--- a/certification/internal/policy/container/container_suite_test.go
+++ b/certification/internal/policy/container/container_suite_test.go
@@ -46,14 +46,3 @@ func (fl FakeLayer) Size() (int64, error) {
 func (fl FakeLayer) MediaType() (types.MediaType, error) {
 	return "mediatype", nil
 }
-
-type FakeSkopeoEngine struct {
-	SkopeoReportStdout string
-	SkopeoReportStderr string
-	Tags               []string
-}
-
-type SkopeoData struct {
-	Repository string
-	Tags       []string
-}

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -8,6 +8,17 @@ The project will include a commandline interface that will accept your operator
 bundle or container image as an input, and will run validate that your container
 image or operator bundle complies with a series of validations.
 
+## Requirements
+
+Development and testing preflight requires that you have the following tools installed,
+functional, and in your path.
+
+| Name             | Tool cli          | Minimum version |
+|----------------- |:-----------------:| ---------------:|
+| OperatorSDK      | `operator-sdk`    | v1.12.0          |
+| OpenShift Client | `oc`              | v4.7.19         |
+| Podman           | `podman`          | v3.0            |
+
 ## Checks
 
 The term "check" refers to a single validation executed against the given asset.


### PR DESCRIPTION
This PR aims to clean up `skopeo` from the project completely, as well as add clarity as what the `preflight` binary requires, and what is required for a developer to interact with the codebase.