### PR TITLE
Write project id back to viper if modified

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -76,6 +76,9 @@ var checkContainerCmd = &cobra.Command{
 		}
 		if strings.HasPrefix(projectId, "ospid-") {
 			projectId = strings.Split(projectId, "-")[1]
+			// Since we want the modified version, write it back
+			// to viper so that subsequent calls don't need to check
+			viper.Set("certification_project_id", projectId)
 		}
 		apiToken := viper.GetString("pyxis_api_token")
 		pyxisEngine := pyxis.NewPyxisEngine(apiToken, projectId, &http.Client{Timeout: 60 * time.Second})


### PR DESCRIPTION
If a certification project id is passed with 'ospid-' we want to strip
that and write the resulting id back to viper, so future calls don't
have to check for that prefix.

Signed-off-by: Brad P. Crochet <brad@redhat.com>