### PR TITLE
Add optional values if target is OpenShift 4.9 or greater

### DIFF
--- a/certification/internal/cli/operatorsdk.go
+++ b/certification/internal/cli/operatorsdk.go
@@ -34,6 +34,7 @@ type OperatorSdkBundleValidateOptions struct {
 	LogLevel        string
 	ContainerEngine string
 	Selector        []string
+	OptionalValues  map[string]string
 	OutputFormat    string
 	Verbose         bool
 }

--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -106,6 +106,11 @@ func (o operatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBund
 			cmdArgs = append(cmdArgs, "--select-optional", fmt.Sprintf("name=%s", selector))
 		}
 	}
+	if opts.OptionalValues != nil {
+		for key, value := range opts.OptionalValues {
+			cmdArgs = append(cmdArgs, "--optional-values", fmt.Sprintf("%s=%s", key, value))
+		}
+	}
 	if opts.Verbose {
 		cmdArgs = append(cmdArgs, "--verbose")
 	}

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -15,4 +15,7 @@ const (
 
 	// secretName is the K8s secret name which stores the auth keys for the private registry access
 	secretName = "registry-auth-keys"
+
+	// versionsKey is the OpenShift versions in annotations.yaml that lists the versions allowed for an operator
+	versionsKey = "com.redhat.openshift.versions"
 )

--- a/certification/internal/policy/operator/validate_operator_bundle.go
+++ b/certification/internal/policy/operator/validate_operator_bundle.go
@@ -1,6 +1,9 @@
 package operator
 
 import (
+	"strings"
+
+	"github.com/blang/semver"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
@@ -17,6 +20,8 @@ func NewValidateOperatorBundleCheck(operatorSdkEngine *cli.OperatorSdkEngine) *V
 		OperatorSdkEngine: *operatorSdkEngine,
 	}
 }
+
+const ocpVerV1beta1Unsupported = "4.9"
 
 func (p ValidateOperatorBundleCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
 	report, err := p.getDataToValidate(bundleRef.ImageFSPath)
@@ -35,6 +40,21 @@ func (p ValidateOperatorBundleCheck) getDataToValidate(imagePath string) (*cli.O
 		Verbose:         true,
 		ContainerEngine: "none",
 		OutputFormat:    "json-alpha1",
+	}
+
+	annotations, err := getAnnotationsFromBundle(imagePath)
+	if err != nil {
+		log.Errorf("unable to get annotations.yaml from the bundle")
+		return nil, err
+	}
+
+	if versions, ok := annotations[versionsKey]; ok {
+		// Check that the label range contains >= 4.9
+		if isTarget49OrGreater(versions) {
+			log.Debug("OpenShift 4.9 detected in annotations. Running with additional checks enabled.")
+			opts.OptionalValues = make(map[string]string)
+			opts.OptionalValues["k8s-version"] = "1.22"
+		}
 	}
 
 	return p.OperatorSdkEngine.BundleValidate(imagePath, opts)
@@ -56,6 +76,78 @@ func (p ValidateOperatorBundleCheck) validate(report *cli.OperatorSdkBundleValid
 		}
 	}
 	return report.Passed, nil
+}
+
+func isTarget49OrGreater(ocpLabelIndex string) bool {
+	semVerOCPV1beta1Unsupported, _ := semver.ParseTolerant(ocpVerV1beta1Unsupported)
+	// the OCP range informed cannot allow carry on to OCP 4.9+
+	beginsEqual := strings.HasPrefix(ocpLabelIndex, "=")
+	// It means that the OCP label is =OCP version
+	if beginsEqual {
+		version := cleanStringToGetTheVersionToParse(strings.Split(ocpLabelIndex, "=")[1])
+		verParsed, err := semver.ParseTolerant(version)
+		if err != nil {
+			log.Errorf("unable to parse the value (%s) on (%s)", version, ocpLabelIndex)
+			return false
+		}
+
+		if verParsed.GE(semVerOCPV1beta1Unsupported) {
+			return true
+		}
+		return false
+	}
+	indexRange := cleanStringToGetTheVersionToParse(ocpLabelIndex)
+	if len(indexRange) > 1 {
+		// Bare version
+		if !strings.Contains(indexRange, "-") {
+			verParsed, err := semver.ParseTolerant(indexRange)
+			if err != nil {
+				log.Error("unable to parse the version")
+				return false
+			}
+			if verParsed.GE(semVerOCPV1beta1Unsupported) {
+				return true
+			}
+		}
+
+		versions := strings.Split(indexRange, "-")
+		version := versions[0]
+		if len(versions) > 1 {
+			version = versions[1]
+			verParsed, err := semver.ParseTolerant(version)
+			if err != nil {
+				log.Error("unable to parse the version")
+				return false
+			}
+
+			if verParsed.GE(semVerOCPV1beta1Unsupported) {
+				return true
+			}
+			return false
+		}
+
+		verParsed, err := semver.ParseTolerant(version)
+		if err != nil {
+			log.Error("unable to parse the version")
+			return false
+		}
+
+		if semVerOCPV1beta1Unsupported.GE(verParsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanStringToGetTheVersionToParse will remove the expected characters for
+// we are able to parse the version informed.
+func cleanStringToGetTheVersionToParse(value string) string {
+	doubleQuote := "\""
+	singleQuote := "'"
+	value = strings.ReplaceAll(value, singleQuote, "")
+	value = strings.ReplaceAll(value, doubleQuote, "")
+	value = strings.ReplaceAll(value, "v", "")
+	return value
 }
 
 func (p ValidateOperatorBundleCheck) Name() string {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redhat-openshift-ecosystem/openshift-preflight
 go 1.16
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/google/go-containerregistry v0.6.0


### PR DESCRIPTION
Many deprecated APIs were removed in OpenShift 4.9 (k8s 1.22). There are
additional check in bundle validate to enforce this. This checks the target
version listed in the bundle, and enables additional checks if the target
is >= 4.9.

Fixes #295

Signed-off-by: Brad P. Crochet <brad@redhat.com>