### PR TITLE
Make GetProject an exported method of PyxisEngine

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -59,7 +59,9 @@ func queryChecks(checkName string) certification.Check {
 	if check, exists := operatorPolicy[checkName]; exists {
 		return check
 	}
-	// if not found in Operator Policy, query container policy
+	// if not found in Operator Policy, query container policy.
+	// No need to check scratch container policy since this is
+	// a superset.
 	if check, exists := containerPolicy[checkName]; exists {
 		return check
 	}
@@ -105,6 +107,15 @@ var containerPolicy = map[string]certification.Check{
 	runnableContainerCheck.Name(): runnableContainerCheck,
 }
 
+var scratchContainerPolicy = map[string]certification.Check{
+	hasLicenseCheck.Name():        hasLicenseCheck,
+	hasUniqueTagCheck.Name():      hasUniqueTagCheck,
+	maxLayersCheck.Name():         maxLayersCheck,
+	hasRequiredLabelsCheck.Name(): hasRequiredLabelsCheck,
+	runAsRootCheck.Name():         runAsRootCheck,
+	runnableContainerCheck.Name(): runnableContainerCheck,
+}
+
 func makeCheckList(checkMap map[string]certification.Check) []string {
 	checks := make([]string, len(checkMap))
 	i := 0
@@ -123,4 +134,8 @@ func OperatorPolicy() []string {
 
 func ContainerPolicy() []string {
 	return makeCheckList(containerPolicy)
+}
+
+func ScratchContainerPolicy() []string {
+	return makeCheckList(scratchContainerPolicy)
 }

--- a/certification/pyxis/pyxis.go
+++ b/certification/pyxis/pyxis.go
@@ -27,7 +27,7 @@ type pyxisEngine struct {
 }
 
 func getPyxisUrl(path string) string {
-	return fmt.Sprintf("https://%s/%s/%s", viper.GetString("pyxis-host"), apiVersion, path)
+	return fmt.Sprintf("https://%s/%s/%s", viper.GetString("pyxis_host"), apiVersion, path)
 }
 
 func NewPyxisEngine(apiToken string, projectId string, httpClient HTTPClient) *pyxisEngine {

--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -2,34 +2,21 @@ package pyxis
 
 import (
 	"context"
-	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *pyxisEngine) SubmitResults(containerImage string) (*CertProject, *CertImage, error) {
+func (p *pyxisEngine) SubmitResults(certProject *CertProject) (*CertProject, *CertImage, error) {
+	var err error
 	ctx := context.Background()
-	projectId := p.ProjectId
-	if projectId == "" {
-		return nil, nil, errors.ErrEmptyProjectID
-	}
-	if strings.HasPrefix(projectId, "ospid-") {
-		projectId = strings.Split(projectId, "-")[1]
-	}
-	project, err := p.GetProject(ctx)
-	if err != nil {
-		log.Error(err, "could not retrieve project")
-		return nil, nil, err
-	}
-	oldProject := project
+	oldProject := certProject
 
-	if project.CertificationStatus == "Started" {
-		project.CertificationStatus = "In Progress"
+	if certProject.CertificationStatus == "Started" {
+		certProject.CertificationStatus = "In Progress"
 	}
 
-	if project != oldProject {
-		project, err = p.updateProject(ctx, projectId, project)
+	if certProject != oldProject {
+		certProject, err = p.updateProject(ctx, p.ProjectId, certProject)
 		if err != nil {
 			log.Error(err, "could not update project")
 			return nil, nil, err
@@ -50,5 +37,5 @@ func (p *pyxisEngine) SubmitResults(containerImage string) (*CertProject, *CertI
 		return nil, nil, err
 	}
 
-	return project, certImage, nil
+	return certProject, certImage, nil
 }

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Pyxis Submit", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, err := pyxisEngine.SubmitResults("foo/container")
+				certProject, certImage, err := pyxisEngine.SubmitResults(&CertProject{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certProject).ToNot(BeNil())
 				Expect(certImage).ToNot(BeNil())

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -66,6 +66,7 @@ type CertProject struct {
 	Name                string    `json:"name"`                      // required
 	ProjectStatus       string    `json:"project_status"`            // required
 	Type                string    `json:"type" default:"Containers"` // required
+	OsContentType       string    `json:"os_content_type,omitempty"`
 }
 
 type Container struct {


### PR DESCRIPTION
Since we will need to check the os-content-type of the project
to determine which checks will be run, GetProject needs to be
exported, and called early in the execution of preflight check
container.

Signed-off-by: Brad P. Crochet <brad@redhat.com>