### PR TITLE
adding in repositories information for create image pyxis call

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrFormattingResults               = errors.New("error formatting results")
 	ErrInsufficientPosArguments        = errors.New("not enough positional arguments")
 	ErrGetRemoteContainerFailed        = errors.New("failed to pull remote container")
+	ErrParseTagInfoFailed              = errors.New("failed to parse tag info")
 	ErrExtractingTarball               = errors.New("failed to extract tarball")
 	ErrCreateTempDir                   = errors.New("failed to create temporary directory")
 	ErrImageInspectFailed              = errors.New("failed to inspect image")

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/name"
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
@@ -100,7 +100,14 @@ func (c *CraneEngine) ExecuteChecks() error {
 		return fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
 	}
 
-	if err := writeCertImage(img); err != nil {
+	// store the image internals in the engine image reference to pass to validations.
+	c.imageRef = certification.ImageReference{
+		ImageURI:    c.Image,
+		ImageFSPath: containerFSPath,
+		ImageInfo:   img,
+	}
+
+	if err := writeCertImage(c.imageRef); err != nil {
 		return err
 	}
 
@@ -108,14 +115,6 @@ func (c *CraneEngine) ExecuteChecks() error {
 		if err := writeRPMManifest(containerFSPath); err != nil {
 			return err
 		}
-	}
-
-	// store the image internals in the engine image reference to pass to validations.
-	// TODO: pass this to validations when the new check interface includes it.
-	c.imageRef = certification.ImageReference{
-		ImageURI:    c.Image,
-		ImageFSPath: containerFSPath,
-		ImageInfo:   img,
 	}
 
 	if c.IsBundle {
@@ -297,28 +296,28 @@ func untar(dst string, r io.Reader) error {
 	}
 }
 
-func writeCertImage(img v1.Image) error {
-	config, err := img.ConfigFile()
+func writeCertImage(imageRef certification.ImageReference) error {
+	config, err := imageRef.ImageInfo.ConfigFile()
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
 	}
 
-	manifest, err := img.Manifest()
+	manifest, err := imageRef.ImageInfo.Manifest()
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
 	}
 
-	digest, err := img.Digest()
+	digest, err := imageRef.ImageInfo.Digest()
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
 	}
 
-	rawConfig, err := img.RawConfigFile()
+	rawConfig, err := imageRef.ImageInfo.RawConfigFile()
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
 	}
 
-	size, err := img.Size()
+	size, err := imageRef.ImageInfo.Size()
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
 	}
@@ -326,7 +325,7 @@ func writeCertImage(img v1.Image) error {
 	labels := convertLabels(config.Config.Labels)
 	layerSizes := make([]pyxis.Layer, 0, len(config.RootFS.DiffIDs))
 	for _, diffid := range config.RootFS.DiffIDs {
-		layer, err := img.LayerByDiffID(diffid)
+		layer, err := imageRef.ImageInfo.LayerByDiffID(diffid)
 		if err != nil {
 			return err
 		}
@@ -352,6 +351,28 @@ func writeCertImage(img v1.Image) error {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
 	}
 
+	addedDate := time.Now().UTC().Format(time.RFC3339)
+
+	log.Debug("getting tag info for image")
+	tag, err := name.NewTag(imageRef.ImageURI)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errors.ErrParseTagInfoFailed, err)
+	}
+
+	tags := make([]pyxis.Tag, 0, 1)
+	tags = append(tags, pyxis.Tag{
+		AddedDate: addedDate,
+		Name:      tag.TagStr(),
+	})
+
+	repositories := make([]pyxis.Repository, 0, 1)
+	repositories = append(repositories, pyxis.Repository{
+		PushDate:   addedDate,
+		Registry:   tag.Context().RegistryStr(),
+		Repository: tag.Context().RepositoryStr(),
+		Tags:       tags,
+	})
+
 	certImage := pyxis.CertImage{
 		DockerImageDigest: digest.String(),
 		DockerImageID:     manifest.Config.Digest.String(),
@@ -369,6 +390,7 @@ func writeCertImage(img v1.Image) error {
 			UncompressedLayerSizes: layerSizes,
 		},
 		RawConfig:         string(rawConfig),
+		Repositories:      repositories,
 		SumLayerSizeBytes: sumLayersSizeBytes,
 		// This is an assumption that the DiffIDs are in order from base up.
 		// Need more evisdence that this is always the case.


### PR DESCRIPTION
- Relates: #369 
- Adding in repositories information to be sent to pyxis  
- Moved `writeCertImage` and `writeRPMManifest` to be after `certification.ImageReference` struct creation since `writeCertImage` will now use `certification.ImageReference` struct instead of `crane v1.Image` struct so that we can call `name.NewTag` with the proper information.

Signed-off-by: Adam D. Cornett <adc@redhat.com>