### PR TITLE
Fix the version output in the action

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -12,8 +12,11 @@ jobs:
       IMAGE_REGISTRY: quay.io/opdev
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch latest release version
+      uses: reloc8/action-latest-release-version@1.0.0
+      id: fetch-latest-release
     - name: Set Env Tags
-      run: echo RELEASE_TAG=$(git describe --tags --abbrev=0) >> $GITHUB_ENV
+      run: echo RELEASE_TAG=${{ steps.fetch-latest-release.outputs.latest-release }} >> $GITHUB_ENV
 
     - name: Build Image
       id: build-image


### PR DESCRIPTION
Apparently, just calling git describe was too naive. Found an action step
that gets the latest release version.

Signed-off-by: Brad P. Crochet <brad@redhat.com>