### PR TITLE
Add check for image sources to DeployableByOLM

### DIFF
--- a/certification/internal/cli/openshift.go
+++ b/certification/internal/cli/openshift.go
@@ -52,4 +52,6 @@ type OpenshiftEngine interface {
 	GetSubscription(name string, opts OpenshiftOptions) (*operatorv1alpha1.Subscription, error)
 
 	GetCSV(name string, opts OpenshiftOptions) (*operatorv1alpha1.ClusterServiceVersion, error)
+
+	GetImages() (map[string]struct{}, error)
 }

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -7,6 +7,7 @@ import (
 
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
@@ -97,6 +98,19 @@ var _ = Describe("DeployableByOLMCheck", func() {
 			})
 		})
 	})
+	DescribeTable("Image Registry validation",
+		func(bundleImages []string, expected bool) {
+			ok := checkImageSource(bundleImages)
+			Expect(ok).To(Equal(expected))
+		},
+		Entry("registry.connect.dev.redhat.com", []string{"registry.connect.dev.redhat.com/"}, true),
+		Entry("registry.connect.qa.redhat.com", []string{"registry.connect.qa.redhat.com/"}, true),
+		Entry("registry.connect.stage.redhat.com", []string{"registry.connect.stage.redhat.com/"}, true),
+		Entry("registry.connect.redhat.com", []string{"registry.connect.redhat.com"}, true),
+		Entry("registry.redhat.io", []string{"registry.redhat.io"}, true),
+		Entry("registry.access.redhat.com", []string{"registry.access.redhat.com/ubi8/ubi"}, true),
+		Entry("quay.io", []string{"quay.io/rocrisp/preflight-operator-bundle:v1"}, false),
+	)
 	AfterEach(func() {
 		err := os.RemoveAll(imageRef.ImageFSPath)
 		Expect(err).ToNot(HaveOccurred())

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -213,6 +213,10 @@ func (foe FakeOpenshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*
 	}, nil
 }
 
+func (foe FakeOpenshiftEngine) GetImages() (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
 type BadOpenshiftEngine struct{}
 
 func (foe BadOpenshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOptions) (*corev1.Namespace, error) {
@@ -348,5 +352,9 @@ func (foe BadOpenshiftEngine) GetSubscription(name string, opts cli.OpenshiftOpt
 }
 
 func (foe BadOpenshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.ClusterServiceVersion, error) {
+	return nil, nil
+}
+
+func (foe BadOpenshiftEngine) GetImages() (map[string]struct{}, error) {
 	return nil, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
+	github.com/openshift/api v3.9.0+incompatible
 	github.com/operator-framework/api v0.10.1
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -660,6 +660,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
+github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
+github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/operator-framework/api v0.10.1 h1:2tBjIr4hRZ0iaJ4UuenVjocbo9xrJi1O409K/tlEddo=
 github.com/operator-framework/api v0.10.1/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
In order to check the image sources, we look for the diff in images in pods and
image streams, before and after the operator is deployed. This diff is then checked
for the sources to ensure they are from approved sources.

Signed-off-by: Brad P. Crochet <brad@redhat.com>