### PR TITLE
adding in a call to pyxis getImage so preflight can run multiple times

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -30,4 +30,5 @@ var (
 	ErrUnsupportedGoType               = errors.New("go type unsupported")
 	ErrSaveFileFailed                  = errors.New("failed to save file to artifacts directory")
 	ErrNon200StatusCode                = errors.New("error calling remote API")
+	Err409StatusCode                   = errors.New("remote API returned conflict")
 )

--- a/certification/pyxis/pyxis_suite_test.go
+++ b/certification/pyxis/pyxis_suite_test.go
@@ -28,6 +28,70 @@ func (fhc fakeHttpClient) Do(req *http.Request) (*http.Response, error) {
 	var results string
 
 	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{"image": "quay.io/awesome/image:latest", "passed": false}`
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		results = `{"object_type": "containerImageRPMManifest"}`
+	case strings.Contains(req.URL.Path, "images"):
+		results = `{"certified":false,"deleted":false,"image_id":"123456789abc"}`
+	}
+
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCertProjectUnauthorizedClient struct{}
+
+func (fhc fakeHttpCertProjectUnauthorizedClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+
+	switch {
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{}`
+	}
+
+	return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateImageConflictClient struct{}
+
+func (fhc fakeHttpCreateImageConflictClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{"image": "quay.io/awesome/image:latest", "passed": false}`
+	case strings.Contains(req.URL.RawQuery, "filter=docker_image_digest=="):
+		results = `{"data":[{"certified":false,"deleted":false,"image_id":"123456789abc"}]}`
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		results = `{"object_type": "containerImageRPMManifest"}`
+	case strings.Contains(req.URL.Path, "images"):
+		results = ``
+		statusCode = http.StatusConflict
+	}
+
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateImageUnauthorizedClient struct{}
+
+func (fhc fakeHttpCreateImageUnauthorizedClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
 	case strings.Contains(req.URL.Path, "certification"):
 		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
 
@@ -35,10 +99,151 @@ func (fhc fakeHttpClient) Do(req *http.Request) (*http.Response, error) {
 			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
 		}
 	case strings.Contains(req.URL.Path, "images"):
-		results = `{"certified":false,"deleted":false}`
-	case strings.Contains(req.URL.Path, "test-results"):
-		results = `{"image": "quay.io/awesome/image:latest", "passed": false,}`
+		results = `{}`
+		statusCode = http.StatusUnauthorized
 	}
 
-	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateImageConflictAndUnauthorizedClient struct{}
+
+func (fhc fakeHttpCreateImageConflictAndUnauthorizedClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{"image": "quay.io/awesome/image:latest", "passed": false}`
+	case strings.Contains(req.URL.RawQuery, "filter=docker_image_digest=="):
+		results = ``
+		statusCode = http.StatusUnauthorized
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		results = `{"object_type": "containerImageRPMManifest"}`
+	case strings.Contains(req.URL.Path, "images"):
+		results = ``
+		statusCode = http.StatusConflict
+	}
+
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateRPMManifestConflictClient struct{}
+
+func (fhc fakeHttpCreateRPMManifestConflictClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{"image": "quay.io/awesome/image:latest", "passed": false}`
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		if req.Method == http.MethodPost {
+			results = `{}`
+			statusCode = http.StatusConflict
+		}
+
+		if req.Method == http.MethodGet {
+			results = `{"object_type": "containerImageRPMManifest"}`
+		}
+	case strings.Contains(req.URL.Path, "images"):
+		results = `{"certified":false,"deleted":false,"image_id":"123456789abc"}`
+
+	}
+
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateRPMManifestConflictAndUnauthorizedClient struct{}
+
+func (fhc fakeHttpCreateRPMManifestConflictAndUnauthorizedClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{"image": "quay.io/awesome/image:latest", "passed": false}`
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		if req.Method == http.MethodPost {
+			results = `{}`
+			statusCode = http.StatusConflict
+		}
+
+		if req.Method == http.MethodGet {
+			results = `{}`
+			statusCode = http.StatusUnauthorized
+		}
+	case strings.Contains(req.URL.Path, "images"):
+		results = `{"certified":false,"deleted":false,"image_id":"123456789abc"}`
+	}
+
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateRPMManifestUnauthorizedClient struct{}
+
+func (fhc fakeHttpCreateRPMManifestUnauthorizedClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{"image": "quay.io/awesome/image:latest", "passed": false}`
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		results = `{}`
+		statusCode = http.StatusUnauthorized
+	case strings.Contains(req.URL.Path, "images"):
+		results = `{"certified":false,"deleted":false,"image_id":"123456789abc"}`
+	}
+
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
+}
+
+type fakeHttpCreateTestResultsUnauthorizedClient struct{}
+
+func (fhc fakeHttpCreateTestResultsUnauthorizedClient) Do(req *http.Request) (*http.Response, error) {
+	var results string
+	statusCode := http.StatusOK
+
+	switch {
+	case strings.Contains(req.URL.Path, "test-results"):
+		results = `{}`
+		statusCode = http.StatusUnauthorized
+	case strings.Contains(req.URL.Path, "certification"):
+		results = `{"certification_status":"Started","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+
+		if req.Method == http.MethodPatch {
+			results = `{"certification_status":"In Progress","name":"My Spiffy Project","project_status":"Foo","type":"Containers","container":{"docker_config_json":"{}","type":"Containers"}}`
+		}
+	case strings.Contains(req.URL.Path, "rpm-manifest"):
+		results = `{"object_type": "containerImageRPMManifest"}`
+	case strings.Contains(req.URL.Path, "images"):
+		results = `{"certified":false,"deleted":false,"image_id":"123456789abc"}`
+	}
+
+	return &http.Response{StatusCode: statusCode, Body: io.NopCloser(bytes.NewReader([]byte(results)))}, nil
 }

