### PR TITLE
Centralize container images used at runtime into a single place, and provide access functions and a relevant subcommand.

### DIFF
--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -143,28 +144,28 @@ func (o operatorSdkEngine) writeScorecardFile(resultFile, stdout string) error {
 }
 
 func createScorecardConfigFile() (string, error) {
-	configTemplate := `kind: Configuration
+	configTemplate := fmt.Sprintf(`kind: Configuration
 apiversion: scorecard.operatorframework.io/v1alpha3
 metadata:
   name: config
 stages:
 - parallel: true
   tests:
-  - image: quay.io/operator-framework/scorecard-test:v1.12.0
+  - image: %s
     entrypoint:
       - scorecard-test
       - basic-check-spec
     labels:
       suite: basic
       test: basic-check-spec-test
-  - image: quay.io/operator-framework/scorecard-test:v1.12.0
+  - image: %s
     entrypoint:
       - scorecard-test
       - olm-bundle-validation
     labels:
       suite: olm
       test: olm-bundle-validation-test
-`
+`, runtime.ScorecardImage(), runtime.ScorecardImage())
 
 	tempConfigFile, err := os.CreateTemp("", "scorecard-test-config-*.yaml")
 	if err != nil {

--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -1,0 +1,51 @@
+package runtime
+
+var (
+
+	// images maps the images use by preflight with their purpose.
+	//
+	// these should have accessor functions made available if they are
+	// to be used outside of this package.
+	//
+	// These images should also all be referenced using digests over tags
+	// to enable disconnected environments.
+	images = map[string]string{
+		// operator policy, operator-sdk scorecard
+		// quay.io/operator-framework/scorecard-test:v1.12.0
+		"scorecard": "quay.io/operator-framework/scorecard-test@sha256:d655333b0246f75ac9e5f6e67a2c04c506ae77b0c8b0c5eb70e6ddc8c2123e55",
+	}
+)
+
+// imageList takes the images mapping and represents them using just
+// the image URIs.
+func imageList() []string {
+	var imageList = make([]string, len(images))
+
+	i := 0
+	for _, image := range images {
+		imageList[i] = image
+		i++
+	}
+
+	return imageList
+}
+
+// Assets returns a full collection of assets used in Preflight.
+func Assets() AssetData {
+	return AssetData{
+		Images: imageList(),
+	}
+}
+
+// ScorecardImage returns the container image used for OperatorSDK
+// Scorecard based checks.
+func ScorecardImage() string {
+	return images["scorecard"]
+}
+
+// Assets is the publicly accessible representation of Preflight's
+// used assets. This struct will be serialized to JSON and presented
+// to the end-user when requested.
+type AssetData struct {
+	Images []string `json:"images"`
+}

--- a/cmd/runtime-assets.go
+++ b/cmd/runtime-assets.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/spf13/cobra"
+)
+
+var runtimeAssetsCmd = &cobra.Command{
+	Use:    "runtime-assets",
+	Short:  "Returns information about assets used at runtime.",
+	Long:   `This command will return information on all runtime assets used by preflight. Useful for preparing a disconnected environment intending to utilize preflight.`,
+	PreRun: preRunConfig,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		assets := runtime.Assets()
+
+		assetsJSON, err := json.MarshalIndent(assets, "", "    ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(assetsJSON))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runtimeAssetsCmd)
+}


### PR DESCRIPTION
Fixes #276

Disconnected environments need to know what images preflight might use to execute checks ahead of actual execution. Ideally, those in disconnected environments would want to provide their own scorecard configs (for example) so that they could rewrite the images, but we don't necessarily want that to change dynamically within preflight.

The compromise was that we'd expose exactly what assets we use at runtime (if any). Currently, I see our scorecard image is in scope, since we write that configuration. This PR just adds in a centralized management approach at the `runtime` package level for container images we use. The output looks something like this (today). 

```
$ ./preflight --version
preflight version 0.0.0 <commit: c53ff6816ff7c376ab682ad0dba3df4ccd693d32>

$ ./preflight runtime-assets
{
    "images": [
        "quay.io/operator-framework/scorecard-test@sha256:d655333b0246f75ac9e5f6e67a2c04c506ae77b0c8b0c5eb70e6ddc8c2123e55"
    ]
}
```

There are hooks into the runtime package that expose the images we use, and those hooks are used in our DeployableByOLM check to make sure we don't drift.