### PR TITLE
changing parsedData.Layers to come from the imageInfo.Manifest

### DIFF
--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -331,7 +331,6 @@ func writeCertImage(imageRef certification.ImageReference) error {
 
 	labels := convertLabels(config.Config.Labels)
 	layerSizes := make([]pyxis.Layer, 0, len(config.RootFS.DiffIDs))
-	layers := make([]string, 0, len(config.RootFS.DiffIDs))
 	for _, diffid := range config.RootFS.DiffIDs {
 		layer, err := imageRef.ImageInfo.LayerByDiffID(diffid)
 		if err != nil {
@@ -352,8 +351,11 @@ func writeCertImage(imageRef certification.ImageReference) error {
 			Size:    written,
 		}
 		layerSizes = append(layerSizes, pyxisLayer)
+	}
 
-		layers = append(layers, diffid.String())
+	manifestLayers := make([]string, 0, len(manifest.Layers))
+	for _, layer := range manifest.Layers {
+		manifestLayers = append(manifestLayers, layer.Digest.String())
 	}
 
 	sumLayersSizeBytes, err := sumLayerSizeBytes(layerSizes)
@@ -395,7 +397,7 @@ func writeCertImage(imageRef certification.ImageReference) error {
 			DockerVersion:          config.DockerVersion,
 			ImageID:                digest.String(),
 			Labels:                 labels,
-			Layers:                 layers,
+			Layers:                 manifestLayers,
 			OS:                     config.OS,
 			Size:                   size,
 			UncompressedLayerSizes: layerSizes,


### PR DESCRIPTION
- Changing where `parsedData.Layers` is sourced from, obtaining it from imageInfo.Manifest.Layers instead of `config.RootFS.DiffIDs`

Signed-off-by: Adam D. Cornett <adc@redhat.com>