### PR TITLE
Add image_id to the test results

### DIFF
--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -29,12 +29,14 @@ func (p *pyxisEngine) SubmitResults(certProject *CertProject, certImage *CertIma
 		return nil, nil, nil, err
 	}
 
-	err = p.createRPMManifest(ctx, certImage.ImageID, rpmManifest.RPMS)
+	rpmManifest.ImageID = certImage.ID
+	_, err = p.createRPMManifest(ctx, rpmManifest)
 	if err != nil {
 		log.Error(err, "could not create rpm manifest")
 		return nil, nil, nil, err
 	}
 
+	testResults.ImageID = certImage.ID
 	testResults, err = p.createTestResults(ctx, testResults)
 	if err != nil {
 		log.Error(err, "could not create test results")

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -1,6 +1,7 @@
 package pyxis
 
 type CertImage struct {
+	ID                     string       `json:"_id,omitempty"`
 	Certified              bool         `json:"certified" default:"false"`
 	Deleted                bool         `json:"deleted" default:"false"`
 	DockerImageDigest      string       `json:"docker_image_digest,omitempty"`
@@ -48,6 +49,7 @@ type Tag struct {
 }
 
 type RPMManifest struct {
+	ID      string `json:"_id,omitempty"`
 	ImageID string `json:"image_id,omitempty"`
 	RPMS    []RPM  `json:"rpms,omitempty"`
 }
@@ -65,6 +67,7 @@ type RPM struct {
 }
 
 type CertProject struct {
+	ID                  string    `json:"_id,omitempty"`
 	CertificationStatus string    `json:"certification_status" default:"In Progress"`
 	Container           Container `json:"container"`
 	Name                string    `json:"name"`                      // required
@@ -84,6 +87,7 @@ type Layer struct {
 }
 
 type TestResults struct {
+	ID                string      `json:"_id,omitempty"`
 	CertProject       string      `json:"cert_project"`       // TODO: see if this should be populated, if so with what?
 	CertificationHash string      `json:"certification_hash"` // TODO: see if this should be populated, if so with what?
 	Image             string      `json:"image"`
@@ -92,6 +96,7 @@ type TestResults struct {
 	Results           Results     `json:"results"`
 	TestLibrary       TestLibrary `json:"test_library"`
 	Version           string      `json:"version"` // TODO: see if this should be populated, if so with what?
+	ImageID           string      `json:"image_id"`
 }
 
 type Errors struct {


### PR DESCRIPTION
When we create the image, pull out the image id and add it to the
test results when submitted.

Signed-off-by: Brad P. Crochet <brad@redhat.com>