### PR TITLE
Fail multi-arch-build on any failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,16 @@ build:
 	@ls | grep preflight
 
 .PHONY: build-multi-arch
-build-multi-arch:
-	$(foreach GOOS, $(PLATFORMS),\
-	$(foreach GOARCH, $(ARCHITECTURES),\
-	$(shell export GOOS=$(GOOS); export GOARCH=$(GOARCH);go build -o $(BINARY)-$(GOOS)-$(GOARCH) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" main.go)))
-	@ls | grep preflight
+build-multi-arch: $(addprefix build-linux-,$(ARCHITECTURES))
+
+define ARCHITECTURE_template
+.PHONY: build-linux-$(1)
+build-linux-$(1):
+	GOOS=linux GOARCH=$(1) go build -o $(BINARY)-linux-$(1) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
+				-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" main.go
+endef
+
+$(foreach arch,$(ARCHITECTURES),$(eval $(call ARCHITECTURE_template,$(arch))))
 
 .PHONY: fmt
 fmt: gofumpt


### PR DESCRIPTION
Implement a template and a new foreach loop to create individual
targets for each architecture. There is currently no support for a
GOOS other than Linux. If that becomes necessary, we can add support
for other OSs.

FIxes #488

Signed-off-by: Brad P. Crochet <brad@redhat.com>