### PR TITLE
remove operatorPkgNameIsUniqueCheck.Name check

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -87,10 +87,10 @@ var basedOnUbiCheck certification.Check = &containerpol.BasedOnUBICheck{}
 
 var operatorPolicy = map[string]certification.Check{
 	//operatorPkgNameIsUniqueCheck.Name(): operatorPkgNameIsUniqueCheck,
-	scorecardBasicSpecCheck.Name():      scorecardBasicSpecCheck,
-	scorecardOlmSuiteCheck.Name():       scorecardOlmSuiteCheck,
-	deployableByOlmCheck.Name():         deployableByOlmCheck,
-	validateOperatorBundle.Name():       validateOperatorBundle,
+	scorecardBasicSpecCheck.Name(): scorecardBasicSpecCheck,
+	scorecardOlmSuiteCheck.Name():  scorecardOlmSuiteCheck,
+	deployableByOlmCheck.Name():    deployableByOlmCheck,
+	validateOperatorBundle.Name():  validateOperatorBundle,
 }
 
 var containerPolicy = map[string]certification.Check{


### PR DESCRIPTION
Request to remove the operatorPkgNameIsUniqueCheck.Name check from the Operator Bundle check list.

