### PR TITLE
adding in scan results url to output and changing to the mongo db _id

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -201,8 +201,9 @@ var checkContainerCmd = &cobra.Command{
 
 			log.Info("Test results have been submitted to Red Hat.")
 			log.Info("These results will be reviewed by Red Hat for final certification.")
-			log.Infof("The container's image id is: %s.", certImage.ImageID)
-			log.Infof(fmt.Sprintf("Please check %s to monitior the progress.", buildConnectURL(projectId)))
+			log.Infof("The container's image id is: %s.", certImage.ID)
+			log.Infof("Please check %s to view scan results.", buildScanResultsURL(projectId, certImage.ID))
+			log.Infof(fmt.Sprintf("Please check %s to monitor the progress.", buildOverviewURL(projectId)))
 		}
 
 		return nil
@@ -230,7 +231,7 @@ func init() {
 	checkCmd.AddCommand(checkContainerCmd)
 }
 
-func buildConnectURL(projectID string) string {
+func buildOverviewURL(projectID string) string {
 	connectURL := fmt.Sprintf("https://connect.redhat.com/projects/%s/overview", projectID)
 	pyxisHost := viper.GetString("pyxis_host")
 	s := strings.Split(pyxisHost, ".")
@@ -238,6 +239,19 @@ func buildConnectURL(projectID string) string {
 	if pyxisHost != DefaultPyxisHost && len(s) > 3 {
 		env := s[1]
 		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/projects/%s/overview", env, projectID)
+	}
+
+	return connectURL
+}
+
+func buildScanResultsURL(projectID string, imageID string) string {
+	connectURL := fmt.Sprintf("https://connect.redhat.com/projects/%s/images/%s/scan-results", projectID, imageID)
+	pyxisHost := viper.GetString("pyxis_host")
+	s := strings.Split(pyxisHost, ".")
+
+	if pyxisHost != DefaultPyxisHost && len(s) > 3 {
+		env := s[1]
+		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/projects/%s/images/%s/scan-results", env, projectID, imageID)
 	}
 
 	return connectURL


### PR DESCRIPTION
- Fixes: #465 
- Displaying scan-results URL to the user
- Changing from displaying `image_id` to `_Id` to the user

Signed-off-by: Adam D. Cornett <adc@redhat.com>