### PR TITLE
updating gitignore to include check container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,18 +23,14 @@ config.yaml
 # Log files
 *.log
 results.json
-
-# Test binary, build with `go test -c`
-*.test
+cert-image.json
+rpm-manifest.json
 
 # Testing dirs
 /artifacts
 
 # But we don't want to ignore the artifacts package
 !/certification/artifacts
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
 
 # editor and IDE paraphernalia
 .idea


### PR DESCRIPTION
- Updating gitignore to include cert-image and rpm-manifest json files
- Removing duplicate entries for `*.out` and `*.test`

Signed-off-by: Adam D. Cornett <adc@redhat.com>