### PR TITLE
Adding extra trace logging to DeployableByOLM

### DIFF
--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -294,6 +294,7 @@ func (p *DeployableByOlmCheck) installedCSV(ctx context.Context, operatorData Op
 		for {
 			log.Debug("Waiting for Subscription.status.installedCSV to become ready...")
 			subs, _ := p.OpenshiftEngine.GetSubscription(ctx, operatorData.App, operatorData.InstallNamespace)
+			log.Trace(subs.Status)
 			installedCSV := subs.Status.InstalledCSV
 			// if the installedCSV field is present, stop the querying
 			if len(installedCSV) > 0 {


### PR DESCRIPTION
Adding extra trace logging to the DeploybleByOLM check.  When this check fails it can be tricky to diagnose the issue.  This extra logging provides a little more context and some extra clues. 