### PR TITLE
Increase the default wait time for scorecard tests

### DIFF
--- a/certification/internal/cli/operatorsdk.go
+++ b/certification/internal/cli/operatorsdk.go
@@ -8,6 +8,7 @@ type OperatorSdkScorecardOptions struct {
 	Namespace      string
 	ServiceAccount string
 	Verbose        bool
+	WaitTime       string
 }
 
 type OperatorSdkScorecardReport struct {
@@ -37,6 +38,7 @@ type OperatorSdkBundleValidateOptions struct {
 	OptionalValues  map[string]string
 	OutputFormat    string
 	Verbose         bool
+	WaitTime        string
 }
 
 type OperatorSdkBundleValidateReport struct {

--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -36,6 +36,9 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 	if opts.Kubeconfig != "" {
 		cmdArgs = append(cmdArgs, "--kubeconfig", opts.Kubeconfig)
 	}
+	if opts.WaitTime != "" {
+		cmdArgs = append(cmdArgs, "--wait-time", opts.WaitTime)
+	}
 	if opts.Namespace != "" {
 		cmdArgs = append(cmdArgs, "--namespace", opts.Namespace)
 	}

--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -42,6 +42,7 @@ func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string
 		Namespace:      namespace,
 		ServiceAccount: serviceAccount,
 		Verbose:        true,
+		WaitTime:       "120s",
 	}
 	return p.OperatorSdkEngine.Scorecard(bundleImage, opts)
 }


### PR DESCRIPTION
* Fixes #329

This PR introduces a new field for the scorecard runtime configuration.
Scorecard requires pulling the busybox image (among others). The default
wait time of 30s is not enough to pull the dependencies and run the check.
This PR increases the wait time to 120s.

Found a relevant issue on github:
https://github.com/operator-framework/operator-sdk/issues/4148