### PR TITLE
Fixing a bug introduced with non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,6 @@ RUN curl --fail -Lo /usr/local/bin/operator-sdk https://github.com/operator-fram
 COPY LICENSE /licenses/LICENSE
 
 USER 65532:65532
-
+WORKDIR /home/nonroot
 ENTRYPOINT ["/usr/local/bin/preflight"]
 CMD ["--help"]


### PR DESCRIPTION
Adding a workdir to fix a bug where creating an artifacts directory gets permission denied when running as the "nonroot" user.

Fixes #516 


