### PR TITLE
check image under test for a certified uncompressed top layer id

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -3,13 +3,17 @@ package engine
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	internal "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/engine"
 	containerpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/container"
 	operatorpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/operator"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/pyxis"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+	"github.com/spf13/viper"
 )
 
 // CheckEngine defines the functionality necessary to run all checks for a policy,
@@ -89,8 +93,9 @@ var (
 	hasNoProhibitedCheck   certification.Check = &containerpol.HasNoProhibitedPackagesCheck{}
 	hasRequiredLabelsCheck certification.Check = &containerpol.HasRequiredLabelsCheck{}
 	runAsRootCheck         certification.Check = &containerpol.RunAsNonRootCheck{}
-	basedOnUbiCheck        certification.Check = &containerpol.BasedOnUBICheck{}
 	hasModifiedFilesCheck  certification.Check = &containerpol.HasModifiedFilesCheck{}
+	basedOnUbiCheck        certification.Check = containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisEngine(viper.GetString("pyxis_api_token"),
+		viper.GetString("certification_project_id"), &http.Client{Timeout: 60 * time.Second}))
 	// runnableContainerCheck  certification.Check = containerpol.NewRunnableContainerCheck(internal.NewPodmanEngine())
 	// runSystemContainerCheck certification.Check = containerpol.NewRunSystemContainerCheck(internal.NewPodmanEngine())
 )

--- a/certification/internal/policy/container/base_on_ubi.go
+++ b/certification/internal/policy/container/base_on_ubi.go
@@ -1,73 +1,67 @@
 package container
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
+	"context"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	pyxis "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/pyxis"
 	log "github.com/sirupsen/logrus"
 )
 
 // BasedOnUBICheck evaluates if the provided image is based on the Red Hat Universal Base Image
 // by inspecting the contents of the `/etc/os-release` and identifying if the ID is `rhel` and the
 // Name value is `Red Hat Enterprise Linux`
