### PR TITLE
Simplify Pyxis Submit call

### DIFF
--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -8,8 +8,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *pyxisEngine) SubmitResults(ctx context.Context, certProject *CertProject, certImage *CertImage, rpmManifest *RPMManifest, testResults *TestResults, artifacts []Artifact) (*CertProject, *CertImage, *TestResults, error) {
+func (p *pyxisEngine) SubmitResults(ctx context.Context, certInput *CertificationInput) (*CertificationResults, error) {
 	var err error
+
+	certProject := certInput.CertProject
 
 	if certProject.CertificationStatus == "Started" {
 		certProject.CertificationStatus = "In Progress"
@@ -17,60 +19,68 @@ func (p *pyxisEngine) SubmitResults(ctx context.Context, certProject *CertProjec
 
 	oldCertProject, err := p.GetProject(ctx)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: %s", err, "could not retrieve project")
+		return nil, fmt.Errorf("%w: %s", err, "could not retrieve project")
 	}
 
 	if *certProject != *oldCertProject {
 		certProject, err = p.updateProject(ctx, certProject)
 		if err != nil {
 			log.Error(err, "could not update project")
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
+	certImage := certInput.CertImage
 	dockerImageDigest := certImage.DockerImageDigest
 
 	certImage, err = p.createImage(ctx, certImage)
 	if err != nil && err != errors.Err409StatusCode {
 		log.Error(err, "could not create image")
-		return nil, nil, nil, err
+		return nil, err
 	}
 	if err != nil && err == errors.Err409StatusCode {
 		certImage, err = p.getImage(ctx, dockerImageDigest)
 		if err != nil {
 			log.Error(err, "could not get image")
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
+	rpmManifest := certInput.RpmManifest
 	rpmManifest.ImageID = certImage.ID
 	_, err = p.createRPMManifest(ctx, rpmManifest)
 	if err != nil && err != errors.Err409StatusCode {
 		log.Error(err, "could not create rpm manifest")
-		return nil, nil, nil, err
+		return nil, err
 	}
 	if err != nil && err == errors.Err409StatusCode {
 		_, err = p.getRPMManifest(ctx, rpmManifest.ImageID)
 		if err != nil {
 			log.Error(err, "could not get rpm manifest")
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
+	artifacts := certInput.Artifacts
 	for _, artifact := range artifacts {
 		artifact.ImageID = certImage.ID
 		if _, err := p.createArtifact(ctx, &artifact); err != nil {
 			log.Errorf("%s: could not create artifact: %s", err, artifact.Filename)
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
+	testResults := certInput.TestResults
 	testResults.ImageID = certImage.ID
 	testResults, err = p.createTestResults(ctx, testResults)
 	if err != nil {
 		log.Error(err, "could not create test results")
-		return nil, nil, nil, err
+		return nil, err
 	}
 
-	return certProject, certImage, testResults, nil
+	return &CertificationResults{
+		CertProject: certProject,
+		CertImage:   certImage,
+		TestResults: testResults,
+	}, nil
 }

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -20,11 +20,18 @@ var _ = Describe("Pyxis Submit", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(certProject).ToNot(BeNil())
-				Expect(certImage).ToNot(BeNil())
-				Expect(testResults).ToNot(BeNil())
+				Expect(certResults).ToNot(BeNil())
+				Expect(certResults.CertProject).ToNot(BeNil())
+				Expect(certResults.CertImage).ToNot(BeNil())
+				Expect(certResults.TestResults).ToNot(BeNil())
 			})
 		})
 	})
@@ -39,11 +46,15 @@ var _ = Describe("Pyxis Submit updateProject 401 Unauthorized", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).To(MatchError(fmt.Errorf("%w: %s", errors.New("error calling remote API"), "could not retrieve project")))
-				Expect(certProject).To(BeNil())
-				Expect(certImage).To(BeNil())
-				Expect(testResults).To(BeNil())
+				Expect(certResults).To(BeNil())
 			})
 		})
 	})
@@ -58,11 +69,18 @@ var _ = Describe("Pyxis Submit with createImage 409 Conflict", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(certProject).ToNot(BeNil())
-				Expect(certImage).ToNot(BeNil())
-				Expect(testResults).ToNot(BeNil())
+				Expect(certResults).ToNot(BeNil())
+				Expect(certResults.CertProject).ToNot(BeNil())
+				Expect(certResults.CertImage).ToNot(BeNil())
+				Expect(certResults.TestResults).ToNot(BeNil())
 			})
 		})
 	})
@@ -77,11 +95,15 @@ var _ = Describe("Pyxis Submit with createImage 401 Unauthorized", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
-				Expect(certProject).To(BeNil())
-				Expect(certImage).To(BeNil())
-				Expect(testResults).To(BeNil())
+				Expect(certResults).To(BeNil())
 			})
 		})
 	})
