### PR TITLE
Limit the usage of log.Info

### DIFF
--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -47,13 +47,13 @@ type CraneEngine struct {
 }
 
 func (c *CraneEngine) ExecuteChecks() error {
-	log.Info("target image: ", c.Image)
+	log.Debug("target image: ", c.Image)
 
 	// prepare crane runtime options, if necessary
 	options := make([]crane.Option, 0)
 
 	// pull the image and save to fs
-	log.Info("pulling image from target registry")
+	log.Debug("pulling image from target registry")
 	img, err := crane.Pull(c.Image, options...)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrGetRemoteContainerFailed, err)
@@ -126,16 +126,16 @@ func (c *CraneEngine) ExecuteChecks() error {
 			log.Error("Unable to determine test cluster version: ", err)
 		}
 	} else {
-		log.Info("Container checks do not require a cluster. skipping cluster version check.")
+		log.Debug("Container checks do not require a cluster. skipping cluster version check.")
 		c.results.TestedOn = runtime.UnknownOpenshiftClusterVersion()
 	}
 
 	// execute checks
-	log.Info("executing checks")
+	log.Debug("executing checks")
 	for _, check := range c.Checks {
 		c.results.TestedImage = c.Image
 
-		log.Info("running check: ", check.Name())
+		log.Debug("running check: ", check.Name())
 
 		// run the validation
 		checkStartTime := time.Now()

--- a/certification/internal/engine/podman.go
+++ b/certification/internal/engine/podman.go
@@ -146,7 +146,7 @@ func (p *podmanEngine) WaitContainer(containerId string, waitOptions cli.WaitOpt
 		return false, err
 	}
 
-	log.Info("container reached a running state")
+	log.Trace("container reached a running state")
 	return true, nil
 }
 

--- a/certification/internal/policy/container/has_license.go
+++ b/certification/internal/policy/container/has_license.go
@@ -64,7 +64,7 @@ func (p *HasLicenseCheck) validate(licenseFileList []fs.DirEntry) (bool, error) 
 			break
 		}
 	}
-	log.Infof("%d Licenses found", len(licenseFileList))
+	log.Debugf("%d Licenses found", len(licenseFileList))
 	return len(licenseFileList) >= minLicenseFileCount && nonZeroLength, nil
 }
 

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -116,7 +116,7 @@ func diffImageList(before, after map[string]struct{}) []string {
 }
 
 func checkImageSource(operatorImages []string) bool {
-	log.Info("Checking that images are from approved sources...")
+	log.Debug("Checking that images are from approved sources...")
 
 	registries := make([]string, 0, len(approvedRegistries))
 	for registry := range approvedRegistries {
@@ -133,7 +133,7 @@ func checkImageSource(operatorImages []string) bool {
 		}
 	}
 	if allApproved {
-		log.Info("All images are from approved sources...")
+		log.Debug("All images are from approved sources...")
 	}
 	return allApproved
 }
@@ -311,7 +311,7 @@ func watch(ctx context.Context, engine cli.OpenshiftEngine, wg *sync.WaitGroup, 
 			return
 		}
 		if done {
-			log.Infof("Successfully retrieved object %s/%s", namespace, obj)
+			log.Debugf("Successfully retrieved object %s/%s", namespace, obj)
 			channel <- obj
 			return
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -55,7 +55,7 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 		mw := io.MultiWriter(os.Stderr, logFile)
 		log.SetOutput(mw)
 	} else {
-		log.Info("Failed to log to file, using default stderr")
+		log.Debug("Failed to log to file, using default stderr")
 	}
 	if ll, err := log.ParseLevel(viper.GetString("loglevel")); err == nil {
 		log.SetLevel(ll)
@@ -63,6 +63,6 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 
 	log.SetFormatter(&log.TextFormatter{})
 	if !configFileUsed {
-		log.Info("config file not found, proceeding without it")
+		log.Debug("config file not found, proceeding without it")
 	}
 }


### PR DESCRIPTION
Since log.Info is going to be the default log level, we want to make sure
that it is not over-used. Most of the things in the internal package should
be debug anyway.

This just makes the default Info level have useful information that we want
all users to see, not debug-type messages.

Signed-off-by: Brad P. Crochet <brad@redhat.com>