--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -3,19 +3,20 @@ package pyxis
 import (
 	"context"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 func (p *pyxisEngine) SubmitResults(certProject *CertProject, certImage *CertImage, rpmManifest *RPMManifest, testResults *TestResults) (*CertProject, *CertImage, *TestResults, error) {
 	var err error
 	ctx := context.Background()
-	oldProject := certProject
+	oldProject := *certProject
 
 	if certProject.CertificationStatus == "Started" {
 		certProject.CertificationStatus = "In Progress"
 	}
 
-	if certProject != oldProject {
+	if *certProject != oldProject {
 		certProject, err = p.updateProject(ctx, certProject)
 		if err != nil {
 			log.Error(err, "could not update project")
@@ -23,17 +24,33 @@ func (p *pyxisEngine) SubmitResults(certProject *CertProject, certImage *CertIma
 		}
 	}
 
+	dockerImageDigest := certImage.DockerImageDigest
+
 	certImage, err = p.createImage(ctx, certImage)
-	if err != nil {
+	if err != nil && err != errors.Err409StatusCode {
 		log.Error(err, "could not create image")
 		return nil, nil, nil, err
+	}
+	if err != nil && err == errors.Err409StatusCode {
+		certImage, err = p.getImage(ctx, dockerImageDigest)
+		if err != nil {
+			log.Error(err, "could not get image")
+			return nil, nil, nil, err
+		}
 	}
 
 	rpmManifest.ImageID = certImage.ID
 	_, err = p.createRPMManifest(ctx, rpmManifest)
-	if err != nil {
+	if err != nil && err != errors.Err409StatusCode {
 		log.Error(err, "could not create rpm manifest")
 		return nil, nil, nil, err
+	}
+	if err != nil && err == errors.Err409StatusCode {
+		_, err = p.getRPMManifest(ctx, rpmManifest.ImageID)
+		if err != nil {
+			log.Error(err, "could not get rpm manifest")
+			return nil, nil, nil, err
+		}
 	}
 
 	testResults.ImageID = certImage.ID

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -1,6 +1,9 @@
 package pyxis
 
 import (
+	"context"
+	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -14,11 +17,197 @@ var _ = Describe("Pyxis Submit", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(certProject).ToNot(BeNil())
+				Expect(certImage).ToNot(BeNil())
+				Expect(testResults).ToNot(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit updateProject 401 Unauthorized", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCertProjectUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
+				Expect(certImage).To(BeNil())
+				Expect(testResults).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createImage 409 Conflict", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateImageConflictClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
 				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{}, &CertImage{}, &RPMManifest{}, &TestResults{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certProject).ToNot(BeNil())
 				Expect(certImage).ToNot(BeNil())
 				Expect(testResults).ToNot(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createImage 401 Unauthorized", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateImageUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
+				Expect(certImage).To(BeNil())
+				Expect(testResults).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createImage 409 Conflict and getImage 401 Unauthorized ", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateImageConflictAndUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
+				Expect(certImage).To(BeNil())
+				Expect(testResults).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createRPMManifest 409 Conflict", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateRPMManifestConflictClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(certProject).ToNot(BeNil())
+				Expect(certImage).ToNot(BeNil())
+				Expect(testResults).ToNot(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createRPMManifest 401 Unauthorized", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateRPMManifestUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
+				Expect(certImage).To(BeNil())
+				Expect(testResults).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createRPMManifest 409 Conflict and getRPMManifest 401 Unauthorized", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateRPMManifestConflictAndUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
+				Expect(certImage).To(BeNil())
+				Expect(testResults).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis Submit with createTestResults 401 Unauthorized", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCreateTestResultsUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(&CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
+				Expect(certImage).To(BeNil())
+				Expect(testResults).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis GetProejct", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, err := pyxisEngine.GetProject(context.Background())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(certProject).ToNot(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("Pyxis GetProject 401 Unauthorized", func() {
+	var pyxisEngine *pyxisEngine
+
+	BeforeEach(func() {
+		pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awseome-project-id", fakeHttpCertProjectUnauthorizedClient{})
+	})
+	Context("when a project is submitted", func() {
+		Context("and it is not already In Progress", func() {
+			It("should switch to In Progress", func() {
+				certProject, err := pyxisEngine.GetProject(context.Background())
+				Expect(err).To(MatchError(errors.New("error calling remote API")))
+				Expect(certProject).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
- Fixes: #442 
- adding in call to `projects/certification/id/%s/images?filter=docker_image_digest==%s` to see if the image already exists in pyxis
- Relates: #369 
- added call to `images/id/%s/rpm-manifest` to get an existing rpm manifest (**note: this route isn't fully functioning in the external pyxis api yet**)
- adding in tests to cover all new and existing methods in pyxis package

Signed-off-by: Adam D. Cornett <adc@redhat.com>