### PR TITLE
Add support for internal registry

### DIFF
--- a/certification/internal/cli/openshift.go
+++ b/certification/internal/cli/openshift.go
@@ -4,6 +4,7 @@ import (
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 type OpenshiftOptions struct {
@@ -30,6 +31,13 @@ type OperatorGroupData struct {
 	TargetNamespaces []string
 }
 
+type RoleBindingData struct {
+	Name      string
+	Subjects  []string
+	Role      string
+	Namespace string
+}
+
 type OpenshiftEngine interface {
 	CreateNamespace(name string, opts OpenshiftOptions) (*corev1.Namespace, error)
 	DeleteNamespace(name string, opts OpenshiftOptions) error
@@ -54,4 +62,8 @@ type OpenshiftEngine interface {
 	GetCSV(name string, opts OpenshiftOptions) (*operatorv1alpha1.ClusterServiceVersion, error)
 
 	GetImages() (map[string]struct{}, error)
+
+	CreateRoleBinding(data RoleBindingData, opts OpenshiftOptions) (*rbacv1.RoleBinding, error)
+	GetRoleBinding(name string, opts OpenshiftOptions) (*rbacv1.RoleBinding, error)
+	DeleteRoleBinding(name string, opts OpenshiftOptions) error
 }

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -18,4 +18,16 @@ const (
 
 	// versionsKey is the OpenShift versions in annotations.yaml that lists the versions allowed for an operator
 	versionsKey = "com.redhat.openshift.versions"
+
+	// pipelineServiceAccount is the name of the service account which is used by the pipeline
+	pipelineServiceAccount = "pipeline"
+
+	// registryViewerRole is the name of the ClusterRole which is used by SA to view the image registry
+	registryViewerRole = "registry-viewer"
+
+	// imagePullerRole is the name of the ClusterRole which is used by SA to pull images from the image registry
+	imagePullerRole = "system:image-puller"
+
+	// openshiftMarketplaceNamespace is the project name for the default openshift marketplace
+	openshiftMarketplaceNamespace = "openshift-marketplace"
 )

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -98,6 +98,22 @@ var _ = Describe("DeployableByOLMCheck", func() {
 			})
 		})
 	})
+	Describe("When deploying an operator using OLM", func() {
+		Context("When index image is in a custom namespace and CSV has been created successfully", func() {
+			BeforeEach(func() {
+				os.Setenv("PFLT_INDEXIMAGE", "image-registry.openshift-image-registry.svc/namespace/indeximage:v0.0.0")
+				engine = FakeOpenshiftEngine{}
+				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine)
+			})
+
+			It("Should pass Validate", func() {
+				ok, err := deployableByOLMCheck.Validate(imageRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+	})
+
 	DescribeTable("Image Registry validation",
 		func(bundleImages []string, expected bool) {
 			ok := checkImageSource(bundleImages)

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -136,6 +137,62 @@ func (foe FakeOpenshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftO
 			TargetNamespaces: []string{"test-ns"},
 		},
 	}, nil
+}
+
+func (foe FakeOpenshiftEngine) CreateRoleBinding(data cli.RoleBindingData, opts cli.OpenshiftOptions) (*rbacv1.RoleBinding, error) {
+	subjectsObj := make([]rbacv1.Subject, 1)
+
+	subjectsObj[0] = rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "test-sa",
+		Namespace: "test-ns",
+	}
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "a namespace",
+		},
+		Subjects: subjectsObj,
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     "a role",
+		},
+	}, nil
+}
+
+func (foe FakeOpenshiftEngine) GetRoleBinding(name string, opts cli.OpenshiftOptions) (*rbacv1.RoleBinding, error) {
+	subjectsObj := make([]rbacv1.Subject, 1)
+
+	subjectsObj[0] = rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "test-sa",
+		Namespace: "test-ns",
+	}
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "a namespace",
+		},
+		Subjects: subjectsObj,
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     "a role",
+		},
+	}, nil
+}
+
+func (foe FakeOpenshiftEngine) DeleteRoleBinding(name string, opts cli.OpenshiftOptions) error {
+	return nil
 }
 
 func (foe FakeOpenshiftEngine) CreateCatalogSource(data cli.CatalogSourceData, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
@@ -357,4 +414,60 @@ func (foe BadOpenshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*o
 
 func (foe BadOpenshiftEngine) GetImages() (map[string]struct{}, error) {
 	return nil, nil
+}
+
+func (foe BadOpenshiftEngine) CreateRoleBinding(data cli.RoleBindingData, opts cli.OpenshiftOptions) (*rbacv1.RoleBinding, error) {
+	subjectsObj := make([]rbacv1.Subject, 1)
+
+	subjectsObj[0] = rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "test-sa",
+		Namespace: "test-ns",
+	}
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "a namespace",
+		},
+		Subjects: subjectsObj,
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     "a role",
+		},
+	}, nil
+}
+
+func (foe BadOpenshiftEngine) GetRoleBinding(name string, opts cli.OpenshiftOptions) (*rbacv1.RoleBinding, error) {
+	subjectsObj := make([]rbacv1.Subject, 1)
+
+	subjectsObj[0] = rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "test-sa",
+		Namespace: "test-ns",
+	}
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding",
+			Namespace: "a namespace",
+		},
+		Subjects: subjectsObj,
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     "a role",
+		},
+	}, nil
+}
+
+func (foe BadOpenshiftEngine) DeleteRoleBinding(name string, opts cli.OpenshiftOptions) error {
+	return nil
 }


### PR DESCRIPTION
Fixes #283

This PR addresses the problem of having index image in openshift internal registry. It creates six rolebinding in the index image namespace which grants the catalog pod the permission to view the image registry and pull the images.

The created rolebindings addresses all the following usecases:
* custom catalog sources
* default OperatorHub catalog sources
* preflight running in the pipeline