### PR TITLE
Reorder the steps in the go action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Format
       run: make fmt
 
-    - name: Build Multi-arch
-      run: make build-multi-arch
-
     - name: Test
       run: make test
+
+    - name: Build Multi-arch
+      run: make build-multi-arch


### PR DESCRIPTION
Put the multi-arch build at the end of the build steps. The multi-
arch builds can take time. We don't want to spend that time unless
all other tests have actually passed. Therefore, it makes sense
to have them at the very end.

Signed-off-by: Brad P. Crochet <brad@redhat.com>