### PR TITLE
Implement RunAsSystemContainer Check

### DIFF
--- a/certification/defaults.go
+++ b/certification/defaults.go
@@ -4,4 +4,5 @@ var (
 	DefaultCertImageFilename   = "cert-image.json"
 	DefaultRPMManifestFilename = "rpm-manifest.json"
 	DefaultTestResultsFilename = "results.json"
+	SystemdDir                 = "/etc/systemd/system"
 )

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -87,6 +87,7 @@ var hasRequiredLabelsCheck certification.Check = &containerpol.HasRequiredLabels
 var runAsRootCheck certification.Check = &containerpol.RunAsNonRootCheck{}
 var basedOnUbiCheck certification.Check = &containerpol.BasedOnUBICheck{}
 var runnableContainerCheck certification.Check = containerpol.NewRunnableContainerCheck(internal.NewPodmanEngine())
+var runSystemContainerCheck certification.Check = containerpol.NewRunSystemContainerCheck(internal.NewPodmanEngine())
 
 var operatorPolicy = map[string]certification.Check{
 	//operatorPkgNameIsUniqueCheck.Name(): operatorPkgNameIsUniqueCheck,
@@ -97,14 +98,15 @@ var operatorPolicy = map[string]certification.Check{
 }
 
 var containerPolicy = map[string]certification.Check{
-	hasLicenseCheck.Name():        hasLicenseCheck,
-	hasUniqueTagCheck.Name():      hasUniqueTagCheck,
-	maxLayersCheck.Name():         maxLayersCheck,
-	hasNoProhibitedCheck.Name():   hasNoProhibitedCheck,
-	hasRequiredLabelsCheck.Name(): hasRequiredLabelsCheck,
-	runAsRootCheck.Name():         runAsRootCheck,
-	basedOnUbiCheck.Name():        basedOnUbiCheck,
-	runnableContainerCheck.Name(): runnableContainerCheck,
+	hasLicenseCheck.Name():         hasLicenseCheck,
+	hasUniqueTagCheck.Name():       hasUniqueTagCheck,
+	maxLayersCheck.Name():          maxLayersCheck,
+	hasNoProhibitedCheck.Name():    hasNoProhibitedCheck,
+	hasRequiredLabelsCheck.Name():  hasRequiredLabelsCheck,
+	runAsRootCheck.Name():          runAsRootCheck,
+	basedOnUbiCheck.Name():         basedOnUbiCheck,
+	runnableContainerCheck.Name():  runnableContainerCheck,
+	runSystemContainerCheck.Name(): runSystemContainerCheck,
 }
 
 var scratchContainerPolicy = map[string]certification.Check{

--- a/certification/internal/cli/podman.go
+++ b/certification/internal/cli/podman.go
@@ -14,8 +14,9 @@ type PodmanOutput struct {
 }
 
 type PodmanCreateOption struct {
-	Entrypoint []string
-	Cmd        []string
+	Entrypoint    []string
+	Cmd           []string
+	ContainerName string
 }
 
 type ImagePullOptions struct {
@@ -39,9 +40,11 @@ type InspectContainerConfig struct {
 }
 
 type PodmanEngine interface {
-	PullImage(imageURI string, options ImagePullOptions) (*PodmanOutput, error)
 	CreateContainer(imageURI string, createOptions PodmanCreateOption) (*PodmanCreateOutput, error)
 	StartContainer(nameOrId string) (*PodmanOutput, error)
 	RemoveContainer(containerId string) error
 	WaitContainer(containerId string, waitOptions WaitOptions) (bool, error)
+	RunSystemContainer(containerName string) (*PodmanOutput, error)
+	IsSystemContainerRunning(serviceName string) (bool, error)
+	StopSystemContainer(serviceName string) error
 }

--- a/certification/internal/engine/podman.go
+++ b/certification/internal/engine/podman.go
@@ -4,11 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
+	"os"
+	exec "os/exec"
+	"regexp"
 	"strings"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	runAsPrivileged = true
 )
 
 type podmanEngine struct{}
@@ -18,52 +25,18 @@ func NewPodmanEngine() *cli.PodmanEngine {
 	return &engine
 }
 
-func (p *podmanEngine) PullImage(imageURI string, options cli.ImagePullOptions) (*cli.PodmanOutput, error) {
-	log.Debug(fmt.Sprintf("Pulling image %s from repository", imageURI))
-	cmdArgs := []string{"pull"}
-
-	if options.Quiet {
-		cmdArgs = append(cmdArgs, "--quiet")
-	}
-
-	cmdArgs = append(cmdArgs, imageURI)
-
-	cmd := exec.Command("podman", cmdArgs...)
-
-	log.Debugf("Command being run: %+v", cmd)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		log.Error(fmt.Sprintf("unable to pull image %s: ", imageURI), err)
-		log.Error("Stderr: ", stderr.String())
-		return &cli.PodmanOutput{
-			Stderr: stderr.String(),
-		}, err
-	}
-	log.Debug(fmt.Sprintf("Successfully pulled image %s from repository", imageURI))
-	return &cli.PodmanOutput{
-		Stdout: stdout.String(),
-	}, nil
-}
-
 func (p *podmanEngine) CreateContainer(imageURI string, createOptions cli.PodmanCreateOption) (*cli.PodmanCreateOutput, error) {
 	log.Debug(fmt.Sprintf("Creating container %s with the run options: %+v", imageURI, createOptions))
 
-	if _, err := p.PullImage(imageURI, cli.ImagePullOptions{Quiet: true}); err != nil {
-		return nil, err
-	}
 	cmdArgs := []string{"create"}
-
 	if len(createOptions.Entrypoint) > 0 {
 		cmdArgs = append(cmdArgs, "--entrypoint")
 		cmdArgs = append(cmdArgs, createOptions.Entrypoint...)
 	}
-
+	if len(createOptions.ContainerName) > 0 {
+		cmdArgs = append(cmdArgs, "--name", createOptions.ContainerName)
+	}
 	cmdArgs = append(cmdArgs, imageURI)
-
 	if len(createOptions.Cmd) > 0 {
 		cmdArgs = append(cmdArgs, createOptions.Cmd...)
 	}
@@ -134,8 +107,7 @@ func (p *podmanEngine) RemoveContainer(containerId string) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		log.Error(fmt.Sprintf("unable to remove container %s: ", containerId), err)
-		log.Error("Stderr: ", stderr.String())
+		log.Debug("Stderr: ", stderr.String())
 		return err
 	}
 	return nil
@@ -176,4 +148,134 @@ func (p *podmanEngine) WaitContainer(containerId string, waitOptions cli.WaitOpt
 
 	log.Info("container reached a running state")
 	return true, nil
+}
+
+func (p *podmanEngine) RunSystemContainer(containerName string) (*cli.PodmanOutput, error) {
+	log.Debug(fmt.Sprintf("Generating Systemd file for container %s", containerName))
+	cmdArgs := []string{"generate", "systemd", "--new", "--files", "--name", containerName}
+
+	output, err := RunCommand(!runAsPrivileged, "podman", cmdArgs)
+
+	if err != nil {
+		return output, err
+	}
+	serviceFilepath := strings.TrimSpace(output.Stdout)
+
+	r, err := regexp.Compile(".*/(.+.service)")
+	if err != nil {
+		log.Error("unable to fetch the name of the systemd service: ", err)
+		return &cli.PodmanOutput{
+			Stderr: err.Error(),
+		}, err
+	}
+	serviceName := r.FindStringSubmatch(serviceFilepath)[1]
+
+	// copy the unit file from working dir to systemd dir
+	_, err = copyFile(runAsPrivileged, serviceFilepath, certification.SystemdDir)
+	defer os.Remove(serviceFilepath)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("unable to copy the unit file into the systemd dir %s: ", certification.SystemdDir), err)
+		return &cli.PodmanOutput{
+			Stderr: err.Error(),
+		}, err
+	}
+
+	log.Debug(fmt.Sprintf("Reloading daemon set and start the service %s", serviceName))
+
+	if output, err = RunCommand(runAsPrivileged, "systemctl", []string{"daemon-reload"}); err != nil {
+		log.Error("unable to reaload the daemon set: ", err)
+		log.Error("Stderr: ", output.Stderr)
+		// remove the service file
+		RunCommand(runAsPrivileged, "rm", []string{"-f", fmt.Sprintf("%s/%s", certification.SystemdDir, serviceName)})
+
+		return &cli.PodmanOutput{
+			Stderr: output.Stderr,
+		}, err
+	}
+	if output, err = RunCommand(runAsPrivileged, "systemctl", []string{"start", serviceName}); err != nil {
+		log.Error(fmt.Sprintf("unable to start the service %s: ", serviceName), err)
+		log.Error("Stderr: ", output.Stderr)
+		// remove the service file
+		RunCommand(runAsPrivileged, "rm", []string{"-f", fmt.Sprintf("%s/%s", certification.SystemdDir, serviceName)})
+
+		return &cli.PodmanOutput{
+			Stderr: output.Stderr,
+		}, err
+	}
+
+	return &cli.PodmanOutput{
+		Stdout: serviceName,
+	}, nil
+}
+
+func (p *podmanEngine) IsSystemContainerRunning(serviceName string) (bool, error) {
+	log.Debug("Checking the service status of ", serviceName)
+
+	output, err := RunCommand(runAsPrivileged, "systemctl", []string{"is-active", serviceName})
+	if err != nil {
+		log.Error(fmt.Sprintf("unable to check the status of the service %s: ", serviceName), err)
+		log.Error("Stderr: ", output.Stderr)
+		return false, err
+	}
+	serviceStatus := strings.TrimSpace(output.Stdout)
+	log.Debug(fmt.Sprintf("The %s status is %s", serviceName, serviceStatus))
+	return strings.ToLower(serviceStatus) == "active", nil
+}
+
+func (p *podmanEngine) StopSystemContainer(serviceName string) error {
+	log.Debug("Stopping the container service ", serviceName)
+
+	if output, err := RunCommand(runAsPrivileged, "systemctl", []string{"stop", serviceName}); err != nil {
+		log.Error(fmt.Sprintf("unable to start the service %s: ", serviceName), err)
+		log.Error("Stderr: ", output.Stderr)
+		return err
+	}
+
+	if output, err := RunCommand(runAsPrivileged, "systemctl", []string{"daemon-reload"}); err != nil {
+		log.Error("unable to reaload the daemon set: ", err)
+		log.Error("Stderr: ", output.Stderr)
+		return err
+	}
+	log.Debug("Successfully stopped the container service ", serviceName)
+	return nil
+}
+
+func copyFile(isPrivileged bool, src string, dst string) (int64, error) {
+	log.Debug(fmt.Sprintf("Copying %s into %s", src, dst))
+
+	if _, err := RunCommand(isPrivileged, "cp", []string{src, dst}); err != nil {
+		log.Error(fmt.Sprintf("failed to copy %s to %s", src, dst))
+		return -1, err
+	}
+	log.Debug(fmt.Sprintf("Successfully copied %s to %s", src, dst))
+	return 0, nil
+}
+
+func RunCommand(isPrivileged bool, command string, args []string) (*cli.PodmanOutput, error) {
+	var cmd *exec.Cmd
+
+	if isPrivileged {
+		cmdArgs := "sudo " + command + " " + strings.Join(args, " ")
+		cmd = exec.Command("sh", "-c", cmdArgs)
+	} else {
+		cmd = exec.Command(command, args...)
+	}
+
+	log.Debugf("Command being run: %+v", cmd)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		log.Error(fmt.Sprintf("unable to run command %+v ", command), err)
+		log.Error("Stderr: ", stderr.String())
+		return &cli.PodmanOutput{
+			Stderr: stderr.String(),
+		}, err
+	}
+	return &cli.PodmanOutput{
+		Stdout: stdout.String(),
+	}, nil
 }

