### PR TITLE
Enable preflight to support all Install modes

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -39,3 +39,4 @@ var ErrRemoveSpecialCharFromProjectID = errors.New("please remove all special ch
 var ErrPullRequestURL = errors.New("please enter a valid url: including scheme, host, and path to pull request")
 var ErrIndexImageUndefined = errors.New("no environment variable PFLT_INDEXIMAGE could be found")
 var ErrUnsupportedGoType = errors.New("go type unsupported")
+var ErrEmptyClusterServiceVersionFile = errors.New("the clusterserviceversion file was empty")

--- a/certification/internal/engine/openshift.go
+++ b/certification/internal/engine/openshift.go
@@ -316,7 +316,7 @@ func (oe *openshiftEngine) GetCSV(ctx context.Context, name string, namespace st
 		log.Error("unable to create a client for csv: ", err)
 		return nil, err
 	}
-	log.Debug(fmt.Sprintf("fetching csv %s from namespace %s ", name, namespace))
+	log.Debug(fmt.Sprintf("fetching csv %s from namespace %s", name, namespace))
 	return csvClient.Get(ctx, name)
 }
 

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -1,5 +1,11 @@
 package operator
 
+import (
+	"time"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
 const (
 	// packageKey is the packageKey in annotations.yaml that contains the package name.
 	packageKey = "operators.operatorframework.io.bundle.package.v1"
@@ -30,4 +36,32 @@ const (
 
 	// openshiftMarketplaceNamespace is the project name for the default openshift marketplace
 	openshiftMarketplaceNamespace = "openshift-marketplace"
+
+	// errorPrefix is the prefix used by goroutines to send error messages on the same channel as the data
+	errorPrefix = "error:"
+
+	// imageRegistryService is the service name of the image registry
+	imageRegistryService = "image-registry.openshift-image-registry.svc"
+)
+
+var (
+	subscriptionTimeout time.Duration = 180 * time.Second
+
+	csvTimeout time.Duration = 180 * time.Second
+
+	approvedRegistries = map[string]struct{}{
+		"registry.connect.dev.redhat.com":   {},
+		"registry.connect.qa.redhat.com":    {},
+		"registry.connect.stage.redhat.com": {},
+		"registry.connect.redhat.com":       {},
+		"registry.redhat.io":                {},
+		"registry.access.redhat.com":        {},
+	}
+
+	prioritizedInstallModes = []string{
+		string(operatorv1alpha1.InstallModeTypeOwnNamespace),
+		string(operatorv1alpha1.InstallModeTypeSingleNamespace),
+		string(operatorv1alpha1.InstallModeTypeMultiNamespace),
+		string(operatorv1alpha1.InstallModeTypeAllNamespaces),
+	}
 )


### PR DESCRIPTION
Fixes #293

This PR enables the preflight to support all install modes (namely OwnNamespace, SingleNamespace, MultiNamespace, AllNamespaces). In a nutshell, this PR:
* refactored watch method to use one channel to be used for errors as well as data. This enables the main goroutine to correctly identify if the check has passed or not
* creates a new namespace which will be used by SingleNamespace and MultiNamespace.
* Reads the operator installModes from csv file, stored on the bundle image
* Selects installModes from a prioritized list. The order is from the highest priority to the lowest is OwnNamespace, SingleNamespace, MultiNamespace, AllNamespaces
* Generates the TargetNamespace of the OperatorGroup based on the selected installmode
* Enquires the csv status from one of the namespace in TargetNamespaces in the case of OwnNamespace, SingleNamespace and MultiNamespace
* In the case of AllNamespaces, enquire the csv status from default, openshift-marketplace and operatorData.TargetNamespace