### PR TITLE
Make scorecard run with --verbose

### DIFF
--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -41,6 +41,7 @@ func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string
 		Kubeconfig:     kubeconfig,
 		Namespace:      namespace,
 		ServiceAccount: serviceAccount,
+		Verbose:        true,
 	}
 	return p.OperatorSdkEngine.Scorecard(bundleImage, opts)
 }


### PR DESCRIPTION
This PR just adds the OperatorSdkScorecardOptions key that enables passing of `--verbose` to operator-sdk. The plumbing was already there, but the value was never set. 

I considered adding this as a configurable, but I figured it made sense to just force verbosity in favor of adding another environment variable given that there are probably next-to-no cases where scorecard breaks in unexpected ways and we don't want to the verbosity the first time around.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>