### PR TITLE
Check for modified base layer files

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -90,6 +90,7 @@ var (
 	hasRequiredLabelsCheck certification.Check = &containerpol.HasRequiredLabelsCheck{}
 	runAsRootCheck         certification.Check = &containerpol.RunAsNonRootCheck{}
 	basedOnUbiCheck        certification.Check = &containerpol.BasedOnUBICheck{}
+	hasModifiedFilesCheck  certification.Check = &containerpol.HasModifiedFilesCheck{}
 	// runnableContainerCheck  certification.Check = containerpol.NewRunnableContainerCheck(internal.NewPodmanEngine())
 	// runSystemContainerCheck certification.Check = containerpol.NewRunSystemContainerCheck(internal.NewPodmanEngine())
 )
@@ -110,6 +111,7 @@ var containerPolicy = map[string]certification.Check{
 	hasRequiredLabelsCheck.Name(): hasRequiredLabelsCheck,
 	runAsRootCheck.Name():         runAsRootCheck,
 	basedOnUbiCheck.Name():        basedOnUbiCheck,
+	hasModifiedFilesCheck.Name():  hasModifiedFilesCheck,
 	// runnableContainerCheck.Name():  runnableContainerCheck,
 	// runSystemContainerCheck.Name(): runSystemContainerCheck,
 }

--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -33,4 +33,5 @@ var (
 	ErrNon200StatusCode                = errors.New("error calling remote API")
 	Err409StatusCode                   = errors.New("remote API returned conflict")
 	ErrInvalidImageUri                 = errors.New("image uri could not be parsed")
+	ErrRetrievingLayers                = errors.New("could not get container layers")
 )

