### PR TITLE
Fixes #169 no artifacts/ created after operator-sdk scorecard fails

### DIFF
--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -73,6 +73,14 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 		if stderr.Len() != 0 {
 			log.Error("stdout: ", stdout.String())
 			log.Error("stderr: ", stderr.String())
+			log.Error("stderr: operator-sdk scorecard failed to run properly. " +
+				"Please review the " + artifacts.Path() + "/" + opts.ResultFile + " file for more information. ")
+
+			if err := o.writeScorecardFile(opts.ResultFile, stderr.String()); err != nil {
+				log.Error("unable to copy result to artifacts directory: ", err)
+				return nil, err
+			}
+
 			return nil, fmt.Errorf("%w: %s", errors.ErrOperatorSdkScorecardFailed, err)
 		}
 	}

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
 )
@@ -47,7 +48,8 @@ func (p *ScorecardBasicSpecCheck) Metadata() certification.Metadata {
 
 func (p *ScorecardBasicSpecCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Check ScorecardBasicSpecCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_BasicSpecCheck.json file for more information.",
+		Message: "Check ScorecardBasicSpecCheck encountered an error. Please review the " +
+			artifacts.Path() + "/" + scorecardBasicCheckResult + " file for more information.",
 		Suggestion: "Make sure that all CRs have a spec block",
 	}
 }

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
 )
@@ -47,7 +48,8 @@ func (p *ScorecardOlmSuiteCheck) Metadata() certification.Metadata {
 
 func (p *ScorecardOlmSuiteCheck) Help() certification.HelpText {
 	return certification.HelpText{
-		Message:    "Check ScorecardOlmSuiteCheck encountered an error. Please review the artifacts/operator_bundle_scorecard_OlmSuiteCheck.json file for more information.",
+		Message: "Check ScorecardOlmSuiteCheck encountered an error. Please review the " +
+			artifacts.Path() + "/" + scorecardOlmSuiteResult + " file for more information.",
 		Suggestion: "See scorecard output for details, artifacts/operator_bundle_scorecard_OlmSuiteCheck.json",
 	}
 }


### PR DESCRIPTION
The proposed code encapsulates stderr from operator-sdk scorecard to artifacts/<scorecard test run>.