@@ -96,11 +118,15 @@ var _ = Describe("Pyxis Submit with createImage 409 Conflict and getImage 401 Un
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
-				Expect(certProject).To(BeNil())
-				Expect(certImage).To(BeNil())
-				Expect(testResults).To(BeNil())
+				Expect(certResults).To(BeNil())
 			})
 		})
 	})
@@ -115,11 +141,18 @@ var _ = Describe("Pyxis Submit with createRPMManifest 409 Conflict", func() {
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(certProject).ToNot(BeNil())
-				Expect(certImage).ToNot(BeNil())
-				Expect(testResults).ToNot(BeNil())
+				Expect(certResults).ToNot(BeNil())
+				Expect(certResults.CertProject).ToNot(BeNil())
+				Expect(certResults.CertImage).ToNot(BeNil())
+				Expect(certResults.TestResults).ToNot(BeNil())
 			})
 		})
 	})
@@ -134,11 +167,15 @@ var _ = Describe("Pyxis Submit with createRPMManifest 401 Unauthorized", func() 
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
-				Expect(certProject).To(BeNil())
-				Expect(certImage).To(BeNil())
-				Expect(testResults).To(BeNil())
+				Expect(certResults).To(BeNil())
 			})
 		})
 	})
@@ -153,11 +190,15 @@ var _ = Describe("Pyxis Submit with createRPMManifest 409 Conflict and getRPMMan
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
-				Expect(certProject).To(BeNil())
-				Expect(certImage).To(BeNil())
-				Expect(testResults).To(BeNil())
+				Expect(certResults).To(BeNil())
 			})
 		})
 	})
@@ -172,11 +213,15 @@ var _ = Describe("Pyxis Submit with createTestResults 401 Unauthorized", func() 
 	Context("when a project is submitted", func() {
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certProject, certImage, testResults, err := pyxisEngine.SubmitResults(ctx, &CertProject{CertificationStatus: "Started"}, &CertImage{}, &RPMManifest{}, &TestResults{}, []Artifact{})
+				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					CertProject: &CertProject{CertificationStatus: "Started"},
+					CertImage:   &CertImage{},
+					RpmManifest: &RPMManifest{},
+					TestResults: &TestResults{},
+					Artifacts:   []Artifact{},
+				})
 				Expect(err).To(MatchError(errors.New("error calling remote API")))
-				Expect(certProject).To(BeNil())
-				Expect(certImage).To(BeNil())
-				Expect(testResults).To(BeNil())
+				Expect(certResults).To(BeNil())
 			})
 		})
 	})

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -4,6 +4,20 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 )
 
+type CertificationInput struct {
+	CertProject *CertProject
+	CertImage   *CertImage
+	TestResults *TestResults
+	RpmManifest *RPMManifest
+	Artifacts   []Artifact
+}
+
+type CertificationResults struct {
+	CertProject *CertProject
+	CertImage   *CertImage
+	TestResults *TestResults
+}
+
 type CertImage struct {
 	ID                     string       `json:"_id,omitempty"`
 	Certified              bool         `json:"certified"`

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -242,15 +242,22 @@ var checkContainerCmd = &cobra.Command{
 			artifacts := make([]pyxis.Artifact, 0, 1)
 			artifacts = append(artifacts, logFileArtifact)
 
-			_, certImage, _, err = pyxisEngine.SubmitResults(ctx, certProject, certImage, rpmManifest, testResults, artifacts)
+			certInput := &pyxis.CertificationInput{
+				CertProject: certProject,
+				CertImage:   certImage,
+				RpmManifest: rpmManifest,
+				TestResults: testResults,
+				Artifacts:   artifacts,
+			}
+			certResults, err := pyxisEngine.SubmitResults(ctx, certInput)
 			if err != nil {
 				return err
 			}
 
 			log.Info("Test results have been submitted to Red Hat.")
 			log.Info("These results will be reviewed by Red Hat for final certification.")
-			log.Infof("The container's image id is: %s.", certImage.ID)
-			log.Infof("Please check %s to view scan results.", buildScanResultsURL(projectId, certImage.ID))
+			log.Infof("The container's image id is: %s.", certResults.CertImage.ID)
+			log.Infof("Please check %s to view scan results.", buildScanResultsURL(projectId, certResults.CertImage.ID))
 			log.Infof(fmt.Sprintf("Please check %s to monitor the progress.", buildOverviewURL(projectId)))
 		}
 


### PR DESCRIPTION
There were too many input parameters and too many output returns.
This makes a type for each to contain each of them. This will allow
expansion of returns and inputs without having to modify the entire
Submit method, since there will only be 2 returns.

Signed-off-by: Brad P. Crochet <brad@redhat.com>