### PR TITLE
Add a flag to specify an image as a scratch image

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -44,9 +44,10 @@ func NewForConfig(config runtime.Config) (CheckEngine, error) {
 	}
 
 	engine := &internal.CraneEngine{
-		Image:    config.Image,
-		Checks:   checks,
-		IsBundle: config.Bundle,
+		Image:     config.Image,
+		Checks:    checks,
+		IsBundle:  config.Bundle,
+		IsScratch: config.Scratch,
 	}
 
 	return engine, nil

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -41,6 +41,9 @@ type CraneEngine struct {
 	// IsBundle is an indicator that the asset is a bundle.
 	IsBundle bool
 
+	// IsScratch is an indicator that the asset is a scratch image
+	IsScratch bool
+
 	imageRef certification.ImageReference
 	results  runtime.Results
 }
@@ -96,12 +99,11 @@ func (c *CraneEngine) ExecuteChecks() error {
 		return fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
 	}
 
-	// only write these files to disk for container checks
-	if !c.IsBundle {
-		if err := writeCertImage(img); err != nil {
-			return err
-		}
+	if err := writeCertImage(img); err != nil {
+		return err
+	}
 
+	if !c.IsScratch {
 		if err := writeRPMManifest(containerFSPath); err != nil {
 			return err
 		}

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -14,6 +14,7 @@ type Config struct {
 	ResponseFormat string
 	Mounted        bool
 	Bundle         bool
+	Scratch        bool
 }
 
 type Result struct {

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -85,6 +85,7 @@ var checkContainerCmd = &cobra.Command{
 		log.Debugf("Certification project name is: %s", certProject.Name)
 		if certProject.OsContentType == "scratch" {
 			cfg.EnabledChecks = engine.ScratchContainerPolicy()
+			cfg.Scratch = true
 		}
 
 		engine, err := engine.NewForConfig(cfg)

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -60,6 +60,7 @@ var checkOperatorCmd = &cobra.Command{
 			EnabledChecks:  engine.OperatorPolicy(),
 			ResponseFormat: DefaultOutputFormat,
 			Bundle:         true,
+			Scratch:        true,
 		}
 
 		engine, err := engine.NewForConfig(cfg)


### PR DESCRIPTION
We have some checks and auxillary methods that will fail if an image is a scratch image. Rather than reuse (and probably overload) the IsBundle flag, this adds a new IsScratch flag. And in the case of an operator check, both will be set to true.
    
Signed-off-by: Brad P. Crochet <brad@redhat.com>