--- a/certification/internal/policy/container/has_modifed_files_test.go
+++ b/certification/internal/policy/container/has_modifed_files_test.go
@@ -1,0 +1,59 @@
+package container
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HasModifiedFiles", func() {
+	var (
+		HasModifiedFiles HasModifiedFilesCheck
+		pkgList          packageFilesRef
+	)
+
+	BeforeEach(func() {
+		pkgList = packageFilesRef{
+			LayerFiles: [][]string{
+				{
+					"this",
+					"is",
+					"not",
+					"prohibitted",
+				},
+				{
+					"there",
+					"are",
+					"no",
+					"prohibitted",
+					"duplicates",
+				},
+			},
+			PackageFiles: map[string]struct{}{
+				"this": {},
+				"is":   {},
+				"not":  {},
+			},
+		}
+	})
+	Describe("Checking if it has any modified RPM files", func() {
+		Context("When there are no modified RPM files found", func() {
+			It("should pass validate", func() {
+				ok, err := HasModifiedFiles.validate(&pkgList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When there is a modified RPM file found", func() {
+			var pkgs packageFilesRef
+			BeforeEach(func() {
+				pkgs = pkgList
+				pkgs.LayerFiles[1] = append(pkgs.LayerFiles[1], "this")
+			})
+			It("should not pass Validate", func() {
+				ok, err := HasModifiedFiles.validate(&pkgs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})

--- a/certification/internal/policy/container/has_modified_files.go
+++ b/certification/internal/policy/container/has_modified_files.go
@@ -1,0 +1,170 @@
+package container
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/rpm"
+	log "github.com/sirupsen/logrus"
+)
+
+// HasLicenseCheck evaluates that the image contains a license definition available at
+// /licenses.
+type HasModifiedFilesCheck struct{}
+
+type packageFilesRef struct {
+	LayerFiles   [][]string
+	PackageFiles map[string]struct{}
+}
+
+func (p *HasModifiedFilesCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+	packageFiles, err := p.getDataToValidate(imgRef)
+	if err != nil {
+		return false, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
+	}
+	return p.validate(packageFiles)
+}
+
+func (p *HasModifiedFilesCheck) getDataToValidate(imageRef certification.ImageReference) (*packageFilesRef, error) {
+	pkgList, err := rpm.GetPackageList(imageRef.ImageFSPath)
+	if err != nil {
+		return nil, err
+	}
+	packageFiles := make(map[string]struct{}, len(pkgList))
+	for _, pkg := range pkgList {
+		filenames, err := pkg.InstalledFiles()
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range filenames {
+			packageFiles[file] = struct{}{}
+		}
+	}
+
+	layers, err := imageRef.ImageInfo.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([][]string, 0, len(layers))
+
+	for _, layer := range layers {
+		r, err := layer.Uncompressed()
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
+		}
+		pathChan := make(chan string)
+
+		go func() {
+			layerFiles := make([]string, 0)
+			for path := range pathChan {
+				layerFiles = append(layerFiles, path)
+			}
+			files = append(files, layerFiles)
+		}()
+		err = untar(pathChan, r)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
+		}
+	}
+
+	return &packageFilesRef{files, packageFiles}, nil
+}
+
+func (p *HasModifiedFilesCheck) validate(packageFilesRef *packageFilesRef) (bool, error) {
+	layerFiles := packageFilesRef.LayerFiles
+	packageFiles := packageFilesRef.PackageFiles
+	baseLayer := make(map[string]struct{}, len(layerFiles[0]))
+	for _, filename := range layerFiles[0] {
+		if _, ok := packageFiles[filename]; ok {
+			baseLayer[filename] = struct{}{}
+		}
+	}
+	layers := layerFiles[1:]
+
+	modifiedFilesDetected := false
+	for _, layer := range layers {
+		for _, file := range layer {
+			if _, ok := baseLayer[file]; ok {
+				// This means the files exists in the base layer. This is a fail.
+				log.Errorf("modified file detected: %s", file)
+				modifiedFilesDetected = true
+			}
+		}
+	}
+	return !modifiedFilesDetected, nil
+}
+
+func (p HasModifiedFilesCheck) Name() string {
+	return "HasModifiedFiles"
+}
+
+func (p HasModifiedFilesCheck) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Check HasModifiedFiles encountered an error. Please review the preflight.log file for more information.",
+		Suggestion: "Do not modify any files installed by RPM in the base Red Hat layer",
+	}
+}
+
+func (p HasModifiedFilesCheck) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checks that no files installed via RPM in the base Red Hat layer have been modified",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+// Untar takes a destination path and a reader; a tar reader loops over the tarfile
+// creating the file structure at 'dst' along the way, and writing any files
+func untar(pathChan chan<- string, r io.Reader) error {
+	tr := tar.NewReader(r)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			close(pathChan)
+			return nil
+
+		// return any other error
+		case err != nil:
+			return err
+
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// the target location where the dir/file should be created
+		target := header.Name
+
+		// the following switch could also be done using fi.Mode(), not sure if there
+		// a benefit of using one vs. the other.
+		// fi := header.FileInfo()
+
+		// check the file type
+		switch header.Typeflag {
+
+		// if its a dir ignore it
+		case tar.TypeDir:
+			continue
+
+		// if it's a file write the name to the channel
+		case tar.TypeReg:
+			// Strip off any leading '/' or './'
+			pathChan <- strings.TrimLeft(target, "./")
+
+		// if it's a link create it
+		case tar.TypeSymlink:
+			pathChan <- strings.TrimLeft(header.Linkname, "./")
+		}
+	}
+}

--- a/certification/internal/policy/container/has_prohibited_packages.go
+++ b/certification/internal/policy/container/has_prohibited_packages.go
@@ -1,13 +1,10 @@
 package container
 
 import (
-	syserrors "errors"
-	"os"
-	"path/filepath"
 	"strings"
 
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/rpm"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -26,20 +23,7 @@ func (p *HasNoProhibitedPackagesCheck) Validate(imgRef certification.ImageRefere
 }
 
 func (p *HasNoProhibitedPackagesCheck) getDataToValidate(dir string) ([]string, error) {
-	// Check for rpmdb.sqlite. If not found, check for Packages
-	rpmdirPath := filepath.Join(dir, "var", "lib", "rpm")
-	rpmdbPath := filepath.Join(rpmdirPath, "rpmdb.sqlite")
-
-	if _, err := os.Stat(rpmdbPath); syserrors.Is(err, os.ErrNotExist) {
-		// rpmdb.sqlite doesn't exist. Fall back to Packages
-		rpmdbPath = filepath.Join(rpmdirPath, "Packages")
-	}
-
-	db, err := rpmdb.Open(rpmdbPath)
-	if err != nil {
-		return nil, err
-	}
-	pkgList, err := db.ListPackages()
+	pkgList, err := rpm.GetPackageList(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/certification/internal/rpm/rpm.go
+++ b/certification/internal/rpm/rpm.go
@@ -1,0 +1,30 @@
+package rpm
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+)
+
+func GetPackageList(basePath string) ([]*rpmdb.PackageInfo, error) {
+	rpmdirPath := filepath.Join(basePath, "var", "lib", "rpm")
+	rpmdbPath := filepath.Join(rpmdirPath, "rpmdb.sqlite")
+
+	if _, err := os.Stat(rpmdbPath); errors.Is(err, os.ErrNotExist) {
+		// rpmdb.sqlite doesn't exist. Fall back to Packages
+		rpmdbPath = filepath.Join(rpmdirPath, "Packages")
+	}
+
+	db, err := rpmdb.Open(rpmdbPath)
+	if err != nil {
+		return nil, err
+	}
+	pkgList, err := db.ListPackages()
+	if err != nil {
+		return nil, err
+	}
+
+	return pkgList, nil
+}


### PR DESCRIPTION
Check that no files from the base layer have been modified by
subsequent layers. This only checks for files that are installed as
RPMs.

Fixes #425 

Signed-off-by: Brad P. Crochet <brad@redhat.com>