### PR TITLE
Add multi-arch binary build capability

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Format
       run: make fmt
 
-    - name: Build
-      run: make build
+    - name: Build Multi-arch
+      run: make build-multi-arch
 
     - name: Test
       run: make test


### PR DESCRIPTION
	This commit adds a new target for
	building multi-arch preflight
	binaries:

	make build_multi_arch

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>