### PR TITLE
Add support for the RELEASE_TAG when building the binary

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -12,6 +12,8 @@ jobs:
       IMAGE_REGISTRY: quay.io/opdev
     steps:
     - uses: actions/checkout@v2
+    - name: Set Env Tags
+      run: echo RELEASE_TAG=$(git describe --tags --abbrev=0) >> $GITHUB_ENV
 
     - name: Build Image
       id: build-image
@@ -21,6 +23,7 @@ jobs:
         tags: ${{ github.sha }}
         build-args: |
           quay_expiration=1w
+          release_tag=${{ env.RELEASE_TAG }}-alpha+${{ github.sha }}
         dockerfiles: |
           ./Dockerfile
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         image: ${{ env.IMAGE_REGISTRY }}/preflight
         tags: ${{ env.RELEASE_TAG }}
+        build-args: |
+          release_tag=${{env.RELEASE_TAG }}
         dockerfiles: |
           ./Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 ARG quay_expiration=never
+ARG release_tag=0.0.0
 
 # golang:1.16 image created 2021-06-24T00:31:06.02014601Z 
 FROM docker.io/library/golang@sha256:be99fa59acd78bb22a41bbc1e15ebfab2262498ee0c2e28c3d09bc44d51d1774 AS builder
 ARG quay_expiration
+ARG release_tag
 
 # Build the preflight binary
 COPY . /go/src/preflight
 WORKDIR /go/src/preflight
-RUN make build
+RUN make build RELEASE_TAG=${release_tag}
 
 # ubi8:latest
 FROM registry.access.redhat.com/ubi8/ubi:latest


### PR DESCRIPTION
Currently, all builds (unless specified by the RELEASE_TAG envvar)
will just use 0.0.0 as the version. This patch will add support for
putting the correct version in the binary.

Fixes #305

Signed-off-by: Brad P. Crochet <brad@redhat.com>