### PR TITLE
making certImage.certified match testResults.passed

### DIFF
--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -4,7 +4,7 @@ import "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/
 
 type CertImage struct {
 	ID                     string       `json:"_id,omitempty"`
-	Certified              bool         `json:"certified" default:"false"`
+	Certified              bool         `json:"certified"`
 	Deleted                bool         `json:"deleted" default:"false"`
 	DockerImageDigest      string       `json:"docker_image_digest,omitempty"`
 	DockerImageID          string       `json:"docker_image_id,omitempty"`

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -141,6 +141,23 @@ var checkContainerCmd = &cobra.Command{
 		if submit {
 			log.Info("preparing results that will be submitted to Red Hat")
 
+			testResultsJsonFile, err := os.Open(path.Join(artifacts.Path(), certification.DefaultTestResultsFilename))
+			if err != nil {
+				return err
+			}
+			defer testResultsJsonFile.Close()
+
+			testResultsBytes, err := io.ReadAll(testResultsJsonFile)
+			if err != nil {
+				return err
+			}
+
+			testResults := new(pyxis.TestResults)
+			err = json.Unmarshal(testResultsBytes, &testResults)
+			if err != nil {
+				return err
+			}
+
 			certImageJsonFile, err := os.Open(path.Join(artifacts.Path(), certification.DefaultCertImageFilename))
 			if err != nil {
 				return err
@@ -159,6 +176,7 @@ var checkContainerCmd = &cobra.Command{
 			}
 
 			certImage.ISVPID = certProject.Container.ISVPID
+			certImage.Certified = testResults.Passed
 
 			rpmManifestJsonFile, err := os.Open(path.Join(artifacts.Path(), certification.DefaultRPMManifestFilename))
 			if err != nil {
@@ -173,23 +191,6 @@ var checkContainerCmd = &cobra.Command{
 
 			rpmManifest := new(pyxis.RPMManifest)
 			err = json.Unmarshal(rpmManifestBytes, rpmManifest)
-			if err != nil {
-				return err
-			}
-
-			testResultsJsonFile, err := os.Open(path.Join(artifacts.Path(), certification.DefaultTestResultsFilename))
-			if err != nil {
-				return err
-			}
-			defer testResultsJsonFile.Close()
-
-			testResultsBytes, err := io.ReadAll(testResultsJsonFile)
-			if err != nil {
-				return err
-			}
-
-			testResults := new(pyxis.TestResults)
-			err = json.Unmarshal(testResultsBytes, &testResults)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- Fixes: #461 
- Moved`testResultsJsonFile` to be the first step since `testResults.passed` is needed in `certImage` creation. The diff makes it looked like more has changed, but it really is that test `testResultsJsonFile` moves from `last` to `first` in this code.

Signed-off-by: Adam D. Cornett <adc@redhat.com>