### PR TITLE
Set a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,5 +54,7 @@ RUN curl --fail -Lo /usr/local/bin/operator-sdk https://github.com/operator-fram
 #copy license
 COPY LICENSE /licenses/LICENSE
 
+USER 65532:65532
+
 ENTRYPOINT ["/usr/local/bin/preflight"]
 CMD ["--help"]


### PR DESCRIPTION
Setting a non-root user for the Preflight image, to make sure it passes the `run_as_nonroot` check && we aren't doing any sudoing during the checks. 