--- a/certification/internal/policy/container/container_suite_test.go
+++ b/certification/internal/policy/container/container_suite_test.go
@@ -51,10 +51,6 @@ func (fl FakeLayer) MediaType() (types.MediaType, error) {
 
 type GoodPodmanEngine struct{}
 
-func (pe GoodPodmanEngine) PullImage(imageURI string, options cli.ImagePullOptions) (*cli.PodmanOutput, error) {
-	return &cli.PodmanOutput{}, nil
-}
-
 func (pe GoodPodmanEngine) CreateContainer(imageURI string, createOptions cli.PodmanCreateOption) (*cli.PodmanCreateOutput, error) {
 	return &cli.PodmanCreateOutput{
 		ContainerId: "containerId",
@@ -73,11 +69,19 @@ func (p GoodPodmanEngine) WaitContainer(containerId string, waitOptions cli.Wait
 	return true, nil
 }
 
-type BadPodmanEngine struct{}
-
-func (pe BadPodmanEngine) PullImage(imageURI string, options cli.ImagePullOptions) (*cli.PodmanOutput, error) {
+func (p GoodPodmanEngine) RunSystemContainer(containerName string) (*cli.PodmanOutput, error) {
 	return &cli.PodmanOutput{}, nil
 }
+
+func (p GoodPodmanEngine) IsSystemContainerRunning(serviceName string) (bool, error) {
+	return true, nil
+}
+
+func (p GoodPodmanEngine) StopSystemContainer(serviceName string) error {
+	return nil
+}
+
+type BadPodmanEngine struct{}
 
 func (pe BadPodmanEngine) CreateContainer(imageURI string, createOptions cli.PodmanCreateOption) (*cli.PodmanCreateOutput, error) {
 	return &cli.PodmanCreateOutput{
@@ -95,4 +99,16 @@ func (p BadPodmanEngine) RemoveContainer(containerId string) error {
 
 func (p BadPodmanEngine) WaitContainer(containerId string, waitOptions cli.WaitOptions) (bool, error) {
 	return false, errors.New("the container wait had failed")
+}
+
+func (p BadPodmanEngine) RunSystemContainer(containerName string) (*cli.PodmanOutput, error) {
+	return &cli.PodmanOutput{}, nil
+}
+
+func (p BadPodmanEngine) IsSystemContainerRunning(serviceName string) (bool, error) {
+	return false, nil
+}
+
+func (p BadPodmanEngine) StopSystemContainer(serviceName string) error {
+	return nil
 }

--- a/certification/internal/policy/container/run_system_container.go
+++ b/certification/internal/policy/container/run_system_container.go
@@ -1,0 +1,80 @@
+package container
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	log "github.com/sirupsen/logrus"
+)
+
+// RunSystemContainerCheck runs a container as a systemd service
+// and ensures that the service is up and running.
+type RunSystemContainerCheck struct {
+	PodmanEngine cli.PodmanEngine
+}
+
+func NewRunSystemContainerCheck(podmanEngine *cli.PodmanEngine) *RunSystemContainerCheck {
+	return &RunSystemContainerCheck{
+		PodmanEngine: *podmanEngine,
+	}
+}
+
+func (p *RunSystemContainerCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	containerName := "podman-test"
+
+	runOptions := &cli.PodmanCreateOption{
+		ContainerName: containerName,
+	}
+
+	createOutput, err := p.PodmanEngine.CreateContainer(imgRef.ImageURI, *runOptions)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := p.PodmanEngine.RemoveContainer(containerName); err != nil {
+			log.Warn(fmt.Sprintf("unable to remove container %s: ", createOutput.ContainerId), err)
+		}
+	}()
+
+	podmanOutput, err := p.PodmanEngine.RunSystemContainer(containerName)
+	if err != nil {
+		return false, err
+	}
+
+	serviceName := podmanOutput.Stdout
+	defer func() {
+		if err := p.PodmanEngine.StopSystemContainer(serviceName); err != nil {
+			log.Warn(fmt.Sprintf("unable to stop service %s: ", serviceName), err)
+		}
+		os.Remove(fmt.Sprintf("%s/%s", certification.SystemdDir, serviceName))
+	}()
+
+	status, err := p.PodmanEngine.IsSystemContainerRunning(serviceName)
+	if err != nil {
+		return false, err
+	}
+
+	return status, nil
+}
+
+func (p *RunSystemContainerCheck) Name() string {
+	return "RunSystemContainer"
+}
+
+func (p *RunSystemContainerCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checking if a container can run as a systemd service",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *RunSystemContainerCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check RunSystemContainer encountered an error. Please review the preflight.log file for more information.",
+		Suggestion: "Ensure that the container can be launched as a systemd service",
+	}
+}

--- a/certification/internal/policy/container/run_system_container_test.go
+++ b/certification/internal/policy/container/run_system_container_test.go
@@ -1,0 +1,43 @@
+package container
+
+import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+)
+
+var _ = Describe("RunSystemContainerCheck", func() {
+	var (
+		engine                  cli.PodmanEngine
+		runSystemContainerCheck RunSystemContainerCheck
+		imageRef                certification.ImageReference
+	)
+
+	BeforeEach(func() {
+		imageRef.ImageURI = "test-image:test-tag"
+	})
+
+	Describe("Checking that the container can run as a systemd service", func() {
+		Context("When container service starts successfully", func() {
+			It("should pass Validate", func() {
+				engine = GoodPodmanEngine{}
+				runSystemContainerCheck = *NewRunSystemContainerCheck(&engine)
+				ok, err := runSystemContainerCheck.Validate(imageRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When container service does not start successfully", func() {
+			It("should not pass Validate", func() {
+				engine = BadPodmanEngine{}
+				runSystemContainerCheck = *NewRunSystemContainerCheck(&engine)
+				ok, err := runSystemContainerCheck.Validate(imageRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
This check ensures that a container can start as a Systemd service.
Ref: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_porting-containers-to-systemd-using-podman_building-running-and-managing-containers

* Fixes #374