### PR TITLE
Add some useful fields to ImageReference

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -1,9 +1,5 @@
 package certification
 
-import (
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-)
-
 // Check as an interface containing all methods necessary
 // to use and identify a given check.
 type Check interface {
@@ -42,10 +38,4 @@ type HelpText struct {
 	// Suggestion is text provided to the user indicating what might need to
 	// change in order to pass a check.
 	Suggestion string `json:"suggestion" xml:"suggestion"`
-}
-
-type ImageReference struct {
-	ImageURI    string
-	ImageFSPath string
-	ImageInfo   v1.Image
 }

--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrSaveFileFailed                  = errors.New("failed to save file to artifacts directory")
 	ErrNon200StatusCode                = errors.New("error calling remote API")
 	Err409StatusCode                   = errors.New("remote API returned conflict")
+	ErrInvalidImageUri                 = errors.New("image uri could not be parsed")
 )

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -100,11 +100,19 @@ func (c *CraneEngine) ExecuteChecks() error {
 		return fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
 	}
 
+	reference, err := name.ParseReference(c.Image)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errors.ErrInvalidImageUri, err)
+	}
+
 	// store the image internals in the engine image reference to pass to validations.
 	c.imageRef = certification.ImageReference{
-		ImageURI:    c.Image,
-		ImageFSPath: containerFSPath,
-		ImageInfo:   img,
+		ImageURI:        c.Image,
+		ImageFSPath:     containerFSPath,
+		ImageInfo:       img,
+		ImageRegistry:   reference.Context().RegistryStr(),
+		ImageRepository: reference.Context().RepositoryStr(),
+		ImageTagOrSha:   reference.Identifier(),
 	}
 
 	if err := writeCertImage(c.imageRef); err != nil {

--- a/certification/types.go
+++ b/certification/types.go
@@ -1,0 +1,13 @@
+package certification
+
+import v1 "github.com/google/go-containerregistry/pkg/v1"
+
+// ImasgeReference holds all things image-related
+type ImageReference struct {
+	ImageURI        string
+	ImageFSPath     string
+	ImageInfo       v1.Image
+	ImageRepository string
+	ImageRegistry   string
+	ImageTagOrSha   string
+}


### PR DESCRIPTION
There are places that need to have the individual parts of the image
URI. This adds the Registry, Repository, and Reference fields.
Reference is either a tag or a sha digest.

Signed-off-by: Brad P. Crochet <brad@redhat.com>