### PR TITLE
displaying response information to the user after results have been submitted

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -191,11 +191,15 @@ var checkContainerCmd = &cobra.Command{
 				return err
 			}
 
-			// TODO: use the return values once we know what we need to display to the user
-			_, _, _, err = pyxisEngine.SubmitResults(certProject, certImage, rpmManifest, testResults)
+			_, certImage, _, err = pyxisEngine.SubmitResults(certProject, certImage, rpmManifest, testResults)
 			if err != nil {
 				return err
 			}
+
+			log.Info("Test results have been submitted to Red Hat.")
+			log.Info("These results will be reviewed by Red Hat for final certification.")
+			log.Infof("The container's image id is: %s.", certImage.ImageID)
+			log.Infof("Please check https://connect.redhat.com/projects/%s/overview to monitior the progress.", projectId)
 		}
 
 		return nil

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -3,7 +3,7 @@ package cmd
 var (
 	DefaultOutputFormat      = "json"
 	DefaultLogFile           = "preflight.log"
-	DefaultLogLevel          = "warn"
+	DefaultLogLevel          = "info"
 	DefaultArtifactsDir      = "artifacts"
 	DefaultNamespace         = "default"
 	DefaultServiceAccount    = "default"


### PR DESCRIPTION
- fixes: #376 
- displaying the image id to the user and then showing them a URL to the project overview.

Signed-off-by: Adam D. Cornett <adc@redhat.com>