### PR TITLE
adding in optional SCORECARD_WAIT_TIME env variable to pass to scorecard

### DIFF
--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -33,7 +34,9 @@ func (p *scorecardCheck) validate(items []cli.OperatorSdkScorecardItem) (bool, e
 func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string, resultFile string) (*cli.OperatorSdkScorecardReport, error) {
 	namespace := viper.GetString("namespace")
 	serviceAccount := viper.GetString("serviceaccount")
+	waitTime := viper.GetString("scorecard_wait_time")
 	kubeconfig := os.Getenv("KUBECONFIG")
+
 	opts := cli.OperatorSdkScorecardOptions{
 		OutputFormat:   "json",
 		Selector:       selector,
@@ -42,7 +45,7 @@ func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string
 		Namespace:      namespace,
 		ServiceAccount: serviceAccount,
 		Verbose:        true,
-		WaitTime:       "240s",
+		WaitTime:       fmt.Sprintf("%ss", waitTime),
 	}
 	return p.OperatorSdkEngine.Scorecard(bundleImage, opts)
 }

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -1,10 +1,11 @@
 package cmd
 
 var (
-	DefaultOutputFormat   = "json"
-	DefaultLogFile        = "preflight.log"
-	DefaultLogLevel       = "warn"
-	DefaultArtifactsDir   = "artifacts"
-	DefaultNamespace      = "default"
-	DefaultServiceAccount = "default"
+	DefaultOutputFormat      = "json"
+	DefaultLogFile           = "preflight.log"
+	DefaultLogLevel          = "warn"
+	DefaultArtifactsDir      = "artifacts"
+	DefaultNamespace         = "default"
+	DefaultServiceAccount    = "default"
+	DefaultScorecardWaitTime = "240"
 )

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -41,6 +41,9 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 	viper.SetDefault("namespace", DefaultNamespace)
 	viper.SetDefault("serviceaccount", DefaultServiceAccount)
 
+	// Set up scorecard wait time default
+	viper.SetDefault("scorecard_wait_time", DefaultScorecardWaitTime)
+
 	// set up logging
 	logname := viper.GetString("logfile")
 	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,6 +24,7 @@ is called.
 |`PFLT_INDEXIMAGE`|env|The index image to use when testing that an operator is `DeployableByOLM`|required|-|
 |`PFLT_DOCKERCONFIG`|env|The full path to a dockerconfigjson file, which is pushed to the target test cluster to access images in private repositories in the `DeployableByOLM`. If empty, no secret is created and the resource is assumed to be public.|optional|-|
 |`PFLT_SCORECARD_IMAGE`|env|A uri that points to the scorecard image digest, used in disconnected environments. It should only be used in a disconnected environment. Use `preflight runtime-assets` on a connected workstation to generate the digest that needs to be mirrored.|optional|-|
+|`PFLT_SCORECARD_WAIT_TIME`|env|A time value that will be passed to scorecard's `--wait-time` environment variable.|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L10)|
 |`PFLT_CHANNEL`|env|The name of the operator channel which is used by `DeployableByOLM` to deploy the operator. If empty, the default operator channel in bundle's annotations file is used.|optional|-|
 
 


### PR DESCRIPTION
- Fixes: #367 
- Adding in SCORECARD_WAIT_TIME so that if user's experience a timeout and preflight returns an error saying they can try to increase the timeout, this actually exposes that value so they can try again with an increased value before they raise an issue against preflight.
- Updated documentation

Signed-off-by: Adam D. Cornett <adc@redhat.com>