### PR TITLE
Ignore multi-arch binaries from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vuln.html
 bin
 preflight
 openshift-preflight
+preflight-*
 
 # Config files
 config.yaml


### PR DESCRIPTION
This adds an ignore line to ignore the multi-arch binaries.

Signed-off-by: Brad P. Crochet <brad@redhat.com>