### PR TITLE
add release version to the binaries located on github releases page

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -13,6 +13,9 @@ jobs:
     - name: code checkout
       uses: actions/checkout@v2
 
+    - name: Set Env Tags
+      run: echo RELEASE_TAG=$(echo $GITHUB_REF | cut -d '/' -f 3) >> $GITHUB_ENV
+
     - name: Install system deps
       run: 'sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev'
 


### PR DESCRIPTION
- Fixes: #503 

Test from forked [release page](https://github.com/acornett21/openshift-preflight/releases/tag/1.1.0-beta6)

Output from fedora box
```
[vagrant@fedora34 download]$ wget -c https://github.com/acornett21/openshift-preflight/releases/download/1.1.0-beta6/preflight-linux-amd64
--2022-03-21 20:16:49--  https://github.com/acornett21/openshift-preflight/releases/download/1.1.0-beta6/preflight-linux-amd64
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/391147297/58ab7810-9d41-4597-9a04-7019bcabeba4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220321%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220321T201649Z&X-Amz-Expires=300&X-Amz-Signature=56c942f5ee99f05f89968f77af1a286d8c34f6e4c095faf44ccd35b171b95269&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=391147297&response-content-disposition=attachment%3B%20filename%3Dpreflight-linux-amd64&response-content-type=application%2Foctet-stream [following]
--2022-03-21 20:16:49--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/391147297/58ab7810-9d41-4597-9a04-7019bcabeba4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220321%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220321T201649Z&X-Amz-Expires=300&X-Amz-Signature=56c942f5ee99f05f89968f77af1a286d8c34f6e4c095faf44ccd35b171b95269&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=391147297&response-content-disposition=attachment%3B%20filename%3Dpreflight-linux-amd64&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.110.133, 185.199.108.133, 185.199.111.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.110.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 50593262 (48M) [application/octet-stream]
Saving to: ‘preflight-linux-amd64’

preflight-linux-amd64                                                         100%[=================================================================================================================================================================================================>]  48.25M  17.6MB/s    in 2.7s    

2022-03-21 20:16:52 (17.6 MB/s) - ‘preflight-linux-amd64’ saved [50593262/50593262]

[vagrant@fedora34 download]$ chmod 755 preflight-linux-amd64 
[vagrant@fedora34 download]$ ./preflight-linux-amd64 --version
preflight version 1.1.0-beta6 <commit: c086ae85276e3c69c571f3a3ea89a492e6815afc>
```

Signed-off-by: Adam D. Cornett <adc@redhat.com>