### PR TITLE
Add PGP key id to the RPM manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,4 +103,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1 => github.com/opdev/go-rpmdb v0.0.0-20220208191623-d02daff2dffb
+replace github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1 => github.com/opdev/go-rpmdb v0.0.0-20220224224313-40fc34da2676

--- a/go.sum
+++ b/go.sum
@@ -1049,8 +1049,8 @@ github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/opdev/go-rpmdb v0.0.0-20220208191623-d02daff2dffb h1:rBk/OmckLACN83JRCu0TUu7krK6kpoaxYmHvpTbzTcs=
-github.com/opdev/go-rpmdb v0.0.0-20220208191623-d02daff2dffb/go.mod h1:r1F7T+vFFyJzPDKZZKEDUVdVkDRMoxOplYIi8Dytp7U=
+github.com/opdev/go-rpmdb v0.0.0-20220224224313-40fc34da2676 h1:u3aSakSNDfs4zPWikDuxEUGpdTTlrJXof2mOW3vhIOM=
+github.com/opdev/go-rpmdb v0.0.0-20220224224313-40fc34da2676/go.mod h1:r1F7T+vFFyJzPDKZZKEDUVdVkDRMoxOplYIi8Dytp7U=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
Update the go-rpmdb to the latest commit in the opdev fork. This fork has support for the PGP key id. Add that field to the RPM entries in the manifest.
 
Signed-off-by: Brad P. Crochet <brad@redhat.com>