### PR TITLE
Update operator-sdk to 1.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL quay.expires-after=${quay_expiration}
 
 # Define versions for dependencies
 ARG OPENSHIFT_CLIENT_VERSION=4.7.19
-ARG OPERATOR_SDK_VERSION=1.13.1
+ARG OPERATOR_SDK_VERSION=1.14.0
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.13.1         |
+| OperatorSDK      | `operator-sdk`    | v1.14.0         |
 | OpenShift Client | `oc`              | v4.7.19         |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.13.1
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.14.0
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -11,8 +11,8 @@ var (
 	// to enable disconnected environments.
 	images = map[string]string{
 		// operator policy, operator-sdk scorecard
-		// quay.io/operator-framework/scorecard-test:v1.13.1
-		"scorecard": "quay.io/operator-framework/scorecard-test@sha256:417d5157a782f72ba83cc613a0a3997cea088fe025c188121f782e93b38bf04e",
+		// quay.io/operator-framework/scorecard-test:v1.14.0
+		"scorecard": "quay.io/operator-framework/scorecard-test@sha256:66023c1e0f6021407811fb2b1d42aa16af6f41f2c791b2bdeb6ba696d000cf5d",
 	}
 )
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.13.1         |
+| OperatorSDK      | `operator-sdk`    | v1.14.0         |
 | OpenShift Client | `oc`              | v4.7.19         |
 | Podman           | `podman`          | v3.0            |
 


### PR DESCRIPTION
Closes #279 

Built preflight image quay.io/tkrishtop/preflight:busybox from this branch and tested it in disconnected env, the issue #279 is fixed.