### PR TITLE
adding in createArtifacts method so we can send pyxis the preflight.log

### DIFF
--- a/certification/pyxis/pyxis.go
+++ b/certification/pyxis/pyxis.go
@@ -328,6 +328,48 @@ func (p *pyxisEngine) createTestResults(ctx context.Context, testResults *TestRe
 	return &newTestResults, nil
 }
 
+func (p *pyxisEngine) createArtifacts(ctx context.Context, artifact *Artifact) (*Artifact, error) {
+	b, err := json.Marshal(artifact)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	req, err := p.newRequestWithApiToken(ctx, http.MethodPost, getPyxisUrl(fmt.Sprintf("projects/certification/id/%s/artifacts", p.ProjectId)), bytes.NewReader(b))
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	log.Debugf("URL is: %s", req.URL)
+
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	if !checkStatus(resp.StatusCode) {
+		log.Errorf("%s: %s", "received non 200 status code in createArtifacts", string(body))
+		return nil, errors.ErrNon200StatusCode
+	}
+
+	var newArtifact Artifact
+	if err := json.Unmarshal(body, &newArtifact); err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	return &newArtifact, nil
+}
+
 func (p *pyxisEngine) newRequestWithApiToken(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {

--- a/certification/pyxis/pyxis.go
+++ b/certification/pyxis/pyxis.go
@@ -328,7 +328,7 @@ func (p *pyxisEngine) createTestResults(ctx context.Context, testResults *TestRe
 	return &newTestResults, nil
 }
 
-func (p *pyxisEngine) createArtifacts(ctx context.Context, artifact *Artifact) (*Artifact, error) {
+func (p *pyxisEngine) createArtifact(ctx context.Context, artifact *Artifact) (*Artifact, error) {
 	b, err := json.Marshal(artifact)
 	if err != nil {
 		log.Error(err)
@@ -357,7 +357,7 @@ func (p *pyxisEngine) createArtifacts(ctx context.Context, artifact *Artifact) (
 	}
 
 	if !checkStatus(resp.StatusCode) {
-		log.Errorf("%s: %s", "received non 200 status code in createArtifacts", string(body))
+		log.Errorf("%s: %s", "received non 200 status code in createArtifact", string(body))
 		return nil, errors.ErrNon200StatusCode
 	}
 

--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -59,8 +59,7 @@ func (p *pyxisEngine) SubmitResults(ctx context.Context, certProject *CertProjec
 
 	for _, artifact := range artifacts {
 		artifact.ImageID = certImage.ID
-		_, err = p.createArtifacts(ctx, &artifact)
-		if err != nil {
+		if _, err := p.createArtifact(ctx, &artifact); err != nil {
 			log.Errorf("%s: could not create artifact: %s", err, artifact.Filename)
 			return nil, nil, nil, err
 		}

--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *pyxisEngine) SubmitResults(ctx context.Context, certProject *CertProject, certImage *CertImage, rpmManifest *RPMManifest, testResults *TestResults) (*CertProject, *CertImage, *TestResults, error) {
+func (p *pyxisEngine) SubmitResults(ctx context.Context, certProject *CertProject, certImage *CertImage, rpmManifest *RPMManifest, testResults *TestResults, artifacts []Artifact) (*CertProject, *CertImage, *TestResults, error) {
 	var err error
 
 	if certProject.CertificationStatus == "Started" {
@@ -53,6 +53,15 @@ func (p *pyxisEngine) SubmitResults(ctx context.Context, certProject *CertProjec
 		_, err = p.getRPMManifest(ctx, rpmManifest.ImageID)
 		if err != nil {
 			log.Error(err, "could not get rpm manifest")
+			return nil, nil, nil, err
+		}
+	}
+
+	for _, artifact := range artifacts {
+		artifact.ImageID = certImage.ID
+		_, err = p.createArtifacts(ctx, &artifact)
+		if err != nil {
+			log.Errorf("%s: could not create artifact: %s", err, artifact.Filename)
 			return nil, nil, nil, err
 		}
 	}

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Pyxis Submit", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certProject).ToNot(BeNil())
 				Expect(certImage).ToNot(BeNil())
@@ -39,7 +39,7 @@ var _ = Describe("Pyxis Submit updateProject 401 Unauthorized", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).To(MatchError(fmt.Errorf("%w: %s", errors.New("error calling remote API"), "could not retrieve project")))
 				Expect(certProject).To(BeNil())
 				Expect(certImage).To(BeNil())
@@ -58,7 +58,7 @@ var _ = Describe("Pyxis Submit with createImage 409 Conflict", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certProject).ToNot(BeNil())
 				Expect(certImage).ToNot(BeNil())
@@ -77,7 +77,7 @@ var _ = Describe("Pyxis Submit with createImage 401 Unauthorized", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
 				Expect(certProject).To(BeNil())
 				Expect(certImage).To(BeNil())
@@ -96,7 +96,7 @@ var _ = Describe("Pyxis Submit with createImage 409 Conflict and getImage 401 Un
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
 				Expect(certProject).To(BeNil())
 				Expect(certImage).To(BeNil())
@@ -115,7 +115,7 @@ var _ = Describe("Pyxis Submit with createRPMManifest 409 Conflict", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certProject).ToNot(BeNil())
 				Expect(certImage).ToNot(BeNil())
@@ -134,7 +134,7 @@ var _ = Describe("Pyxis Submit with createRPMManifest 401 Unauthorized", func() 
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
 				Expect(certProject).To(BeNil())
 				Expect(certImage).To(BeNil())
@@ -153,7 +153,7 @@ var _ = Describe("Pyxis Submit with createRPMManifest 409 Conflict and getRPMMan
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
 				Expect(certProject).To(BeNil())
 				Expect(certImage).To(BeNil())
@@ -172,7 +172,7 @@ var _ = Describe("Pyxis Submit with createTestResults 401 Unauthorized", func() 
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{})
+				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
 				Expect(certProject).To(BeNil())
 				Expect(certImage).To(BeNil())

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -1,6 +1,8 @@
 package pyxis
 
-import "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+)
 
 type CertImage struct {
 	ID                     string       `json:"_id,omitempty"`
@@ -98,4 +100,14 @@ type TestResults struct {
 	Version     string `json:"version,omitempty"`
 	ImageID     string `json:"image_id,omitempty"`
 	formatters.UserResponse
+}
+
+type Artifact struct {
+	ID          string `json:"_id"`
+	CertProject string `json:"cert_project"`
+	Content     string `json:"content"`
+	ContentType string `json:"content_type"`
+	FileSize    int64  `json:"file_size"`
+	Filename    string `json:"filename"`
+	ImageID     string `json:"image_id"`
 }


### PR DESCRIPTION
- Fixes: #447 
- Added `POST` call to `/artifacts`
- Added code to read log file off of disk and build `Artifact` struct
- **Note** Existing tests already cover this method since the URL path is shared. Tests of pyxis code will be enhanced when we we switch to grahpql calls.

Signed-off-by: Adam D. Cornett <adc@redhat.com>