### PR TITLE
test removing the s390 build

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and push main snapshot images
     strategy: 
       matrix:
-        architecture: [amd64,ppc64le,arm64,s390x]
+        architecture: [amd64,ppc64le,arm64]
         platform: [linux]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
a check to see if other archs are ok with being run as buildah builds in a matrix.