### PR TITLE
updating FATA string comparison to convert the error we get back from scorecard test

### DIFF
--- a/certification/internal/engine/operatorsdk.go
+++ b/certification/internal/engine/operatorsdk.go
@@ -73,16 +73,9 @@ func (o operatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecard
 		//
 		// We also conclude/assume that "FATA" being in stderr would indicate an error in the
 		// check execution itself.
-		if stderr.Len() != 0 && strings.Contains(stderr.String(), "FATA") {
-			log.Error("stdout: ", stdout.String())
+		if stderr.Len() != 0 && strings.Contains(strings.ToUpper(stderr.String()), "FATA") {
+			log.Error("operator-sdk scorecard failed to run properly.")
 			log.Error("stderr: ", stderr.String())
-			log.Error("stderr: operator-sdk scorecard failed to run properly. " +
-				"Please review the " + artifacts.Path() + "/" + opts.ResultFile + " file for more information. ")
-
-			if err := o.writeScorecardFile(opts.ResultFile, stderr.String()); err != nil {
-				log.Error("unable to copy result to artifacts directory: ", err)
-				return nil, err
-			}
 
 			return nil, fmt.Errorf("%w: %s", errors.ErrOperatorSdkScorecardFailed, err)
 		}


### PR DESCRIPTION
- Fixes: #355 
- updating comparison to convert to up upper case since `preflgiht` runs `operator-sdk` in a non-tty fashion and `preflight` receives `stderr` in a different format then running `operator-sdk` cmd directly.

Below are `preflight.log` entries from testing this by manually setting `--waittime 5s`
```
12-15T12:09:06-07:00" level=error msg="stdout: "
time="2021-12-15T12:09:07-07:00" level=error msg="stderr: time=\"2021-12-15T12:08:56-07:00\" level=debug msg=\"Debug logging is set\"\nError: error running tests context deadline exceeded\nUsage:\n  operator-sdk scorecard [flags]\n\nFlags:\n  -c, --config string            path to scorecard config file\n  -h, --help                     help for scorecard\n      --kubeconfig string        kubeconfig path\n  -L, --list                     Option to enable listing which tests are run\n  -n, --namespace string         namespace to run the test images in\n  -o, --output string            Output format for results. Valid values: text, json, xunit (default \"text\")\n  -l, --selector string          label selector to determine which tests are run\n  -s, --service-account string   Service account to use for tests (default \"default\")\n  -x, --skip-cleanup             Disable resource cleanup after tests are run\n  -b, --storage-image string     Storage image to be used by the Scorecard pod (default \"docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af\")\n  -t, --test-output string       Test output directory. (default \"test-output\")\n  -u, --untar-image string       Untar image to be used by the Scorecard pod (default \"registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7\")\n  -w, --wait-time duration       seconds to wait for tests to complete. Example: 35s (default 30s)\n\nGlobal Flags:\n      --plugins strings   plugin keys to be used for this subcommand execution\n      --verbose           Enable verbose logging\n\ntime=\"2021-12-15T12:09:01-07:00\" level=fatal msg=\"error running tests context deadline exceeded\"\n"
time="2021-12-15T12:09:10-07:00" level=error msg="stderr: operator-sdk scorecard failed to run properly. Please review the /Users/acornett/go/src/github.com/acornett21/openshift-preflight/artifacts/operator_bundle_scorecard_OlmSuiteCheck.json file for more information. "
```

Signed-off-by: Adam D. Cornett <adc@redhat.com>