### PR TITLE
updating gitignore to include test file we create as part of runnable tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vuln.html
 bin
 preflight
 openshift-preflight
+container-podman-test.service
 
 # Config files
 config.yaml


### PR DESCRIPTION
- updating the gitignore to include files we create during runnable tests.
- we remove this file after the test is over, but during development/testing sometimes this file stays around and its better that it doesn't get committed.

Signed-off-by: Adam D. Cornett <adc@redhat.com>