### PR TITLE
add a reusable multiarch manifest action

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main, ghactions ]
 
+env:
+  IMAGE_NAME: preflight
+  
 jobs:
   build-main:
     name: Build and push main snapshot images
@@ -29,7 +32,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
-        image: ${{ secrets.IMAGE_REGISTRY }}/preflight
+        image: ${{ secrets.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: ${{ env.SHA_SHORT }}-${{ matrix.platform }}-${{ matrix.architecture }}
         archs: ${{ matrix.architecture }}
         build-args: |
@@ -43,7 +46,7 @@ jobs:
       id: push-image
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: preflight
+        image: ${{ env.IMAGE_NAME }}
         tags: ${{ env.SHA_SHORT }}-${{ matrix.platform }}-${{ matrix.architecture }}
         registry: ${{ secrets.IMAGE_REGISTRY }}
         username: ${{ secrets.REGISTRY_USER }}
@@ -51,3 +54,18 @@ jobs:
 
     - name: Print image url
       run: echo "Image pushed to ${{ steps.push-image.outputs.registry-paths }}"
+    
+    outputs:
+      imageName: ${{ env.IMAGE_NAME }}
+      imageVersion: ${{ env.SHA_SHORT }}
+
+  build-multiarch:
+    needs: build-main
+    uses: ./.github/workflows/build-multiarch.yml
+    with:
+      name: ${{ needs.build-main.outputs.imageName }}
+      tag: ${{ needs.build-main.outputs.imageVersion }}
+    secrets:
+      registry: ${{ secrets.IMAGE_REGISTRY }}
+      user: ${{ secrets.REGISTRY_USER }}
+      password: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -1,0 +1,54 @@
+name: Build and push a multi-arch manifest
+
+# Usage example:
+#    uses: ./.github/workflows/build-multiarch.yml
+#    with:
+#      name: preflight
+#      tag: 89123ab
+#    secrets:
+#      registry: ${{ secrets.IMAGE_REGISTRY }}
+#      user: ${{ secrets.REGISTRY_USER }}
+#      password: ${{ secrets.REGISTRY_PASSWORD }}
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+    secrets:
+      registry:
+        required: true
+      user:
+        required: true
+      password:
+        required: true
+        
+
+jobs:
+  create-and-push-multiarch-manifest:
+    name: create and push a multiarch manifest to the repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create and add to manifest
+        run: |
+          buildah manifest create ${{ inputs.name }}
+          buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-amd64
+          buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-ppc64le
+          buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-arm64
+          buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-s390x
+
+      # Authenticate to container image registry to push the image
+      - name: Podman Login
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ secrets.registry }}
+          username: ${{ secrets.user }}
+          password: ${{ secrets.password }}
+          
+      - name: Push manifest
+        run: |
+            podman manifest push ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}  --all

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,6 +6,9 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
     branches: [ ghactions ]
 
+env:
+  IMAGE_NAME: preflight
+
 jobs:
   build-release:
     name: Build and push tag images
@@ -26,7 +29,7 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
-        image: ${{ secrets.IMAGE_REGISTRY }}/preflight
+        image: ${{ secrets.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: ${{ env.RELEASE_TAG }}-${{ matrix.platform }}-${{ matrix.architecture }}
         archs: ${{ matrix.architecture }}
         build-args: |
@@ -39,7 +42,7 @@ jobs:
       id: push-image
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: preflight
+        image: ${{ env.IMAGE_NAME }}
         tags: ${{ env.RELEASE_TAG }}-${{ matrix.platform }}-${{ matrix.architecture }}
         registry: ${{ secrets.IMAGE_REGISTRY }}
         username: ${{ secrets.REGISTRY_USER }}
@@ -47,3 +50,18 @@ jobs:
 
     - name: Print image url
       run: echo "Image pushed to ${{ steps.push-image.outputs.registry-paths }}"
+
+    outputs:
+      imageName: ${{ env.IMAGE_NAME }}
+      imageVersion: ${{ env.RELEASE_TAG }}
+
+  build-multiarch:
+    needs: build-release
+    uses: ./.github/workflows/build-multiarch.yml
+    with:
+      name: ${{ needs.build-release.outputs.imageName }}
+      tag: ${{ needs.build-release.outputs.imageVersion }}
+    secrets:
+      registry: ${{ secrets.IMAGE_REGISTRY }}
+      user: ${{ secrets.REGISTRY_USER }}
+      password: ${{ secrets.REGISTRY_PASSWORD }}


### PR DESCRIPTION
Adding a reusable action to create a top-level manifest consolidating the multi-arch images built by the specific main/release run.

the structure outline will be

```sh
jobs:
  build-main:
    (1)
  
  build-multiarch:
    (2) 
```

where:
1. the existing matrix-based parallel build code for creating individual images per each architecture.
2. a re-usable action to create a unified manifest, accepting the desired name and tag, and adding images pushed in step (1).


Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>