### PR TITLE
Ensure DeployableByOLM outputs the artifact in yaml manifest format

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -38,3 +38,4 @@ var ErrRemoveOSPIDFromProjectID = errors.New("please remove leading character os
 var ErrRemoveSpecialCharFromProjectID = errors.New("please remove all special characters from project id")
 var ErrPullRequestURL = errors.New("please enter a valid url: including scheme, host, and path to pull request")
 var ErrIndexImageUndefined = errors.New("no environment variable PFLT_INDEXIMAGE could be found")
+var ErrUnsupportedGoType = errors.New("go type unsupported")

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 func TestOperator(t *testing.T) {
@@ -136,6 +137,9 @@ func (foe FakeOpenshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftO
 		Spec: operatorv1.OperatorGroupSpec{
 			TargetNamespaces: []string{"test-ns"},
 		},
+		Status: operatorv1.OperatorGroupStatus{
+			LastUpdated: &metav1.Time{Time: time.Now()},
+		},
 	}, nil
 }
 
@@ -210,6 +214,10 @@ func (foe FakeOpenshiftEngine) DeleteCatalogSource(name string, opts cli.Openshi
 
 func (foe FakeOpenshiftEngine) GetCatalogSource(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
 	return &operatorv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cs",
+			Namespace: "test-ns",
+		},
 		Spec: operatorv1alpha1.CatalogSourceSpec{
 			SourceType: operatorv1alpha1.SourceTypeGrpc,
 			Image:      "indexImageUri",
@@ -347,11 +355,18 @@ func (foe BadOpenshiftEngine) GetOperatorGroup(name string, opts cli.OpenshiftOp
 		Spec: operatorv1.OperatorGroupSpec{
 			TargetNamespaces: []string{"test-ns"},
 		},
+		Status: operatorv1.OperatorGroupStatus{
+			LastUpdated: &metav1.Time{Time: time.Now()},
+		},
 	}, nil
 }
 
 func (foe BadOpenshiftEngine) CreateCatalogSource(data cli.CatalogSourceData, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
 	return &operatorv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cs",
+			Namespace: "test-ns",
+		},
 		Spec: operatorv1alpha1.CatalogSourceSpec{
 			SourceType: operatorv1alpha1.SourceTypeGrpc,
 			Image:      "indexImageUri",
@@ -365,6 +380,10 @@ func (foe BadOpenshiftEngine) DeleteCatalogSource(name string, opts cli.Openshif
 
 func (foe BadOpenshiftEngine) GetCatalogSource(name string, opts cli.OpenshiftOptions) (*operatorv1alpha1.CatalogSource, error) {
 	return &operatorv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cs",
+			Namespace: "test-ns",
+		},
 		Spec: operatorv1alpha1.CatalogSourceSpec{
 			SourceType: operatorv1alpha1.SourceTypeGrpc,
 			Image:      "indexImageUri",


### PR DESCRIPTION
* Fixes #313

This PR ensures that the artifacts created by DeployableByOLM is in
yaml manifest format, and could be manually inspected and created
by the consumers.