### PR TITLE
After a certain point in the command, silence the usage output

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -78,6 +78,10 @@ var checkContainerCmd = &cobra.Command{
 		// also write to stdout
 		resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
 
+		// At this point, we would no longer want usage information printed out
+		// on error, so it doesn't contaminate the output.
+		cmd.SilenceUsage = true
+
 		// execute the checks
 		if err := engine.ExecuteChecks(); err != nil {
 			return err

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -87,6 +87,10 @@ var checkOperatorCmd = &cobra.Command{
 		// also write to stdout
 		resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
 
+		// At this point, we would no longer want usage information printed out
+		// on error, so it doesn't contaminate the output.
+		cmd.SilenceUsage = true
+
 		// execute the checks
 		if err := engine.ExecuteChecks(); err != nil {
 			return err


### PR DESCRIPTION
Once we get past a certain point (just before executing the checks)
it is no longer helpful to have the usage information printed out
if there is an error. This patch sets SilenceUsage to true once
we get to that point.

Fixes #409

Signed-off-by: Brad P. Crochet <brad@redhat.com>