### PR TITLE
Show junit elapsed time as just seconds

### DIFF
--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -90,7 +90,7 @@ func junitXMLFormatter(r runtime.Results) ([]byte, error) {
 		totalDuration += result.ElapsedTime
 	}
 
-	testsuite.Time = totalDuration.String()
+	testsuite.Time = fmt.Sprintf("%f", totalDuration.Seconds())
 	suites.Suites = append(suites.Suites, testsuite)
 
 	bytes, err := xml.MarshalIndent(suites, "", "\t")


### PR DESCRIPTION
The junit format is expecting a float of seconds. Currently, it prints
a full string. This makes it just have the seconds, and nothing else.

Fixes #324

Signed-off-by: Brad P. Crochet <brad@redhat.com>