### PR TITLE
using crane's name package to determine the format of the registry

### DIFF
--- a/certification/internal/policy/container/has_unique_tag.go
+++ b/certification/internal/policy/container/has_unique_tag.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -19,12 +20,7 @@ type HasUniqueTagCheck struct {
 }
 
 func (p *HasUniqueTagCheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	cleanUri := imgRef.ImageURI
-	badCharIndex := strings.IndexAny(cleanUri, "@:")
-	if badCharIndex > -1 {
-		cleanUri = imgRef.ImageURI[:badCharIndex]
-	}
-	tags, err := p.getDataToValidate(cleanUri)
+	tags, err := p.getDataToValidate(fmt.Sprintf("%s/%s", imgRef.ImageRegistry, imgRef.ImageRepository))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- Fixes: #467
- Using crane's built in mechanism to format the registry information to call ListTags properly
- Removed tests, since the responsibility of parsing the `image` information is moved upstream into the `engine.go`

Signed-off-by: Adam D. Cornett <adc@redhat.com>