### PR TITLE
Remove tag from container when listing tags

### DIFF
--- a/certification/internal/policy/container/has_unique_tag.go
+++ b/certification/internal/policy/container/has_unique_tag.go
@@ -19,7 +19,12 @@ type HasUniqueTagCheck struct {
 }
 
 func (p *HasUniqueTagCheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	tags, err := p.getDataToValidate(imgRef.ImageURI)
+	cleanUri := imgRef.ImageURI
+	badCharIndex := strings.IndexAny(cleanUri, "@:")
+	if badCharIndex > -1 {
+		cleanUri = imgRef.ImageURI[:badCharIndex]
+	}
+	tags, err := p.getDataToValidate(cleanUri)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
When listing tags from a remote repository, Crane will throw an error if there
is already a tag on the URI (which makes sense, as we're trying to get a list
of tags!). This strips the tag before passing to Crane. Adds a unit test for
this.

Fixes #290

Signed-off-by: Brad P. Crochet <brad@redhat.com>