### PR TITLE
Introduce context param throughout the codebase

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -1,11 +1,13 @@
 package certification
 
+import "context"
+
 // Check as an interface containing all methods necessary
 // to use and identify a given check.
 type Check interface {
 	// Validate will test the provided image and determine whether the
 	// image complies with the check's requirements.
-	Validate(imageReference ImageReference) (result bool, err error)
+	Validate(ctx context.Context, imageReference ImageReference) (result bool, err error)
 	// Name returns the name of the check.
 	Name() string
 	// Metadata returns the check's metadata.

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -2,6 +2,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -23,9 +24,9 @@ type CheckEngine interface {
 	// store the results. Errors returned by ExecuteChecks should reflect
 	// errors in pre-validation tasks, and not errors in individual check
 	// execution itself.
-	ExecuteChecks() error
+	ExecuteChecks(context.Context) error
 	// Results returns the outcome of executing all checks.
-	Results() runtime.Results
+	Results(context.Context) runtime.Results
 }
 
 func NewForConfig(config runtime.Config) (CheckEngine, error) {

--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -3,6 +3,7 @@
 package formatters
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
@@ -19,12 +20,12 @@ type ResponseFormatter interface {
 	FileExtension() string
 	// Format takes Results, formats it as needed, and returns the formatted
 	// results ready to write as a byte slice.
-	Format(runtime.Results) (response []byte, formattingError error)
+	Format(context.Context, runtime.Results) (response []byte, formattingError error)
 }
 
 // FormatterFunc describes a function that formats the check validation
 // results.
-type FormatterFunc = func(runtime.Results) (response []byte, formattingError error)
+type FormatterFunc = func(context.Context, runtime.Results) (response []byte, formattingError error)
 
 // NewForConfig returns a new formatter based on the user-provided configuration. It relies
 // on config values which should align with known/supported/built-in formatters.
@@ -73,8 +74,8 @@ func (f *genericFormatter) PrettyName() string {
 }
 
 // Format returns the formatted results as a byte slice.
-func (f *genericFormatter) Format(r runtime.Results) ([]byte, error) {
-	return f.formatterFunc(r)
+func (f *genericFormatter) Format(ctx context.Context, r runtime.Results) ([]byte, error) {
+	return f.formatterFunc(ctx, r)
 }
 
 // FileExtension returns the extension a user might use when formatting

--- a/certification/formatters/formatters_test.go
+++ b/certification/formatters/formatters_test.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,7 +42,7 @@ var _ = Describe("Formatters", func() {
 		Context("with improper arguments", func() {
 			expectedResult := []byte(fmt.Errorf("failed to create a new generic formatter: %w",
 				errors.ErrFormatterNameNotProvided).Error())
-			var fn FormatterFunc = func(runtime.Results) ([]byte, error) {
+			var fn FormatterFunc = func(context.Context, runtime.Results) ([]byte, error) {
 				return expectedResult, nil
 			}
 
@@ -56,7 +57,7 @@ var _ = Describe("Formatters", func() {
 			var expectedResult []byte = []byte("this is a test")
 			var name string = "testFormatter"
 			var extension string = "txt"
-			var fn FormatterFunc = func(runtime.Results) ([]byte, error) {
+			var fn FormatterFunc = func(context.Context, runtime.Results) ([]byte, error) {
 				return expectedResult, nil
 			}
 
@@ -66,7 +67,7 @@ var _ = Describe("Formatters", func() {
 				Expect(formatter).ToNot(BeNil())
 			})
 
-			formattingResult, err := formatter.Format(runtime.Results{})
+			formattingResult, err := formatter.Format(context.TODO(), runtime.Results{})
 			It("should format results as expected", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(formattingResult).To(Equal(expectedResult))

--- a/certification/formatters/generic.go
+++ b/certification/formatters/generic.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -15,7 +16,7 @@ var (
 )
 
 // genericJSONFormatter is a FormatterFunc that formats results as JSON
-func genericJSONFormatter(r runtime.Results) ([]byte, error) {
+func genericJSONFormatter(ctx context.Context, r runtime.Results) ([]byte, error) {
 	response := getResponse(r)
 
 	responseJSON, err := jsonMarshalIndent(response, "", "    ")
@@ -33,7 +34,7 @@ func genericJSONFormatter(r runtime.Results) ([]byte, error) {
 }
 
 // genericXMLFormatter is a FormatterFunc that formats results as XML
-func genericXMLFormatter(r runtime.Results) ([]byte, error) {
+func genericXMLFormatter(ctx context.Context, r runtime.Results) ([]byte, error) {
 	response := getResponse(r)
 
 	responseJSON, err := xmlMarshalIndent(response, "", "    ")

--- a/certification/formatters/generic_test.go
+++ b/certification/formatters/generic_test.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -65,7 +66,7 @@ func TestGenericJSONFormatter(t *testing.T) {
 		}
 
 		// Run the function
-		funcOutput, err := genericJSONFormatter(tc.results)
+		funcOutput, err := genericJSONFormatter(context.TODO(), tc.results)
 
 		if err == nil {
 			// Marshal the response JSON back into an object
@@ -142,7 +143,7 @@ func TestGenericXMLFormatter(t *testing.T) {
 		}
 
 		// Run the function
-		funcOutput, err := genericXMLFormatter(tc.results)
+		funcOutput, err := genericXMLFormatter(context.TODO(), tc.results)
 
 		if err == nil {
 			// Marshal the response XML back into an object

--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"time"
@@ -50,7 +51,7 @@ type JUnitFailure struct {
 	Contents string `xml:",chardata"`
 }
 
-func junitXMLFormatter(r runtime.Results) ([]byte, error) {
+func junitXMLFormatter(ctx context.Context, r runtime.Results) ([]byte, error) {
 	response := getResponse(r)
 	suites := JUnitTestSuites{}
 	testsuite := JUnitTestSuite{

--- a/certification/generic_check.go
+++ b/certification/generic_check.go
@@ -1,8 +1,10 @@
 package certification
 
+import "context"
+
 // ValidatorFunc describes a function that, when executed, will check that an
 // artifact (e.g. operator bundle) complies with a given check.
-type ValidatorFunc = func(ImageReference) (bool, error)
+type ValidatorFunc = func(context.Context, ImageReference) (bool, error)
 
 type genericCheckDefinition struct {
 	name        string
@@ -15,8 +17,8 @@ func (pd *genericCheckDefinition) Name() string {
 	return pd.name
 }
 
-func (pd *genericCheckDefinition) Validate(imgRef ImageReference) (bool, error) {
-	return pd.validatorFn(imgRef)
+func (pd *genericCheckDefinition) Validate(ctx context.Context, imgRef ImageReference) (bool, error) {
+	return pd.validatorFn(ctx, imgRef)
 }
 
 func (pd *genericCheckDefinition) Metadata() Metadata {

--- a/certification/internal/bundle/bundle.go
+++ b/certification/internal/bundle/bundle.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,7 +19,7 @@ const ocpVerV1beta1Unsupported = "4.9"
 // versionsKey is the OpenShift versions in annotations.yaml that lists the versions allowed for an operator
 const versionsKey = "com.redhat.openshift.versions"
 
-func ValidateBundle(engine cli.OperatorSdkEngine, imagePath string) (*cli.OperatorSdkBundleValidateReport, error) {
+func ValidateBundle(ctx context.Context, engine cli.OperatorSdkEngine, imagePath string) (*cli.OperatorSdkBundleValidateReport, error) {
 	selector := []string{"community", "operatorhub"}
 	opts := cli.OperatorSdkBundleValidateOptions{
 		Selector:        selector,
@@ -27,7 +28,7 @@ func ValidateBundle(engine cli.OperatorSdkEngine, imagePath string) (*cli.Operat
 		OutputFormat:    "json-alpha1",
 	}
 
-	annotations, err := GetAnnotations(imagePath)
+	annotations, err := GetAnnotations(ctx, imagePath)
 	if err != nil {
 		log.Error("unable to get annotations.yaml from the bundle")
 		return nil, err
@@ -117,7 +118,7 @@ func cleanStringToGetTheVersionToParse(value string) string {
 	return value
 }
 
-func GetAnnotations(mountedDir string) (map[string]string, error) {
+func GetAnnotations(ctx context.Context, mountedDir string) (map[string]string, error) {
 	log.Trace("reading annotations file from the bundle")
 	log.Debug("mounted directory is ", mountedDir)
 	annotationsFilePath := path.Join(mountedDir, "metadata", "annotations.yaml")
@@ -128,7 +129,7 @@ func GetAnnotations(mountedDir string) (map[string]string, error) {
 		return nil, err
 	}
 
-	annotations, err := ExtractAnnotationsBytes(fileContents)
+	annotations, err := ExtractAnnotationsBytes(ctx, fileContents)
 	if err != nil {
 		log.Error("metadata/annotations.yaml found but is malformed")
 		return nil, err
@@ -139,7 +140,7 @@ func GetAnnotations(mountedDir string) (map[string]string, error) {
 
 // extractAnnotationsBytes reads the annotation data read from a file and returns the expected format for that yaml
 // represented as a map[string]string.
-func ExtractAnnotationsBytes(annotationBytes []byte) (map[string]string, error) {
+func ExtractAnnotationsBytes(ctx context.Context, annotationBytes []byte) (map[string]string, error) {
 	type metadata struct {
 		Annotations map[string]string
 	}
@@ -177,7 +178,7 @@ func getCsvFilePathFromBundle(mountedDir string) (string, error) {
 	return matches[0], nil
 }
 
-func GetSupportedInstalledModes(mountedDir string) (map[string]bool, error) {
+func GetSupportedInstalledModes(ctx context.Context, mountedDir string) (map[string]bool, error) {
 	csvFilepath, err := getCsvFilePathFromBundle(mountedDir)
 	if err != nil {
 		return nil, err

--- a/certification/internal/bundle/bundle_test.go
+++ b/certification/internal/bundle/bundle_test.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -30,7 +31,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				data := []byte("annotations:\n foo: bar")
 
 				It("should properly marshal to a map[string]string", func() {
-					annotations, err := ExtractAnnotationsBytes(data)
+					annotations, err := ExtractAnnotationsBytes(context.TODO(), data)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(annotations["foo"]).To(Equal("bar"))
 				})
@@ -40,7 +41,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				data := []byte{}
 
 				It("should return an error", func() {
-					_, err := ExtractAnnotationsBytes(data)
+					_, err := ExtractAnnotationsBytes(context.TODO(), data)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -49,7 +50,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				data := []byte(`malformed`)
 
 				It("should return an error", func() {
-					_, err := ExtractAnnotationsBytes(data)
+					_, err := ExtractAnnotationsBytes(context.TODO(), data)
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
@@ -48,7 +49,7 @@ type CraneEngine struct {
 	results  runtime.Results
 }
 
-func (c *CraneEngine) ExecuteChecks() error {
+func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 	log.Debug("target image: ", c.Image)
 
 	// prepare crane runtime options, if necessary
@@ -114,12 +115,12 @@ func (c *CraneEngine) ExecuteChecks() error {
 		ImageTagOrSha:   reference.Identifier(),
 	}
 
-	if err := writeCertImage(c.imageRef); err != nil {
+	if err := writeCertImage(ctx, c.imageRef); err != nil {
 		return err
 	}
 
 	if !c.IsScratch {
-		if err := writeRPMManifest(containerFSPath); err != nil {
+		if err := writeRPMManifest(ctx, containerFSPath); err != nil {
 			return err
 		}
 	}
@@ -144,7 +145,7 @@ func (c *CraneEngine) ExecuteChecks() error {
 
 		// run the validation
 		checkStartTime := time.Now()
-		checkPassed, err := check.Validate(c.imageRef)
+		checkPassed, err := check.Validate(ctx, c.imageRef)
 		checkElapsedTime := time.Since(checkStartTime)
 
 		if err != nil {
@@ -231,7 +232,7 @@ func generateBundleHash(bundlePath string) (string, error) {
 }
 
 // Results will return the results of check execution.
-func (c *CraneEngine) Results() runtime.Results {
+func (c *CraneEngine) Results(ctx context.Context) runtime.Results {
 	return c.results
 }
 
@@ -303,7 +304,7 @@ func untar(dst string, r io.Reader) error {
 	}
 }
 
-func writeCertImage(imageRef certification.ImageReference) error {
+func writeCertImage(ctx context.Context, imageRef certification.ImageReference) error {
 	config, err := imageRef.ImageInfo.ConfigFile()
 	if err != nil {
 		return fmt.Errorf("%w: %s", errors.ErrImageInspectFailed, err)
@@ -420,8 +421,8 @@ func writeCertImage(imageRef certification.ImageReference) error {
 	return nil
 }
 
-func writeRPMManifest(containerFSPath string) error {
-	pkgList, err := rpm.GetPackageList(containerFSPath)
+func writeRPMManifest(ctx context.Context, containerFSPath string) error {
+	pkgList, err := rpm.GetPackageList(ctx, containerFSPath)
 	if err != nil {
 		return err
 	}

--- a/certification/internal/policy/container/base_on_ubi.go
+++ b/certification/internal/policy/container/base_on_ubi.go
@@ -24,16 +24,16 @@ func NewBasedOnUbiCheck(layerHashChecker layerHashChecker) *BasedOnUBICheck {
 	return &BasedOnUBICheck{LayerHashCheckEngine: layerHashChecker}
 }
 
-func (p *BasedOnUBICheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	layerHashes, err := p.getImageLayers(imgRef.ImageInfo)
+func (p *BasedOnUBICheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
+	layerHashes, err := p.getImageLayers(ctx, imgRef.ImageInfo)
 	if err != nil {
 		return false, err
 	}
 
-	return p.validate(layerHashes)
+	return p.validate(ctx, layerHashes)
 }
 
-func (p *BasedOnUBICheck) getImageLayers(image cranev1.Image) ([]cranev1.Hash, error) {
+func (p *BasedOnUBICheck) getImageLayers(ctx context.Context, image cranev1.Image) ([]cranev1.Hash, error) {
 	configFile, err := image.ConfigFile()
 	if err != nil {
 		return nil, err
@@ -53,8 +53,7 @@ func (p *BasedOnUBICheck) checkRedHatLayers(ctx context.Context, layerHashes []c
 	return false, nil
 }
 
-func (p *BasedOnUBICheck) validate(layerHashes []cranev1.Hash) (bool, error) {
-	ctx := context.Background()
+func (p *BasedOnUBICheck) validate(ctx context.Context, layerHashes []cranev1.Hash) (bool, error) {
 	hasUBIHash, err := p.checkRedHatLayers(ctx, layerHashes)
 	if err != nil {
 		log.Error("Unable to verify layer hashes", err)

--- a/certification/internal/policy/container/base_on_ubi_test.go
+++ b/certification/internal/policy/container/base_on_ubi_test.go
@@ -55,7 +55,7 @@ var _ = Describe("BaseOnUBI", func() {
 			})
 			Context("and pyxis returns a match", func() {
 				It("should pass Validate", func() {
-					ok, err := basedOnUbiCheck.Validate(imageRef)
+					ok, err := basedOnUbiCheck.Validate(context.TODO(), imageRef)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
 				})
@@ -68,7 +68,7 @@ var _ = Describe("BaseOnUBI", func() {
 			Context("When the image does not contain a layer hash that is a ubi or ubi derived uncompressed top layer id", func() {
 				Context("and pyxis returns no matches", func() {
 					It("should not pass Validate", func() {
-						ok, err := basedOnUbiCheck.Validate(imageRef)
+						ok, err := basedOnUbiCheck.Validate(context.TODO(), imageRef)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(ok).To(BeFalse())
 					})

--- a/certification/internal/policy/container/has_license_test.go
+++ b/certification/internal/policy/container/has_license_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -34,7 +35,7 @@ var _ = Describe("HasLicense", func() {
 		})
 		Context("When license(s) are found", func() {
 			It("Should pass Validate", func() {
-				ok, err := HasLicense.Validate(imgRef)
+				ok, err := HasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -44,7 +45,7 @@ var _ = Describe("HasLicense", func() {
 				imgRef.ImageFSPath = "/invalid"
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate(imgRef)
+				ok, err := HasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -55,7 +56,7 @@ var _ = Describe("HasLicense", func() {
 				os.Remove(filepath.Join(imgRef.ImageFSPath, licenses, emptyLicense))
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate(imgRef)
+				ok, err := HasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -65,7 +66,7 @@ var _ = Describe("HasLicense", func() {
 				os.Remove(filepath.Join(imgRef.ImageFSPath, licenses, validLicense))
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate(imgRef)
+				ok, err := HasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/has_modified_files.go
+++ b/certification/internal/policy/container/has_modified_files.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"archive/tar"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -21,16 +22,16 @@ type packageFilesRef struct {
 	PackageFiles map[string]struct{}
 }
 
-func (p *HasModifiedFilesCheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	packageFiles, err := p.getDataToValidate(imgRef)
+func (p *HasModifiedFilesCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
+	packageFiles, err := p.getDataToValidate(ctx, imgRef)
 	if err != nil {
 		return false, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
 	}
 	return p.validate(packageFiles)
 }
 
-func (p *HasModifiedFilesCheck) getDataToValidate(imageRef certification.ImageReference) (*packageFilesRef, error) {
-	pkgList, err := rpm.GetPackageList(imageRef.ImageFSPath)
+func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef certification.ImageReference) (*packageFilesRef, error) {
+	pkgList, err := rpm.GetPackageList(ctx, imgRef.ImageFSPath)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +46,7 @@ func (p *HasModifiedFilesCheck) getDataToValidate(imageRef certification.ImageRe
 		}
 	}
 
-	layers, err := imageRef.ImageInfo.Layers()
+	layers, err := imgRef.ImageInfo.Layers()
 	if err != nil {
 		return nil, err
 	}

--- a/certification/internal/policy/container/has_prohibited_packages.go
+++ b/certification/internal/policy/container/has_prohibited_packages.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -12,18 +13,18 @@ import (
 // which refers to packages that are not redistributable without an appropriate license.
 type HasNoProhibitedPackagesCheck struct{}
 
-func (p *HasNoProhibitedPackagesCheck) Validate(imgRef certification.ImageReference) (bool, error) {
-	pkgList, err := p.getDataToValidate(imgRef.ImageFSPath)
+func (p *HasNoProhibitedPackagesCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
+	pkgList, err := p.getDataToValidate(ctx, imgRef.ImageFSPath)
 	if err != nil {
 		log.Error("unable to get a list of all packages in the image")
 		return false, err
 	}
 
-	return p.validate(pkgList)
+	return p.validate(ctx, pkgList)
 }
 
-func (p *HasNoProhibitedPackagesCheck) getDataToValidate(dir string) ([]string, error) {
-	pkgList, err := rpm.GetPackageList(dir)
+func (p *HasNoProhibitedPackagesCheck) getDataToValidate(ctx context.Context, dir string) ([]string, error) {
+	pkgList, err := rpm.GetPackageList(ctx, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +35,7 @@ func (p *HasNoProhibitedPackagesCheck) getDataToValidate(dir string) ([]string, 
 	return pkgs, nil
 }
 
-func (p *HasNoProhibitedPackagesCheck) validate(pkgList []string) (bool, error) {
+func (p *HasNoProhibitedPackagesCheck) validate(ctx context.Context, pkgList []string) (bool, error) {
 	var prohibitedPackages []string
 	for _, pkg := range pkgList {
 		_, ok := prohibitedPackageList[pkg]

--- a/certification/internal/policy/container/has_prohibited_packages_test.go
+++ b/certification/internal/policy/container/has_prohibited_packages_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -22,7 +24,7 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 	Describe("Checking if it has an prohibited packages", func() {
 		Context("When there are no prohibited packages found", func() {
 			It("should pass validate", func() {
-				ok, err := HasNoProhibitedPackages.validate(pkgList)
+				ok, err := HasNoProhibitedPackages.validate(context.TODO(), pkgList)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -33,7 +35,7 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 				pkgs = append(pkgList, "grub")
 			})
 			It("should not pass Validate", func() {
-				ok, err := HasNoProhibitedPackages.validate(pkgs)
+				ok, err := HasNoProhibitedPackages.validate(context.TODO(), pkgs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -44,7 +46,7 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 				pkgs = append(pkgList, "kpatch2121")
 			})
 			It("should not pass Validate", func() {
-				ok, err := HasNoProhibitedPackages.validate(pkgs)
+				ok, err := HasNoProhibitedPackages.validate(context.TODO(), pkgs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/has_required_labels.go
+++ b/certification/internal/policy/container/has_required_labels.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
@@ -12,7 +14,7 @@ var requiredLabels = []string{"name", "vendor", "version", "release", "summary",
 // labels are present on the image asset as it exists in its current container registry.
 type HasRequiredLabelsCheck struct{}
 
-func (p *HasRequiredLabelsCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+func (p *HasRequiredLabelsCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
 	labels, err := p.getDataForValidate(imgRef.ImageInfo)
 	if err != nil {
 		return false, err

--- a/certification/internal/policy/container/has_required_labels_test.go
+++ b/certification/internal/policy/container/has_required_labels_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo/v2"
@@ -57,7 +59,7 @@ var _ = Describe("HasRequiredLabels", func() {
 	Describe("Checking for required labels", func() {
 		Context("When it has required labels", func() {
 			It("should pass Validate", func() {
-				ok, err := hasRequiredLabelsCheck.Validate(imageRef)
+				ok, err := hasRequiredLabelsCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -70,7 +72,7 @@ var _ = Describe("HasRequiredLabels", func() {
 				imageRef.ImageInfo = &fakeImage
 			})
 			It("should not succeed the check", func() {
-				ok, err := hasRequiredLabelsCheck.Validate(imageRef)
+				ok, err := hasRequiredLabelsCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/has_unique_tag.go
+++ b/certification/internal/policy/container/has_unique_tag.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -19,7 +20,7 @@ type HasUniqueTagCheck struct {
 	TagLister service.TagLister
 }
 
-func (p *HasUniqueTagCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+func (p *HasUniqueTagCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
 	tags, err := p.getDataToValidate(fmt.Sprintf("%s/%s", imgRef.ImageRegistry, imgRef.ImageRepository))
 	if err != nil {
 		return false, err

--- a/certification/internal/policy/container/has_unique_tag_test.go
+++ b/certification/internal/policy/container/has_unique_tag_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -28,7 +30,7 @@ var _ = Describe("UniqueTag", func() {
 				hasUniqueTagCheck = *NewHasUniqueTagCheck(&fakeTagLister{Tags: validImageTags()})
 			})
 			It("should pass Validate", func() {
-				ok, err := hasUniqueTagCheck.Validate(certification.ImageReference{ImageRegistry: "index.docker.io", ImageRepository: "dummy/image"})
+				ok, err := hasUniqueTagCheck.Validate(context.TODO(), certification.ImageReference{ImageRegistry: "index.docker.io", ImageRepository: "dummy/image"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -38,7 +40,7 @@ var _ = Describe("UniqueTag", func() {
 				hasUniqueTagCheck = *NewHasUniqueTagCheck(&fakeTagLister{Tags: invalidImageTags()})
 			})
 			It("should not pass Validate", func() {
-				ok, err := hasUniqueTagCheck.Validate(certification.ImageReference{ImageRegistry: "index.docker.io", ImageRepository: "dummy/other-image"})
+				ok, err := hasUniqueTagCheck.Validate(context.TODO(), certification.ImageReference{ImageRegistry: "index.docker.io", ImageRepository: "dummy/other-image"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/max_layers.go
+++ b/certification/internal/policy/container/max_layers.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
@@ -15,8 +16,8 @@ const (
 // UnderLayerMaxCheck ensures that the image has less layers in its assembly than a predefined maximum.
 type MaxLayersCheck struct{}
 
-func (p *MaxLayersCheck) Validate(imageRef certification.ImageReference) (bool, error) {
-	layers, err := p.getDataToValidate(imageRef.ImageInfo)
+func (p *MaxLayersCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
+	layers, err := p.getDataToValidate(imgRef.ImageInfo)
 	if err != nil {
 		return false, err
 	}

--- a/certification/internal/policy/container/max_layers_test.go
+++ b/certification/internal/policy/container/max_layers_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo/v2"
@@ -40,7 +42,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 	Describe("Checking for less than max layers", func() {
 		Context("When it has fewer layers than max", func() {
 			It("should pass Validate", func() {
-				ok, err := maxLayersCheck.Validate(imgRef)
+				ok, err := maxLayersCheck.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -53,7 +55,7 @@ var _ = Describe("LessThanMaxLayers", func() {
 				imgRef.ImageInfo = &fakeImage
 			})
 			It("should not succeed the check", func() {
-				ok, err := maxLayersCheck.Validate(imgRef)
+				ok, err := maxLayersCheck.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/run_system_container.go
+++ b/certification/internal/policy/container/run_system_container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -21,7 +22,7 @@ func NewRunSystemContainerCheck(podmanEngine *cli.PodmanEngine) *RunSystemContai
 	}
 }
 
-func (p *RunSystemContainerCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+func (p *RunSystemContainerCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
 	containerName := "podman-test"
 
 	runOptions := &cli.PodmanCreateOption{

--- a/certification/internal/policy/container/run_system_container_test.go
+++ b/certification/internal/policy/container/run_system_container_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,7 +26,7 @@ var _ = Describe("RunSystemContainerCheck", func() {
 			It("should pass Validate", func() {
 				engine = GoodPodmanEngine{}
 				runSystemContainerCheck = *NewRunSystemContainerCheck(&engine)
-				ok, err := runSystemContainerCheck.Validate(imageRef)
+				ok, err := runSystemContainerCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -33,7 +35,7 @@ var _ = Describe("RunSystemContainerCheck", func() {
 			It("should not pass Validate", func() {
 				engine = BadPodmanEngine{}
 				runSystemContainerCheck = *NewRunSystemContainerCheck(&engine)
-				ok, err := runSystemContainerCheck.Validate(imageRef)
+				ok, err := runSystemContainerCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/runnable_container.go
+++ b/certification/internal/policy/container/runnable_container.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	"github.com/containers/podman/v3/libpod/define"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
@@ -19,7 +21,7 @@ func NewRunnableContainerCheck(podmanEngine *cli.PodmanEngine) *RunnableContaine
 	}
 }
 
-func (p *RunnableContainerCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+func (p *RunnableContainerCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
 	runOptions := &cli.PodmanCreateOption{
 		Cmd: []string{"sleep", checkContainerTimeout.String()},
 	}

--- a/certification/internal/policy/container/runnable_container_test.go
+++ b/certification/internal/policy/container/runnable_container_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,7 +26,7 @@ var _ = Describe("RunnableContainerCheck", func() {
 			It("should pass Validate", func() {
 				engine = GoodPodmanEngine{}
 				runnableContainerCheck = *NewRunnableContainerCheck(&engine)
-				ok, err := runnableContainerCheck.Validate(imageRef)
+				ok, err := runnableContainerCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -33,7 +35,7 @@ var _ = Describe("RunnableContainerCheck", func() {
 			It("should not pass Validate", func() {
 				engine = BadPodmanEngine{}
 				runnableContainerCheck = *NewRunnableContainerCheck(&engine)
-				ok, err := runnableContainerCheck.Validate(imageRef)
+				ok, err := runnableContainerCheck.Validate(context.TODO(), imageRef)
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/runs_as_nonroot.go
+++ b/certification/internal/policy/container/runs_as_nonroot.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
@@ -10,7 +12,7 @@ import (
 // which correlates to the root user.
 type RunAsNonRootCheck struct{}
 
-func (p *RunAsNonRootCheck) Validate(imgRef certification.ImageReference) (bool, error) {
+func (p *RunAsNonRootCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
 	user, err := p.getDataToValidate(imgRef.ImageInfo)
 	if err != nil {
 		return false, err

--- a/certification/internal/policy/container/runs_as_nonroot_test.go
+++ b/certification/internal/policy/container/runs_as_nonroot_test.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"context"
+
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo/v2"
@@ -48,7 +50,7 @@ var _ = Describe("RunAsNonRoot", func() {
 	Describe("Checking manifest user is not root", func() {
 		Context("When manifest user is not root", func() {
 			It("should pass Validate", func() {
-				ok, err := runAsNonRoot.Validate(imageRef)
+				ok, err := runAsNonRoot.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -63,7 +65,7 @@ var _ = Describe("RunAsNonRoot", func() {
 				imageRef.ImageInfo = &fakeImage
 			})
 			It("should not pass Validate", func() {
-				ok, err := runAsNonRoot.Validate(imageRef)
+				ok, err := runAsNonRoot.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -76,7 +78,7 @@ var _ = Describe("RunAsNonRoot", func() {
 				imageRef.ImageInfo = &fakeImage
 			})
 			It("should not pass Validate", func() {
-				ok, err := runAsNonRoot.Validate(imageRef)
+				ok, err := runAsNonRoot.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -89,7 +91,7 @@ var _ = Describe("RunAsNonRoot", func() {
 				imageRef.ImageInfo = &fakeImage
 			})
 			It("should not pass Validate", func() {
-				ok, err := runAsNonRoot.Validate(imageRef)
+				ok, err := runAsNonRoot.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -53,10 +53,8 @@ func NewDeployableByOlmCheck(openshiftEngine *cli.OpenshiftEngine, operatorSdkEn
 	}
 }
 
-func (p *DeployableByOlmCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
-	ctx := context.Background()
-
-	if report, err := bundle.ValidateBundle(p.OperatorSdkEngine, bundleRef.ImageFSPath); err != nil || !report.Passed {
+func (p *DeployableByOlmCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
+	if report, err := bundle.ValidateBundle(ctx, p.OperatorSdkEngine, bundleRef.ImageFSPath); err != nil || !report.Passed {
 		return false, err
 	}
 
@@ -67,7 +65,7 @@ func (p *DeployableByOlmCheck) Validate(bundleRef certification.ImageReference) 
 	}
 
 	// retrieve the required data
-	operatorData, err := p.operatorMetadata(bundleRef)
+	operatorData, err := p.operatorMetadata(ctx, bundleRef)
 	if err != nil {
 		return false, err
 	}
@@ -138,9 +136,9 @@ func checkImageSource(operatorImages []string) bool {
 	return allApproved
 }
 
-func (p *DeployableByOlmCheck) operatorMetadata(bundleRef certification.ImageReference) (*OperatorData, error) {
+func (p *DeployableByOlmCheck) operatorMetadata(ctx context.Context, bundleRef certification.ImageReference) (*OperatorData, error) {
 	// retrieve the operator metadata from bundle image
-	annotations, err := bundle.GetAnnotations(bundleRef.ImageFSPath)
+	annotations, err := bundle.GetAnnotations(ctx, bundleRef.ImageFSPath)
 	if err != nil {
 		log.Error("unable to get annotations.yaml from the bundle")
 		return nil, err
@@ -164,7 +162,7 @@ func (p *DeployableByOlmCheck) operatorMetadata(bundleRef certification.ImageRef
 		return nil, err
 	}
 
-	installedModes, err := bundle.GetSupportedInstalledModes(bundleRef.ImageFSPath)
+	installedModes, err := bundle.GetSupportedInstalledModes(ctx, bundleRef.ImageFSPath)
 	if err != nil {
 		log.Error("unable to extract operator install modes from ClusterServicVersion: ", err)
 		return nil, err

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"time"
@@ -107,7 +108,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine, &fakeEngine)
 			})
 			It("Should pass Validate", func() {
-				ok, err := deployableByOLMCheck.Validate(imageRef)
+				ok, err := deployableByOLMCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -118,7 +119,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine, &fakeEngine)
 			})
 			It("Should fail Validate", func() {
-				ok, err := deployableByOLMCheck.Validate(imageRef)
+				ok, err := deployableByOLMCheck.Validate(context.TODO(), imageRef)
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -130,7 +131,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine, &fakeEngine)
 			})
 			It("Should pass Validate", func() {
-				ok, err := deployableByOLMCheck.Validate(imageRef)
+				ok, err := deployableByOLMCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -143,7 +144,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine, &fakeEngine)
 			})
 			It("Should pass Validate", func() {
-				ok, err := deployableByOLMCheck.Validate(imageRef)
+				ok, err := deployableByOLMCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -157,7 +158,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine, &fakeEngine)
 			})
 			It("Should pass Validate", func() {
-				ok, err := deployableByOLMCheck.Validate(imageRef)
+				ok, err := deployableByOLMCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -170,7 +171,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				deployableByOLMCheck = *NewDeployableByOlmCheck(&engine, &fakeEngine)
 			})
 			It("Should pass Validate", func() {
-				ok, err := deployableByOLMCheck.Validate(imageRef)
+				ok, err := deployableByOLMCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})

--- a/certification/internal/policy/operator/operator_pkg_name_uniqueness_test.go
+++ b/certification/internal/policy/operator/operator_pkg_name_uniqueness_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,7 +35,7 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 				goodMap := map[string]string{key: pkg}
 
 				It("should return the package name and no error", func() {
-					pkgName, err := check.getPackageName(goodMap)
+					pkgName, err := check.getPackageName(context.TODO(), goodMap)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(pkgName).To(Equal(pkg))
 				})
@@ -44,7 +45,7 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 				mapWithoutKey := map[string]string{}
 
 				It("should return an error", func() {
-					_, err := check.getPackageName(mapWithoutKey)
+					_, err := check.getPackageName(context.TODO(), mapWithoutKey)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -53,7 +54,7 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 				var nilMap map[string]string
 
 				It("should return an error", func() {
-					_, err := check.getPackageName(nilMap)
+					_, err := check.getPackageName(context.TODO(), nilMap)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -65,7 +66,7 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 			packageName := "my-custom-package"
 
 			It("should accurately reflect the input url and package name in the request data", func() {
-				request, err := check.buildRequest(url, packageName)
+				request, err := check.buildRequest(context.TODO(), url, packageName)
 				Expect(fmt.Sprintf("%s://%s", request.URL.Scheme, request.URL.Host)).To(Equal(url))
 				Expect(request.URL.RawQuery).To(ContainSubstring(packageName))
 				Expect(err).ToNot(HaveOccurred())
@@ -92,13 +93,14 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 				}
 
 				It("should not throw an error when the api responses with a 200 ok", func() {
-					goodResp, goodErr := check.queryAPI(&goodClient, &fakeRequest)
+					ctx := context.TODO()
+					goodResp, goodErr := check.queryAPI(ctx, &goodClient, &fakeRequest)
 					Expect(goodErr).ToNot(HaveOccurred())
 
-					data, err := check.parseAPIResponse(goodResp)
+					data, err := check.parseAPIResponse(ctx, goodResp)
 					Expect(err).ToNot(HaveOccurred())
 
-					isValid, err := check.validate(data)
+					isValid, err := check.validate(ctx, data)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(isValid).To(BeTrue())
 				})
@@ -115,13 +117,14 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 				}
 
 				It("should not throw an error when the api responses with a 200 ok, but should not validate", func() {
-					failResp, failErr := check.queryAPI(&failClient, &fakeRequest)
+					ctx := context.TODO()
+					failResp, failErr := check.queryAPI(ctx, &failClient, &fakeRequest)
 					Expect(failErr).ToNot(HaveOccurred())
 
-					data, err := check.parseAPIResponse(failResp)
+					data, err := check.parseAPIResponse(ctx, failResp)
 					Expect(err).ToNot(HaveOccurred())
 
-					isValid, err := check.validate(data)
+					isValid, err := check.validate(ctx, data)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(isValid).To(BeFalse())
 				})
@@ -136,7 +139,7 @@ var _ = Describe("OperatorPkgNameIsUniqueCheck", func() {
 				}
 
 				It("should throw an error", func() {
-					_, err := check.queryAPI(&errClient, &fakeRequest)
+					_, err := check.queryAPI(context.TODO(), &errClient, &fakeRequest)
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
@@ -23,17 +25,17 @@ func NewScorecardBasicSpecCheck(operatorSdkEngine *cli.OperatorSdkEngine) *Score
 	}
 }
 
-func (p *ScorecardBasicSpecCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+func (p *ScorecardBasicSpecCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
 	log.Debug("Running operator-sdk scorecard check for ", bundleRef.ImageURI)
 	selector := []string{"test=basic-check-spec-test"}
 	log.Debugf("--selector=%s", selector)
-	scorecardReport, err := p.getDataToValidate(bundleRef.ImageFSPath, selector, scorecardBasicCheckResult)
+	scorecardReport, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath, selector, scorecardBasicCheckResult)
 	if err != nil {
 		p.fatalError = true
 		return false, err
 	}
 
-	return p.validate(scorecardReport.Items)
+	return p.validate(ctx, scorecardReport.Items)
 }
 
 func (p *ScorecardBasicSpecCheck) Name() string {

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -72,7 +74,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {
 			It("Should pass Validate", func() {
-				ok, err := scorecardBasicCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := scorecardBasicCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -85,7 +87,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
 			})
 			It("Should not pass Validate", func() {
-				ok, err := scorecardBasicCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := scorecardBasicCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -98,7 +100,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := scorecardBasicCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := scorecardBasicCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -14,7 +15,7 @@ type scorecardCheck struct {
 	OperatorSdkEngine cli.OperatorSdkEngine
 }
 
-func (p *scorecardCheck) validate(items []cli.OperatorSdkScorecardItem) (bool, error) {
+func (p *scorecardCheck) validate(ctx context.Context, items []cli.OperatorSdkScorecardItem) (bool, error) {
 	foundTestFailed := false
 
 	if len(items) == 0 {
@@ -31,7 +32,7 @@ func (p *scorecardCheck) validate(items []cli.OperatorSdkScorecardItem) (bool, e
 	return !foundTestFailed, nil
 }
 
-func (p *scorecardCheck) getDataToValidate(bundleImage string, selector []string, resultFile string) (*cli.OperatorSdkScorecardReport, error) {
+func (p *scorecardCheck) getDataToValidate(ctx context.Context, bundleImage string, selector []string, resultFile string) (*cli.OperatorSdkScorecardReport, error) {
 	namespace := viper.GetString("namespace")
 	serviceAccount := viper.GetString("serviceaccount")
 	waitTime := viper.GetString("scorecard_wait_time")

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
@@ -23,17 +25,17 @@ func NewScorecardOlmSuiteCheck(operatorSdkEngine *cli.OperatorSdkEngine) *Scorec
 	}
 }
 
-func (p *ScorecardOlmSuiteCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
+func (p *ScorecardOlmSuiteCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
 	log.Debug("Running operator-sdk scorecard Check for ", bundleRef.ImageURI)
 	selector := []string{"suite=olm"}
 	log.Debugf("--selector=%s", selector)
-	scorecardReport, err := p.getDataToValidate(bundleRef.ImageFSPath, selector, scorecardOlmSuiteResult)
+	scorecardReport, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath, selector, scorecardOlmSuiteResult)
 	if err != nil {
 		p.fatalError = true
 		return false, err
 	}
 
-	return p.validate(scorecardReport.Items)
+	return p.validate(ctx, scorecardReport.Items)
 }
 
 func (p *ScorecardOlmSuiteCheck) Name() string {

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -72,7 +74,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {
 			It("Should pass Validate", func() {
-				ok, err := scorecardOlmSuiteCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := scorecardOlmSuiteCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -85,7 +87,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
 			})
 			It("Should not pass Validate", func() {
-				ok, err := scorecardOlmSuiteCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := scorecardOlmSuiteCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -98,7 +100,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := scorecardOlmSuiteCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := scorecardOlmSuiteCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/operator/validate_operator_bundle.go
+++ b/certification/internal/policy/operator/validate_operator_bundle.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
@@ -21,21 +23,21 @@ func NewValidateOperatorBundleCheck(operatorSdkEngine *cli.OperatorSdkEngine) *V
 
 const ocpVerV1beta1Unsupported = "4.9"
 
-func (p ValidateOperatorBundleCheck) Validate(bundleRef certification.ImageReference) (bool, error) {
-	report, err := p.getDataToValidate(bundleRef.ImageFSPath)
+func (p ValidateOperatorBundleCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
+	report, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath)
 	if err != nil {
 		log.Error("Error while executing operator-sdk bundle validate: ", err)
 		return false, err
 	}
 
-	return p.validate(report)
+	return p.validate(ctx, report)
 }
 
-func (p ValidateOperatorBundleCheck) getDataToValidate(imagePath string) (*cli.OperatorSdkBundleValidateReport, error) {
-	return bundle.ValidateBundle(p.OperatorSdkEngine, imagePath)
+func (p ValidateOperatorBundleCheck) getDataToValidate(ctx context.Context, imagePath string) (*cli.OperatorSdkBundleValidateReport, error) {
+	return bundle.ValidateBundle(ctx, p.OperatorSdkEngine, imagePath)
 }
 
-func (p ValidateOperatorBundleCheck) validate(report *cli.OperatorSdkBundleValidateReport) (bool, error) {
+func (p ValidateOperatorBundleCheck) validate(ctx context.Context, report *cli.OperatorSdkBundleValidateReport) (bool, error) {
 	if !report.Passed || len(report.Outputs) > 0 {
 		for _, output := range report.Outputs {
 			var logFn func(...interface{})

--- a/certification/internal/policy/operator/validate_operator_bundle_test.go
+++ b/certification/internal/policy/operator/validate_operator_bundle_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -60,7 +61,7 @@ var _ = Describe("BundleValidateCheck", func() {
 	Describe("Operator Bundle Validate", func() {
 		Context("When Operator Bundle Validate passes", func() {
 			It("Should pass Validate", func() {
-				ok, err := bundleValidateCheck.Validate(imageRef)
+				ok, err := bundleValidateCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -77,7 +78,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				bundleValidateCheck = *NewValidateOperatorBundleCheck(&fakeEngine)
 			})
 			It("Should not pass Validate", func() {
-				ok, err := bundleValidateCheck.Validate(imageRef)
+				ok, err := bundleValidateCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -90,7 +91,7 @@ var _ = Describe("BundleValidateCheck", func() {
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {
-				ok, err := bundleValidateCheck.Validate(certification.ImageReference{ImageURI: "dummy/image"})
+				ok, err := bundleValidateCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
 				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/rpm/rpm.go
+++ b/certification/internal/rpm/rpm.go
@@ -1,6 +1,7 @@
 package rpm
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -8,7 +9,7 @@ import (
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 )
 
-func GetPackageList(basePath string) ([]*rpmdb.PackageInfo, error) {
+func GetPackageList(ctx context.Context, basePath string) ([]*rpmdb.PackageInfo, error) {
 	rpmdirPath := filepath.Join(basePath, "var", "lib", "rpm")
 	rpmdbPath := filepath.Join(rpmdirPath, "rpmdb.sqlite")
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
@@ -23,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(checkCmd)
 }
 
-func writeJunitIfEnabled(results runtime.Results) error {
+func writeJunitIfEnabled(ctx context.Context, results runtime.Results) error {
 	if !viper.GetBool("junit") {
 		return nil
 	}
@@ -35,7 +37,7 @@ func writeJunitIfEnabled(results runtime.Results) error {
 	if err != nil {
 		return err
 	}
-	junitResults, err := junitformatter.Format(results)
+	junitResults, err := junitformatter.Format(ctx, results)
 	if err != nil {
 		return err
 	}

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -137,13 +137,13 @@ var checkContainerCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		// execute the checks
-		if err := engine.ExecuteChecks(); err != nil {
+		if err := engine.ExecuteChecks(ctx); err != nil {
 			return err
 		}
-		results := engine.Results()
+		results := engine.Results(ctx)
 
 		// return results to the user and then close output files
-		formattedResults, err := formatter.Format(results)
+		formattedResults, err := formatter.Format(ctx, results)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ var checkContainerCmd = &cobra.Command{
 			return err
 		}
 
-		if err := writeJunitIfEnabled(results); err != nil {
+		if err := writeJunitIfEnabled(ctx, results); err != nil {
 			return err
 		}
 

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -44,6 +45,8 @@ var checkOperatorCmd = &cobra.Command{
 		// so that we can get a more user-friendly error message
 
 		log.Info("certification library version ", version.Version.String())
+
+		ctx := context.Background()
 
 		operatorImage := args[0]
 
@@ -92,13 +95,13 @@ var checkOperatorCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		// execute the checks
-		if err := engine.ExecuteChecks(); err != nil {
+		if err := engine.ExecuteChecks(ctx); err != nil {
 			return err
 		}
-		results := engine.Results()
+		results := engine.Results(ctx)
 
 		// return results to the user and then close output files
-		formattedResults, err := formatter.Format(results)
+		formattedResults, err := formatter.Format(ctx, results)
 		if err != nil {
 			return err
 		}
@@ -108,7 +111,7 @@ var checkOperatorCmd = &cobra.Command{
 			return err
 		}
 
-		if err := writeJunitIfEnabled(results); err != nil {
+		if err := writeJunitIfEnabled(ctx, results); err != nil {
 			return err
 		}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
@@ -28,8 +30,9 @@ var _ = Describe("policy validation", func() {
 			engine, err := engine.NewForConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
-			engine.ExecuteChecks()
-			results := engine.Results()
+			ctx := context.TODO()
+			engine.ExecuteChecks(ctx)
+			results := engine.Results(ctx)
 
 			It("should pass all checks", func() {
 				Expect(len(results.Passed)).To(Equal(len(cfg.EnabledChecks)))
@@ -45,8 +48,9 @@ var _ = Describe("policy validation", func() {
 			engine, err := engine.NewForConfig(cfg)
 			Expect(err).To(BeNil())
 
-			engine.ExecuteChecks()
-			results := engine.Results()
+			ctx := context.TODO()
+			engine.ExecuteChecks(ctx)
+			results := engine.Results(ctx)
 
 			// TODO: Replace this check so that you test for individual check failures
 			It("should not pass any checks", func() {
@@ -72,8 +76,9 @@ var _ = Describe("policy validation", func() {
 			engine, err := engine.NewForConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
-			engine.ExecuteChecks()
-			results := engine.Results()
+			ctx := context.TODO()
+			engine.ExecuteChecks(ctx)
+			results := engine.Results(ctx)
 
 			It("should pass all checks", func() {
 				Expect(len(results.Passed)).To(Equal(len(cfg.EnabledChecks)))
@@ -94,8 +99,9 @@ var _ = Describe("policy validation", func() {
 			engine, err := engine.NewForConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
-			engine.ExecuteChecks()
-			results := engine.Results()
+			ctx := context.TODO()
+			engine.ExecuteChecks(ctx)
+			results := engine.Results(ctx)
 
 			// TODO: Replace this check so that you test for individual check failures
 			It("should fail all checks", func() {


### PR DESCRIPTION
Context should be shared from the highest level down through all
calls. This is the beginning of making that a reality. Once context
is being passed, we can start to add things to the context, like
params from viper, so that the parts of the codebase that do not
have to do with the CLI don't know anything about viper. Consider
it a separation of concerns.

Signed-off-by: Brad P. Crochet <brad@redhat.com>