### PR TITLE
added base64 encoded contents to artifacts

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -232,7 +233,7 @@ var checkContainerCmd = &cobra.Command{
 
 			logFileArtifact := pyxis.Artifact{
 				CertProject: projectId,
-				Content:     string(logFileBytes),
+				Content:     base64.StdEncoding.EncodeToString(logFileBytes),
 				ContentType: http.DetectContentType(logFileBytes),
 				Filename:    logFileName,
 				FileSize:    logFileInfo.Size(),


### PR DESCRIPTION
Added base64 encoded contents to artifacts

#### Context
- Pyxis API is expecting base64 encoded contents instead of plain text In the content field: https://catalog.qa.redhat.com/api/containers/v1/ui/#/Images/pyxis.rest.legacy.cert_project_artifacts.get_certification_artifacts_by_image_id
![Screenshot 2022-03-14 at 2 03 33 PM](https://user-images.githubusercontent.com/8397274/158134567-c5ab568f-6e47-491b-b52e-35ae04cb05c6.png)
