### PR TITLE
Use the submit variable where possible

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -138,7 +138,7 @@ var checkContainerCmd = &cobra.Command{
 		}
 
 		// submitting results to pxysis if submit flag is set
-		if s, _ := cmd.Flags().GetBool("submit"); s {
+		if submit {
 			log.Info("preparing results that will be submitted to Red Hat")
 
 			certImageJsonFile, err := os.Open(path.Join(artifacts.Path(), certification.DefaultCertImageFilename))


### PR DESCRIPTION
One spot still used viper directly, instead of the submit variable
that was introduced in another PR.

Signed-off-by: Brad P. Crochet <brad@redhat.com>