### PR TITLE
Remove code that could exit preflight prematurely

### DIFF
--- a/certification/internal/client/catalogsource.go
+++ b/certification/internal/client/catalogsource.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"log"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	log "github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -102,10 +102,15 @@ func (c catalogSourceClient) convert(u *unstructured.Unstructured) (*operatorv1a
 func CatalogSourceClient(namespace string) (*catalogSourceClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not read kubeconfig")
+		return nil, err
+	}
+
 	controllerClient, err := client.New(kubeconfig, client.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatal(err)
+		log.Error("could not get catalog source client")
 		return nil, err
 	}
 

--- a/certification/internal/client/csv.go
+++ b/certification/internal/client/csv.go
@@ -2,11 +2,11 @@ package client
 
 import (
 	"context"
-	"log"
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,10 +60,15 @@ func (c csvClient) convert(u *unstructured.Unstructured) (*operatorv1alpha1.Clus
 func CsvClient(namespace string) (*csvClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
+
 	controllerClient, err := client.New(kubeconfig, client.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatal(err)
+		log.Error("could not get csv client")
 		return nil, err
 	}
 

--- a/certification/internal/client/operatorgroup.go
+++ b/certification/internal/client/operatorgroup.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"log"
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -12,6 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -99,10 +99,15 @@ func (c operatorGroupClient) convert(u *unstructured.Unstructured) (*operatorv1.
 func OperatorGroupClient(namespace string) (*operatorGroupClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
+
 	controllerClient, err := client.New(kubeconfig, client.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatal(err)
+		log.Error("could not get operator group client")
 		return nil, err
 	}
 

--- a/certification/internal/client/subscription.go
+++ b/certification/internal/client/subscription.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"log"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
@@ -10,6 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -102,10 +102,14 @@ func (c subscriptionClient) convert(u *unstructured.Unstructured) (*operatorv1al
 func SubscriptionClient(namespace string) (*subscriptionClient, error) {
 	scheme := runtime.NewScheme()
 	operatorv1alpha1.AddToScheme(scheme)
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
 	controllerClient, err := client.New(kubeconfig, client.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatal(err)
+		log.Error("could not get subscription client")
 		return nil, err
 	}
 

--- a/certification/internal/engine/openshift.go
+++ b/certification/internal/engine/openshift.go
@@ -29,7 +29,11 @@ func NewOpenshiftEngine() *cli.OpenshiftEngine {
 
 func (oe *openshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOptions) (*corev1.Namespace, error) {
 
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
@@ -60,7 +64,11 @@ func (oe *openshiftEngine) CreateNamespace(name string, opts cli.OpenshiftOption
 }
 
 func (oe *openshiftEngine) DeleteNamespace(name string, opts cli.OpenshiftOptions) error {
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
@@ -75,7 +83,11 @@ func (oe *openshiftEngine) DeleteNamespace(name string, opts cli.OpenshiftOption
 
 func (oe *openshiftEngine) GetNamespace(name string) (*corev1.Namespace, error) {
 
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
@@ -139,7 +151,11 @@ func (oe *openshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftOptio
 }
 
 func (oe openshiftEngine) CreateSecret(name string, content map[string]string, secretType corev1.SecretType, opts cli.OpenshiftOptions) (*corev1.Secret, error) {
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
@@ -174,7 +190,11 @@ func (oe openshiftEngine) CreateSecret(name string, content map[string]string, s
 }
 
 func (oe openshiftEngine) DeleteSecret(name string, opts cli.OpenshiftOptions) error {
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
@@ -188,7 +208,11 @@ func (oe openshiftEngine) DeleteSecret(name string, opts cli.OpenshiftOptions) e
 }
 
 func (oe openshiftEngine) GetSecret(name string, opts cli.OpenshiftOptions) (*corev1.Secret, error) {
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {
@@ -311,7 +335,11 @@ func (oe *openshiftEngine) GetCSV(name string, opts cli.OpenshiftOptions) (*oper
 }
 
 func (oe *openshiftEngine) GetImages() (map[string]struct{}, error) {
-	kubeconfig := ctrl.GetConfigOrDie()
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error("could not get kubeconfig")
+		return nil, err
+	}
 	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
 
 	if err != nil {


### PR DESCRIPTION
We don't want preflight to exit somewhere in the middle of a run. That
should only occur at the very top level, so that we don't end up with
partial results. This includes using GetConfigOrDie() for kubeconfig
and log.Fatal.

Fixes #309

Signed-off-by: Brad P. Crochet <brad@redhat.com>