### PR TITLE
Introduce Pyxis Engine

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -40,3 +40,4 @@ var ErrPullRequestURL = errors.New("please enter a valid url: including scheme, 
 var ErrIndexImageUndefined = errors.New("no environment variable PFLT_INDEXIMAGE could be found")
 var ErrUnsupportedGoType = errors.New("go type unsupported")
 var ErrEmptyClusterServiceVersionFile = errors.New("the clusterserviceversion file was empty")
+var ErrInvalidPyxisHost = errors.New("invalid pyxis host specified")

--- a/certification/internal/engine/pyxis.go
+++ b/certification/internal/engine/pyxis.go
@@ -1,0 +1,11 @@
+package engine
+
+type pyxisEngine struct {
+	ApiToken string
+}
+
+func NewPyxisEngine(apiToken string) *pyxisEngine {
+	return &pyxisEngine{
+		ApiToken: apiToken,
+	}
+}

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var checkContainerCmd = &cobra.Command{
@@ -103,5 +104,8 @@ var checkContainerCmd = &cobra.Command{
 }
 
 func init() {
+	checkContainerCmd.Flags().String("pyxis-api-token", "", "API token for Pyxis authentication")
+	viper.BindPFlag("pyxis_api_token", checkContainerCmd.Flags().Lookup("pyxis-api-token"))
+
 	checkCmd.AddCommand(checkContainerCmd)
 }

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -8,4 +8,5 @@ var (
 	DefaultNamespace         = "default"
 	DefaultServiceAccount    = "default"
 	DefaultScorecardWaitTime = "240"
+	DefaultPyxisHost         = "catalog.redhat.com"
 )

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -44,6 +44,10 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 	// Set up scorecard wait time default
 	viper.SetDefault("scorecard_wait_time", DefaultScorecardWaitTime)
 
+	// Set up pyxis host
+	viper.SetDefault("pyxis_host", DefaultPyxisHost)
+	viper.SetDefault("pyxis_api_token", "")
+
 	// set up logging
 	logname := viper.GetString("logfile")
 	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,4 +32,10 @@ For information on how to build an index image, see [BUILDING_AN_INDEX.md](BUILD
 
 ## Container Policy Configuration
 
-There are no configurables specific to the container policy (i.e. when running `preflight check container ...`).
+These configurables are specific to cases where `preflight check container ...`
+is called.
+
+|Variable|Kind|Doc|Required or Optional|Default|
+|--|--|--|--|--|
+|`PFLT_PYXIS_HOST`|env|The Pyxis host to connect to|optional|pyxis.engineering.redhat.com|
+|`PFLT_PYXIS_API_TOKEN`|env|The API Token to be used when connecting to Pyxis. Used for authenticated calls only.|optional?|-|


### PR DESCRIPTION
This is the start of the Pyxis engine. It also adds support for a
PYXIS_HOST envvar, and a PYXIS_API_TOKEN envvar and CLI param.

The PyxisEngine should export useful methods to those that use it.
It is up to the user to create interfaces if necessary for testing
purposes.

Signed-off-by: Brad P. Crochet <brad@redhat.com>