### PR TITLE
remove `options` from `crane.ListTags`

### DIFF
--- a/certification/internal/engine/crane.go
+++ b/certification/internal/engine/crane.go
@@ -1,6 +1,8 @@
 package engine
 
-import "github.com/google/go-containerregistry/pkg/crane"
+import (
+	"github.com/google/go-containerregistry/pkg/crane"
+)
 
 type craneEngine struct{}
 
@@ -9,8 +11,5 @@ func NewCraneEngine() *craneEngine {
 }
 
 func (c *craneEngine) ListTags(imageURI string) ([]string, error) {
-	// prepare crane runtime options
-	options := make([]crane.Option, 0)
-
-	return crane.ListTags(imageURI, options...)
+	return crane.ListTags(imageURI)
 }


### PR DESCRIPTION
- removing `options` from `crane.ListTags` since crane ends up using options.auth in their implementation and then they point this back to the local `auth.json` file or more simply pout the `DefaultKeychain` on the system.

Signed-off-by: Adam D. Cornett <adc@redhat.com>