### PR TITLE
Add support for private registry

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -37,4 +37,5 @@ var ErrRemovePFromProjectID = errors.New("please remove leading character p from
 var ErrRemoveOSPIDFromProjectID = errors.New("please remove leading character ospid- from project id")
 var ErrRemoveSpecialCharFromProjectID = errors.New("please remove all special characters from project id")
 var ErrPullRequestURL = errors.New("please enter a valid url: including scheme, host, and path to pull request")
-var ErrIndexImageUndefined = errors.New("index image environment variable not set")
+var ErrIndexImageUndefined = errors.New("no environment variable PFLT_INDEXIMAGE could be found")
+var ErrNoDockerconfig = errors.New("no environment variable DOCKERCONFIG could be found")

--- a/certification/internal/cli/openshift.go
+++ b/certification/internal/cli/openshift.go
@@ -20,8 +20,9 @@ type SubscriptionData struct {
 }
 
 type CatalogSourceData struct {
-	Name  string
-	Image string
+	Name    string
+	Image   string
+	Secrets []string
 }
 
 type OperatorGroupData struct {
@@ -33,6 +34,10 @@ type OpenshiftEngine interface {
 	CreateNamespace(name string, opts OpenshiftOptions) (*corev1.Namespace, error)
 	DeleteNamespace(name string, opts OpenshiftOptions) error
 	GetNamespace(name string) (*corev1.Namespace, error)
+
+	CreateSecret(name string, content map[string]string, secretType corev1.SecretType, opts OpenshiftOptions) (*corev1.Secret, error)
+	DeleteSecret(name string, opts OpenshiftOptions) error
+	GetSecret(name string, opts OpenshiftOptions) (*corev1.Secret, error)
 
 	CreateOperatorGroup(data OperatorGroupData, opts OpenshiftOptions) (*operatorv1.OperatorGroup, error)
 	DeleteOperatorGroup(name string, opts OpenshiftOptions) error

--- a/certification/internal/client/catalogsource.go
+++ b/certification/internal/client/catalogsource.go
@@ -47,6 +47,7 @@ func (c catalogSourceClient) Create(data cli.CatalogSourceData, opts cli.Openshi
 			"sourceType":  operatorv1alpha1.SourceTypeGrpc,
 			"image":       data.Image,
 			"displayName": data.Name,
+			"secrets":     data.Secrets,
 		},
 	}
 	u.SetGroupVersionKind(catalogSourceKind)

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -12,4 +12,7 @@ const (
 
 	// apiEndpoint is the endpoint used to query for package uniqueness.
 	apiEndpoint = "https://catalog.redhat.com/api/containers/v1/operators/packages"
+
+	// secretName is the K8s secret name which stores the auth keys for the private registry access
+	secretName = "registry-auth-keys"
 )

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -84,6 +84,32 @@ func (foe FakeOpenshiftEngine) GetNamespace(name string) (*corev1.Namespace, err
 	}, nil
 }
 
+func (foe FakeOpenshiftEngine) CreateSecret(name string, content map[string]string, secretType corev1.SecretType, opts cli.OpenshiftOptions) (*corev1.Secret, error) {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-image-secret",
+			Namespace: "test-ns",
+		},
+		Type:       "kubernetes.io/dockerconfigjson",
+		StringData: map[string]string{".dockerconfigjson": "secretData"},
+	}, nil
+}
+
+func (foe FakeOpenshiftEngine) DeleteSecret(name string, opts cli.OpenshiftOptions) error {
+	return nil
+}
+
+func (foe FakeOpenshiftEngine) GetSecret(name string, opts cli.OpenshiftOptions) (*corev1.Secret, error) {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-image-secret",
+			Namespace: "test-ns",
+		},
+		Type:       "kubernetes.io/dockerconfigjson",
+		StringData: map[string]string{".dockerconfigjson": "secretData"},
+	}, nil
+}
+
 func (foe FakeOpenshiftEngine) CreateOperatorGroup(data cli.OperatorGroupData, opts cli.OpenshiftOptions) (*operatorv1.OperatorGroup, error) {
 	return &operatorv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -206,6 +232,32 @@ func (foe BadOpenshiftEngine) GetNamespace(name string) (*corev1.Namespace, erro
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-ns",
 		},
+	}, nil
+}
+
+func (foe BadOpenshiftEngine) CreateSecret(name string, content map[string]string, secretType corev1.SecretType, opts cli.OpenshiftOptions) (*corev1.Secret, error) {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-image-secret",
+			Namespace: "test-ns",
+		},
+		Type:       "kubernetes.io/dockerconfigjson",
+		StringData: map[string]string{".dockerconfigjson": "secretData"},
+	}, nil
+}
+
+func (foe BadOpenshiftEngine) DeleteSecret(name string, opts cli.OpenshiftOptions) error {
+	return nil
+}
+
+func (foe BadOpenshiftEngine) GetSecret(name string, opts cli.OpenshiftOptions) (*corev1.Secret, error) {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-image-secret",
+			Namespace: "test-ns",
+		},
+		Type:       "kubernetes.io/dockerconfigjson",
+		StringData: map[string]string{".dockerconfigjson": "secretData"},
 	}, nil
 }
 

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var checkOperatorCmd = &cobra.Command{
@@ -38,6 +39,14 @@ var checkOperatorCmd = &cobra.Command{
 
 		if _, ok := os.LookupEnv("KUBECONFIG"); !ok {
 			return errors.ErrNoKubeconfig
+		}
+
+		if _, ok := os.LookupEnv("DOCKERCONFIG"); !ok {
+			return errors.ErrNoDockerconfig
+		}
+
+		if catalogImage := viper.GetString("indexImage"); len(catalogImage) == 0 {
+			return errors.ErrIndexImageUndefined
 		}
 
 		cfg := runtime.Config{

--- a/docs/BUILDING_AN_INDEX.md
+++ b/docs/BUILDING_AN_INDEX.md
@@ -48,6 +48,7 @@ accessible to Preflight as well as the target cluster.
 ```shell
 podman push registry.example.org/your-namespace/your-index:0.0.1
 ```
+If the index image is stored in a private repository, set the value of `DOCKERCONFIG` to the path of the docker configuration path.
 
 Finally, set the value of `PFLT_INDEXIMAGE` to this value and run preflight:
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -31,6 +31,7 @@ test asset by executing the following.
 ```bash
 export KUBECONFIG=/path/to/your/kubeconfig 
 export PFLT_INDEXIMAGE=registry.example.org/your-namespace/your-index-image:sometag
+export DOCKERCONFIG=~/.docker/config.json
 preflight check operator registry.example.org/your-namespace/your-bundle-image:sometag
 ```
 
@@ -58,6 +59,7 @@ $CONTAINER_TOOL run \
   --env KUBECONFIG=/kubeconfig \
   --env PFLT_LOGLEVEL=trace \
   --env PFLT_INDEXIMAGE=registry.example.org/your-namespace/your-index-image:sometag \
+  --env DOCKERCONFIG=~/.docker/config.json \
   --env PFLT_ARTIFACTS=/artifacts \
   --env PFLT_LOGFILE=/artifacts/preflight.log \
   -v /some/path/on/your/host/artifacts:/artifacts \
@@ -109,6 +111,8 @@ spec:
             value: trace
           - name: PFLT_INDEXIMAGE
             value: "registry.example.org/your-namespace/your-index-image:sometag"
+          - name: DOCKERCONFIG
+            value: "/root/.docker/config.json"
           - name: PFLT_LOGFILE
             value: "/artifacts/preflight.log"
           - name: PFLT_ARTIFACTS


### PR DESCRIPTION
This PR enables the preflight to work with the index images that are in private
registries. It introduces a new mandatory DOCKERCONFIG environment variable
which must point to the docker config file.

Fixes #245