### PR TITLE
Remove check for label from UBI check

### DIFF
--- a/certification/internal/policy/container/base_on_ubi.go
+++ b/certification/internal/policy/container/base_on_ubi.go
@@ -49,20 +49,22 @@ func (p *BasedOnUBICheck) getOsReleaseContents(path string) ([]string, error) {
 }
 
 func (p *BasedOnUBICheck) validate(labels map[string]string, osRelease []string) (bool, error) {
-	var hasRHELID, hasRHELName, hasUbiComponentLabel bool
+	var hasRHELID, hasRHELName bool
 	for _, value := range osRelease {
-		if strings.HasPrefix(value, `ID="rhel"`) {
+		line := strings.Split(value, "=")
+		if line[0] == "ID" && line[1] == `"rhel"` {
+			log.Trace("Has RHEL ID")
 			hasRHELID = true
-		} else if strings.HasPrefix(value, `NAME="Red Hat Enterprise Linux"`) {
+			continue
+		}
+		if line[0] == "NAME" && line[1] == `"Red Hat Enterprise Linux"` {
+			log.Trace("Has RHEL Name")
 			hasRHELName = true
+			continue
 		}
 	}
 
-	if component, exists := labels["com.redhat.component"]; exists {
-		hasUbiComponentLabel = strings.Contains(component, "ubi")
-	}
-
-	if hasRHELID && hasRHELName && hasUbiComponentLabel {
+	if hasRHELID && hasRHELName {
 		return true, nil
 	}
 

--- a/certification/internal/policy/container/base_on_ubi_test.go
+++ b/certification/internal/policy/container/base_on_ubi_test.go
@@ -82,7 +82,7 @@ NAME="Red Hat Enterprise Linux"
 	})
 	Describe("Checking for UBI as a base", func() {
 		Context("When it is based on UBI", func() {
-			Context("and has the correct labels and os-release", func() {
+			Context("and has the correct os-release", func() {
 				It("should pass Validate", func() {
 					ok, err := basedOnUbiCheck.Validate(imageRef)
 					Expect(err).ToNot(HaveOccurred())
@@ -91,36 +91,10 @@ NAME="Red Hat Enterprise Linux"
 			})
 		})
 		Context("When it is not based on UBI", func() {
-			Context("and has the correct labels but bad os-release", func() {
+			Context("and has a bad os-release", func() {
 				JustBeforeEach(func() {
 					err := os.WriteFile(filepath.Join(imageRef.ImageFSPath, "etc", osrelease), []byte("Not a good file"), 0644)
 					Expect(err).ToNot(HaveOccurred())
-				})
-				It("should not pass Validate", func() {
-					ok, err := basedOnUbiCheck.Validate(imageRef)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(ok).To(BeFalse())
-				})
-			})
-			Context("and has does not have correct labels but good os-release", func() {
-				JustBeforeEach(func() {
-					fakeImage := fakecranev1.FakeImage{
-						ConfigFileStub: badLabelsConfigFile,
-					}
-					imageRef.ImageInfo = &fakeImage
-				})
-				It("should not pass Validate", func() {
-					ok, err := basedOnUbiCheck.Validate(imageRef)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(ok).To(BeFalse())
-				})
-			})
-			Context("and it is missing the correct label", func() {
-				JustBeforeEach(func() {
-					fakeImage := fakecranev1.FakeImage{
-						ConfigFileStub: missingUbiLableConfigFile,
-					}
-					imageRef.ImageInfo = &fakeImage
 				})
 				It("should not pass Validate", func() {
 					ok, err := basedOnUbiCheck.Validate(imageRef)


### PR DESCRIPTION
The check for the component label is not reliable. Remove for now. This
check eventually needs to be more robust, but for now it needs to just
check for the entries in os-release.

Fixes #289

Signed-off-by: Brad P. Crochet <brad@redhat.com>