### PR TITLE
Changes uses of make to be more idiomatic Go

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -30,8 +30,8 @@ func NewForConfig(config runtime.Config) (CheckEngine, error) {
 		return nil, errors.ErrNoChecksEnabled
 	}
 
-	checks := make([]certification.Check, len(config.EnabledChecks))
-	for i, checkString := range config.EnabledChecks {
+	checks := make([]certification.Check, 0, len(config.EnabledChecks))
+	for _, checkString := range config.EnabledChecks {
 		check := queryChecks(checkString)
 		if check == nil {
 			err := fmt.Errorf("%w: %s",
@@ -40,7 +40,7 @@ func NewForConfig(config runtime.Config) (CheckEngine, error) {
 			return nil, err
 		}
 
-		checks[i] = check
+		checks = append(checks, check)
 	}
 
 	engine := &internal.CraneEngine{
@@ -106,12 +106,10 @@ var containerPolicy = map[string]certification.Check{
 }
 
 func makeCheckList(checkMap map[string]certification.Check) []string {
-	checks := make([]string, len(checkMap))
-	i := 0
+	checks := make([]string, 0, len(checkMap))
 
-	for key := range checkMap {
-		checks[i] = key
-		i++
+	for key, _ := range checkMap {
+		checks = append(checks, key)
 	}
 
 	return checks

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -8,23 +8,23 @@ import (
 // getResponse will extract the runtime's results and format it to fit the
 // UserResponse definition in a way that can then be formatted.
 func getResponse(r runtime.Results) UserResponse {
-	passedChecks := make([]checkExecutionInfo, len(r.Passed))
-	failedChecks := make([]checkExecutionInfo, len(r.Failed))
-	erroredChecks := make([]checkExecutionInfo, len(r.Errors))
+	passedChecks := make([]checkExecutionInfo, 0, len(r.Passed))
+	failedChecks := make([]checkExecutionInfo, 0, len(r.Failed))
+	erroredChecks := make([]checkExecutionInfo, 0, len(r.Errors))
 
 	if len(r.Passed) > 0 {
-		for i, check := range r.Passed {
-			passedChecks[i] = checkExecutionInfo{
+		for _, check := range r.Passed {
+			passedChecks = append(passedChecks, checkExecutionInfo{
 				Name:        check.Name(),
 				ElapsedTime: float64(check.ElapsedTime.Milliseconds()),
 				Description: check.Metadata().Description,
-			}
+			})
 		}
 	}
 
 	if len(r.Failed) > 0 {
-		for i, check := range r.Failed {
-			failedChecks[i] = checkExecutionInfo{
+		for _, check := range r.Failed {
+			failedChecks = append(failedChecks, checkExecutionInfo{
 				Name:             check.Name(),
 				ElapsedTime:      float64(check.ElapsedTime.Milliseconds()),
 				Description:      check.Metadata().Description,
@@ -32,18 +32,18 @@ func getResponse(r runtime.Results) UserResponse {
 				Suggestion:       check.Help().Suggestion,
 				KnowledgeBaseURL: check.Metadata().KnowledgeBaseURL,
 				CheckURL:         check.Metadata().CheckURL,
-			}
+			})
 		}
 	}
 
 	if len(r.Errors) > 0 {
-		for i, check := range r.Errors {
-			erroredChecks[i] = checkExecutionInfo{
+		for _, check := range r.Errors {
+			erroredChecks = append(erroredChecks, checkExecutionInfo{
 				Name:        check.Name(),
 				ElapsedTime: float64(check.ElapsedTime.Milliseconds()),
 				Description: check.Metadata().Description,
 				Help:        check.Help().Message,
-			}
+			})
 		}
 	}
 

--- a/certification/internal/policy/container/has_prohibited_packages.go
+++ b/certification/internal/policy/container/has_prohibited_packages.go
@@ -32,9 +32,9 @@ func (p *HasNoProhibitedPackagesCheck) getDataToValidate(dir string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	pkgs := make([]string, len(pkgList))
-	for i, pkg := range pkgList {
-		pkgs[i] = pkg.Name
+	pkgs := make([]string, 0, len(pkgList))
+	for _, pkg := range pkgList {
+		pkgs = append(pkgs, pkg.Name)
 	}
 	return pkgs, nil
 }

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -118,11 +118,9 @@ func diffImageList(before, after map[string]struct{}) []string {
 func checkImageSource(operatorImages []string) bool {
 	log.Info("Checking that images are from approved sources...")
 
-	registries := make([]string, len(approvedRegistries))
-	i := 0
+	registries := make([]string, 0, len(approvedRegistries))
 	for registry := range approvedRegistries {
-		registries[i] = registry
-		i++
+		registries = append(registries, registry)
 	}
 
 	log.Debug("List of approved registries are: ", registries)

--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -24,9 +24,8 @@ var (
 // imageList takes the images mapping and represents them using just
 // the image URIs.
 func imageList() []string {
-	var imageList = make([]string, len(images))
+	var imageList = make([]string, 0, len(images))
 
-	i := 0
 	for _, image := range images {
 		base := strings.Split(image, ":")[0]
 		digest, err := crane.Digest(image)
@@ -35,8 +34,7 @@ func imageList() []string {
 			// Skip this entry
 			continue
 		}
-		imageList[i] = fmt.Sprintf("%s@%s", base, digest)
-		i++
+		imageList = append(imageList, fmt.Sprintf("%s@%s", base, digest))
 	}
 
 	return imageList


### PR DESCRIPTION
make can accept a second integer parameter that specifies the capacity
when making a slice. When used in this fashion, a slice can have the
benefits of being preallocated with capacity (not requiring to
continually be extended), but a 0 length (when passed 0 as the first).
Then, one can use append and not need the extra index var.

Signed-off-by: Brad P. Crochet <brad@redhat.com>