-type BasedOnUBICheck struct{}
-
-func (p *BasedOnUBICheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	labels, err := p.getLabels(imgRef.ImageInfo)
-	if err != nil {
-		return false, err
-	}
-
-	osRelease, err := p.getOsReleaseContents(imgRef.ImageFSPath)
-	if err != nil {
-		log.Debugf("could not retrieve contents of os-release")
-		return false, err
-	}
-
-	return p.validate(labels, osRelease)
+type BasedOnUBICheck struct {
+	LayerHashCheckEngine layerHashChecker
 }
 
-func (p *BasedOnUBICheck) getLabels(image cranev1.Image) (map[string]string, error) {
+type layerHashChecker interface {
+	CheckRedHatLayers(ctx context.Context, layerHashes []cranev1.Hash) ([]pyxis.CertImage, error)
+}
+
+func NewBasedOnUbiCheck(layerHashChecker layerHashChecker) *BasedOnUBICheck {
+	return &BasedOnUBICheck{LayerHashCheckEngine: layerHashChecker}
+}
+
+func (p *BasedOnUBICheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	layerHashes, err := p.getImageLayers(imgRef.ImageInfo)
+	if err != nil {
+		return false, err
+	}
+
+	return p.validate(layerHashes)
+}
+
+func (p *BasedOnUBICheck) getImageLayers(image cranev1.Image) ([]cranev1.Hash, error) {
 	configFile, err := image.ConfigFile()
 	if err != nil {
 		return nil, err
 	}
-	return configFile.Config.Labels, nil
+
+	return configFile.RootFS.DiffIDs, nil
 }
 
-func (p *BasedOnUBICheck) getOsReleaseContents(path string) ([]string, error) {
-	osrelease, err := os.ReadFile(filepath.Join(path, "etc", "os-release"))
+func (p *BasedOnUBICheck) checkRedHatLayers(ctx context.Context, layerHashes []cranev1.Hash) (bool, error) {
+	certImages, err := p.LayerHashCheckEngine.CheckRedHatLayers(ctx, layerHashes)
 	if err != nil {
-		log.Debug("could not open os-release file for reading")
-		return nil, err
+		log.Error("Error when querying pyxis for uncompressed top layer ids", err)
 	}
-
-	return strings.Split(string(osrelease), "\n"), nil
-}
-
-func (p *BasedOnUBICheck) validate(labels map[string]string, osRelease []string) (bool, error) {
-	var hasRHELID, hasRHELName bool
-	for _, value := range osRelease {
-		line := strings.Split(value, "=")
-		if line[0] == "ID" && line[1] == `"rhel"` {
-			log.Trace("Has RHEL ID")
-			hasRHELID = true
-			continue
-		}
-		if line[0] == "NAME" && strings.Contains(line[1], "Red Hat Enterprise Linux") {
-			log.Trace("Has RHEL Name")
-			hasRHELName = true
-			continue
-		}
-	}
-
-	if hasRHELID && hasRHELName {
+	if certImages != nil && len(certImages) >= 1 {
 		return true, nil
 	}
+	return false, nil
+}
 
+func (p *BasedOnUBICheck) validate(layerHashes []cranev1.Hash) (bool, error) {
+	ctx := context.Background()
+	hasUBIHash, err := p.checkRedHatLayers(ctx, layerHashes)
+	if err != nil {
+		log.Error("Unable to verify layer hashes", err)
+	}
+	if hasUBIHash {
+		return true, nil
+	}
 	return false, nil
 }
 

--- a/certification/internal/policy/container/base_on_ubi_test.go
+++ b/certification/internal/policy/container/base_on_ubi_test.go
@@ -1,56 +1,36 @@
 package container
 
 import (
+	"context"
 	"os"
-	"path/filepath"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/pyxis"
 )
 
-func labelsForUbiCheck(label string, bad bool) map[string]string {
-	labels := map[string]string{
-		"name":                 "name",
-		"vendor":               "vendor",
-		"version":              "version",
-		"release":              "release",
-		"summary":              "summary",
-		"description":          "description",
-		"com.redhat.component": label,
-	}
-
-	if bad {
-		delete(labels, "com.redhat.component")
-	}
-
-	return labels
-}
-
-func goodLabelsConfigFile() (*cranev1.ConfigFile, error) {
+func ConfigFile() (*cranev1.ConfigFile, error) {
 	return &cranev1.ConfigFile{
-		Config: cranev1.Config{
-			Labels: labelsForUbiCheck("ubi8-container", false),
-		},
+		Config: cranev1.Config{},
 	}, nil
 }
 
-func missingUbiLableConfigFile() (*cranev1.ConfigFile, error) {
-	return &cranev1.ConfigFile{
-		Config: cranev1.Config{
-			Labels: labelsForUbiCheck("", true),
-		},
-	}, nil
+type fakeLayerHashChecker struct{}
+
+func (flhc *fakeLayerHashChecker) CheckRedHatLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
+	var matchingImages []pyxis.CertImage
+	matchingImages = append(matchingImages, pyxis.CertImage{})
+	return matchingImages, nil
 }
 
-func badLabelsConfigFile() (*cranev1.ConfigFile, error) {
-	return &cranev1.ConfigFile{
-		Config: cranev1.Config{
-			Labels: labelsForUbiCheck("doesnothavestring", false),
-		},
-	}, nil
+type fakeLayerHashCheckerNoMatch struct{}
+
+func (flhc *fakeLayerHashCheckerNoMatch) CheckRedHatLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
+	var matchingImages []pyxis.CertImage
+	return matchingImages, nil
 }
 
 var _ = Describe("BaseOnUBI", func() {
@@ -59,45 +39,21 @@ var _ = Describe("BaseOnUBI", func() {
 		imageRef        certification.ImageReference
 	)
 
-	const osrelease = "os-release"
-
 	BeforeEach(func() {
 		fakeImage := fakecranev1.FakeImage{
-			ConfigFileStub: goodLabelsConfigFile,
+			ConfigFileStub: ConfigFile,
 		}
 		imageRef.ImageInfo = &fakeImage
-		var err error
-		tmpDir, err := os.MkdirTemp("", "based-on-ubi-*")
-		Expect(err).ToNot(HaveOccurred())
-		err = os.Mkdir(filepath.Join(tmpDir, "etc"), 0o755)
-		Expect(err).ToNot(HaveOccurred())
-		err = os.WriteFile(filepath.Join(tmpDir, "etc", osrelease), []byte(`ID="rhel"
-NAME="Red Hat Enterprise Linux"
-`), 0o644)
-		Expect(err).ToNot(HaveOccurred())
-		imageRef.ImageFSPath = tmpDir
 	})
 	AfterEach(func() {
 		os.RemoveAll(imageRef.ImageFSPath)
 	})
 	Describe("Checking for UBI as a base", func() {
-		Context("When it is based on UBI 8", func() {
-			Context("and has the correct os-release", func() {
-				It("should pass Validate", func() {
-					ok, err := basedOnUbiCheck.Validate(imageRef)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(ok).To(BeTrue())
-				})
+		Context("When the image contains a layer hash that is a ubi or ubi derived uncompressed top layer id", func() {
+			JustBeforeEach(func() {
+				basedOnUbiCheck.LayerHashCheckEngine = &fakeLayerHashChecker{}
 			})
-		})
-		Context("When it is based on UBI 7", func() {
-			Context("and has the correct os-release", func() {
-				JustBeforeEach(func() {
-					err := os.WriteFile(filepath.Join(imageRef.ImageFSPath, "etc", osrelease), []byte(`ID="rhel"
-NAME="Red Hat Enterprise Linux Server"
-`), 0o644)
-					Expect(err).ToNot(HaveOccurred())
-				})
+			Context("and pyxis returns a match", func() {
 				It("should pass Validate", func() {
 					ok, err := basedOnUbiCheck.Validate(imageRef)
 					Expect(err).ToNot(HaveOccurred())
@@ -106,25 +62,16 @@ NAME="Red Hat Enterprise Linux Server"
 			})
 		})
 		Context("When it is not based on UBI", func() {
-			Context("and has a bad os-release", func() {
-				JustBeforeEach(func() {
-					err := os.WriteFile(filepath.Join(imageRef.ImageFSPath, "etc", osrelease), []byte("Not a good file"), 0o644)
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("should not pass Validate", func() {
-					ok, err := basedOnUbiCheck.Validate(imageRef)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(ok).To(BeFalse())
-				})
+			JustBeforeEach(func() {
+				basedOnUbiCheck.LayerHashCheckEngine = &fakeLayerHashCheckerNoMatch{}
 			})
-			Context("and os-release is missing", func() {
-				JustBeforeEach(func() {
-					os.Remove(filepath.Join(imageRef.ImageFSPath, "etc", osrelease))
-				})
-				It("should not pass Validate", func() {
-					ok, err := basedOnUbiCheck.Validate(imageRef)
-					Expect(err).To(HaveOccurred())
-					Expect(ok).To(BeFalse())
+			Context("When the image does not contain a layer hash that is a ubi or ubi derived uncompressed top layer id", func() {
+				Context("and pyxis returns no matches", func() {
+					It("should not pass Validate", func() {
+						ok, err := basedOnUbiCheck.Validate(imageRef)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(ok).To(BeFalse())
+					})
 				})
 			})
 		})

--- a/certification/pyxis/layers.go
+++ b/certification/pyxis/layers.go
@@ -1,0 +1,66 @@
+package pyxis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+	log "github.com/sirupsen/logrus"
+)
+
+func (p *pyxisEngine) CheckRedHatLayers(ctx context.Context, layerHashes []cranev1.Hash) ([]CertImage, error) {
+	layerIds := make([]string, 0, len(layerHashes))
+	for _, layer := range layerHashes {
+		layerIds = append(layerIds, layer.String())
+	}
+
+	log.Tracef("the layerIds passed to pyxis are %s", layerIds)
+
+	req, err := p.newRequestWithApiToken(
+		ctx,
+		http.MethodGet,
+		getPyxisUrl(fmt.Sprintf("filter=repositories.registry=eq=(registry.access.redhat.com) and uncompressed_top_layer_id=in=(%s)", strings.Join(layerIds, ","))),
+		nil,
+	)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		err := fmt.Sprintf("Recieved http status %s instead of 200 OK", resp.Status)
+		log.Error("Unexpected Status Code", err)
+		return nil, errors.New(err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	type imageList struct {
+		Images []CertImage `json:"data"`
+	}
+
+	var images imageList
+	if err := json.Unmarshal(body, &images); err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	return images.Images, nil
+}


### PR DESCRIPTION
Addresses #25 this will make the current based on ubi check fail due to the query to pyxis timing out. This improvement to the based on ubi check attempts to emulate[1] There is an issue open to refactor the query on the pyxis side[2]

[1]https://gitlab.cee.redhat.com/cvp/pipeline/-/blob/master/src/org/cvp/pipeline/IsvContainerUtils.groovy#L17
[2]https://issues.redhat.com/browse/ISV-1843

Fixes #25 