### PR TITLE
Parameterize the IMAGE_REGISTRY in Actions

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -2,7 +2,7 @@ name: Build Main
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ghactions ]
 
 jobs:
   build-main:
@@ -12,8 +12,6 @@ jobs:
         architecture: [amd64,ppc64le,arm64,s390x]
         platform: [linux]
     runs-on: ubuntu-latest
-    env:
-      IMAGE_REGISTRY: quay.io/opdev
     steps:
     - uses: actions/checkout@v2
     - name: Fetch latest release version
@@ -31,7 +29,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/preflight
+        image: ${{ secrets.IMAGE_REGISTRY }}/preflight
         tags: ${{ env.SHA_SHORT }}-${{ matrix.platform }}-${{ matrix.architecture }}
         archs: ${{ matrix.architecture }}
         build-args: |
@@ -47,7 +45,7 @@ jobs:
       with:
         image: preflight
         tags: ${{ env.SHA_SHORT }}-${{ matrix.platform }}-${{ matrix.architecture }}
-        registry: ${{ env.IMAGE_REGISTRY }}
+        registry: ${{ secrets.IMAGE_REGISTRY }}
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+    branches: [ ghactions ]
 
 jobs:
   build-release:
@@ -13,8 +14,6 @@ jobs:
         architecture: [amd64,ppc64le,arm64,s390x]
         platform: [linux]
     runs-on: ubuntu-latest
-    env:
-      IMAGE_REGISTRY: quay.io/opdev
     steps:
     - uses: actions/checkout@v2
     - name: Set Env Tags
@@ -27,7 +26,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
-        image: ${{ env.IMAGE_REGISTRY }}/preflight
+        image: ${{ secrets.IMAGE_REGISTRY }}/preflight
         tags: ${{ env.RELEASE_TAG }}-${{ matrix.platform }}-${{ matrix.architecture }}
         archs: ${{ matrix.architecture }}
         build-args: |
@@ -42,7 +41,7 @@ jobs:
       with:
         image: preflight
         tags: ${{ env.RELEASE_TAG }}-${{ matrix.platform }}-${{ matrix.architecture }}
-        registry: ${{ env.IMAGE_REGISTRY }}
+        registry: ${{ secrets.IMAGE_REGISTRY }}
         username: ${{ secrets.REGISTRY_USER }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 


### PR DESCRIPTION
In order to make testing of actions more useful, this patch sets
the image registry based on the IMAGE_REGISTRY secret on the
current repository.

It also triggers on the 'ghactions' branch, which facilitates
using that branch to test changes to the CI without having to
modify the main repo.

Signed-off-by: Brad P. Crochet <brad@redhat.com>