### PR TITLE
Extend docs on PFLT_DOCKERCONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,32 @@ preflight check operator quay.io/example-namespace/example-operator:0.0.1
 
 For more detailed usage examples, see [Recipes](docs/RECIPES.md).
 
+For more information on how to configure the execution of `preflight`, see
+[CONFIG](docs/CONFIG.md)
+
 ### Authenticating to Registries
 
 The `preflight` command will automatically utilize a credential file at
 `$DOCKER_CONFIG/config.json` (default: `~/.docker/config.json`) to access images
 in private registries.
+
+#### Remote Checks
+
+In some cases (e.g. *DeployableByOLM*), `preflight` will also pass credentials
+to the cluster used for testing (i.e. the cluster that is accessible through the
+current-context of the provided `KUBECONFIG`).
+
+We anticipate that the credentials in `$DOCKER_CONFIG/config.json` may contain
+more access than what is needed for `preflight` execution. To avoid passing more
+credentials than needed into a cluster for those checks, `preflight` will also
+accept a full path to a dockerconfigjson that should be passed through to a
+remote cluster via the `PFLT_DOCKERCONFIG` environment variable.
+
+If this variable is unset, `preflight` will assume that the images in scope
+(e.g. PFLT_INDEXIMAGE value, and the test target itself) are already accessible
+from the cluster used for testing.
+
+#### Podman Users
 
 [Podman](https://podman.io/) stores credentials at
 `${XDG_RUNTIME_DIR}/containers/auth.json`, which can also be used by executing
@@ -76,9 +97,6 @@ the following:
 ln -sf ${XDG_RUNTIME_DIR}/containers/auth.json ${XDG_RUNTIME_DIR}/containers/config.json
 DOCKER_CONFIG=${XDG_RUNTIME_DIR}/containers
 ```
-
-For more information on how to configure the execution of `preflight`, see
-[CONFIG](docs/CONFIG.md)
 
 ## Installation
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,6 +22,8 @@ is called.
 |`PFLT_NAMESPACE`|env|The namespace to use when running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/)|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L8)|
 |`PFLT_SERVICEACCOUNT`|env|The service account to use when running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/)|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L9)|
 |`PFLT_INDEXIMAGE`|env|The index image to use when testing that an operator is `DeployableByOLM`|required|-|
+|`PFLT_DOCKERCONFIG`|env|The full path to a dockerconfigjson file, which is pushed to the target test cluster to access images in private repositories in the `DeployableByOLM`. If empty, no secret is created and the resource is assumed to be public.|optional|-|
+
 
 For information on how to build an index image, see [BUILDING_AN_INDEX.md](BUILDING_AN_INDEX.md).
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -31,7 +31,6 @@ test asset by executing the following.
 ```bash
 export KUBECONFIG=/path/to/your/kubeconfig 
 export PFLT_INDEXIMAGE=registry.example.org/your-namespace/your-index-image:sometag
-export PFLT_DOCKERCONFIG=~/.docker/config.json
 preflight check operator registry.example.org/your-namespace/your-bundle-image:sometag
 ```
 
@@ -59,7 +58,6 @@ $CONTAINER_TOOL run \
   --env KUBECONFIG=/kubeconfig \
   --env PFLT_LOGLEVEL=trace \
   --env PFLT_INDEXIMAGE=registry.example.org/your-namespace/your-index-image:sometag \
-  --env PFLT_DOCKERCONFIG=~/.docker/config.json \
   --env PFLT_ARTIFACTS=/artifacts \
   --env PFLT_LOGFILE=/artifacts/preflight.log \
   -v /some/path/on/your/host/artifacts:/artifacts \
@@ -111,8 +109,6 @@ spec:
             value: trace
           - name: PFLT_INDEXIMAGE
             value: "registry.example.org/your-namespace/your-index-image:sometag"
-          - name: PFLT_DOCKERCONFIG
-            value: "/root/.docker/config.json"
           - name: PFLT_LOGFILE
             value: "/artifacts/preflight.log"
           - name: PFLT_ARTIFACTS


### PR DESCRIPTION
This PR extends the existing documentation on authenticating to private registries such that it's understood how the addition of PFLT_DOCKERCONFIG changes preflight's approach to pulling the image.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>