### PR TITLE
Modify runtime assets to dynamically pull the digest

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -23,6 +23,7 @@ is called.
 |`PFLT_SERVICEACCOUNT`|env|The service account to use when running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/)|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L9)|
 |`PFLT_INDEXIMAGE`|env|The index image to use when testing that an operator is `DeployableByOLM`|required|-|
 |`PFLT_DOCKERCONFIG`|env|The full path to a dockerconfigjson file, which is pushed to the target test cluster to access images in private repositories in the `DeployableByOLM`. If empty, no secret is created and the resource is assumed to be public.|optional|-|
+|`PFLT_SCORECARD_IMAGE`|env|A uri that points to the scorecard image digest, used in disconnected environments. It should only be used in a disconnected environment. Use `preflight runtime-assets` on a connected workstation to generate the digest that needs to be mirrored.|optional|-|
 
 
 For information on how to build an index image, see [BUILDING_AN_INDEX.md](BUILDING_AN_INDEX.md).


### PR DESCRIPTION
Instead of hard-coding the digest, this patch now pulls the digest dynamically
at runtime, when 'preflight runtime-assets' is run. The output would then be
used to mirror to a disconnected registry. Also, when preflight is run in a
disconnected cluster, this digest can be passed via PFLT_SCORECARD_IMAGE.

This predicates that the preflight runtime-assets be run on a connected host.
But because the image can be passed by envvar, preflight check operator can
be run on a disconnected cluster without having the sha hard-coded.

Signed-off-by: Brad P. Crochet <brad@redhat.com>