### PR TITLE
default pyxis host

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,5 +37,5 @@ is called.
 
 |Variable|Kind|Doc|Required or Optional|Default|
 |--|--|--|--|--|
-|`PFLT_PYXIS_HOST`|env|The Pyxis host to connect to|optional|pyxis.engineering.redhat.com|
+|`PFLT_PYXIS_HOST`|env|The Pyxis host to connect to|optional|catalog.redhat.com|
 |`PFLT_PYXIS_API_TOKEN`|env|The API Token to be used when connecting to Pyxis. Used for authenticated calls only.|optional?|-|


### PR DESCRIPTION
change the default host in the doc to match the host in the code: https://catalog.redhat.com/api/containers/v1/ui/#/