### PR TITLE
Fix the duration output for each check

### DIFF
--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -67,7 +67,7 @@ func junitXMLFormatter(r runtime.Results) ([]byte, error) {
 		testCase := JUnitTestCase{
 			Classname: response.Image,
 			Name:      result.Name(),
-			Time:      result.ElapsedTime.String(),
+			Time:      fmt.Sprintf("%f", result.ElapsedTime.Seconds()),
 			Failure:   nil,
 			Message:   result.Metadata().Description,
 		}


### PR DESCRIPTION
The total time was already fixed. This makes the time for each check
show correctly.

Fixes #324

Signed-off-by: Brad P. Crochet <brad@redhat.com>