### PR TITLE
Fix preflight release after the digest change for scorecard-test v1.14.0

### DIFF
--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -12,7 +12,7 @@ var (
 	images = map[string]string{
 		// operator policy, operator-sdk scorecard
 		// quay.io/operator-framework/scorecard-test:v1.14.0
-		"scorecard": "quay.io/operator-framework/scorecard-test@sha256:66023c1e0f6021407811fb2b1d42aa16af6f41f2c791b2bdeb6ba696d000cf5d",
+		"scorecard": "quay.io/operator-framework/scorecard-test@sha256:ff3ce0785e706185260a8308c0f40bae950fdba03cbb302fd002dddf3129b189",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Tatiana Krishtop <26544656+tkrishtop@users.noreply.github.com>

[Digest for scorecard-test v1.14.0 was changed 5 hours ago](https://quay.io/repository/operator-framework/scorecard-test?tab=tags).

[Opened an issue in the operator-sdk repository to prevent such situations in the future](https://github.com/operator-framework/operator-sdk/issues/5341).