### PR TITLE
Force use of prod pyxis for Based On UBI check

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -95,8 +95,13 @@ var (
 	hasRequiredLabelsCheck certification.Check = &containerpol.HasRequiredLabelsCheck{}
 	runAsRootCheck         certification.Check = &containerpol.RunAsNonRootCheck{}
 	hasModifiedFilesCheck  certification.Check = &containerpol.HasModifiedFilesCheck{}
-	basedOnUbiCheck        certification.Check = containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisEngine(viper.GetString("pyxis_api_token"),
-		viper.GetString("certification_project_id"), &http.Client{Timeout: 60 * time.Second}))
+
+	// Since the Pyxis data for checking UBI is only correct in prod, force the use of external prod
+	basedOnUbiCheck certification.Check = containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisEngine(
+		"catalog.redhat.com/api/containers",
+		viper.GetString("pyxis_api_token"),
+		viper.GetString("certification_project_id"),
+		&http.Client{Timeout: 60 * time.Second}))
 	// runnableContainerCheck  certification.Check = containerpol.NewRunnableContainerCheck(internal.NewPodmanEngine())
 	// runSystemContainerCheck certification.Check = containerpol.NewRunSystemContainerCheck(internal.NewPodmanEngine())
 )

--- a/certification/internal/policy/container/base_on_ubi.go
+++ b/certification/internal/policy/container/base_on_ubi.go
@@ -46,6 +46,7 @@ func (p *BasedOnUBICheck) checkRedHatLayers(ctx context.Context, layerHashes []c
 	certImages, err := p.LayerHashCheckEngine.CheckRedHatLayers(ctx, layerHashes)
 	if err != nil {
 		log.Error("Error when querying pyxis for uncompressed top layer ids", err)
+		return false, err
 	}
 	if certImages != nil && len(certImages) >= 1 {
 		return true, nil
@@ -58,6 +59,7 @@ func (p *BasedOnUBICheck) validate(ctx context.Context, layerHashes []cranev1.Ha
 	hasUBIHash, err := p.checkRedHatLayers(ctx, layerHashes)
 	if err != nil {
 		log.Error("Unable to verify layer hashes", err)
+		return false, err
 	}
 	if hasUBIHash {
 		return true, nil

--- a/certification/pyxis/layers.go
+++ b/certification/pyxis/layers.go
@@ -3,7 +3,6 @@ package pyxis
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -21,12 +21,12 @@ func (p *pyxisEngine) CheckRedHatLayers(ctx context.Context, layerHashes []crane
 	}
 	log.Tracef("the layerIds passed to pyxis are %s", layerIds)
 
-	pyxisQuery := url.QueryEscape(fmt.Sprintf("repositories.registry=in=(registry.access.redhat.com) and uncompressed_top_layer_id=in=(%s)", strings.Join(layerIds, ",")))
+	pyxisQuery := url.QueryEscape(fmt.Sprintf("repositories.registry==registry.access.redhat.com and uncompressed_top_layer_id=in=(%s)", strings.Join(layerIds, ",")))
 
-	req, err := p.newRequestWithApiToken(
+	req, err := p.newRequest(
 		ctx,
 		http.MethodGet,
-		fmt.Sprintf("%s?filter=%s", getPyxisUrl("images"), pyxisQuery),
+		fmt.Sprintf("%s?filter=%s", p.getPyxisUrl("images"), pyxisQuery),
 		nil,
 	)
 	if err != nil {
@@ -41,16 +41,16 @@ func (p *pyxisEngine) CheckRedHatLayers(ctx context.Context, layerHashes []crane
 		return nil, err
 	}
 
-	if resp.StatusCode != 200 {
-		err := fmt.Sprintf("Recieved http status %s instead of 200 OK", resp.Status)
-		log.Error("Unexpected Status Code", err)
-		return nil, errors.New(err)
-	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error(err)
 		return nil, err
+	}
+
+	if !checkStatus(resp.StatusCode) {
+		log.Errorf("%s: %s", "received non 200 status code in CheckRedHatLayers", string(body))
+		return nil, errors.ErrNon200StatusCode
 	}
 
 	log.Tracef("query response from pyxis %s", string(body))

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
@@ -14,7 +13,6 @@ import (
 var ctx = context.Background()
 
 var _ = Describe("Pyxis Submit", func() {
-	os.Setenv("PFLT_PYXIS_HOST", "my.pyxis.host/api")
 	var pyxisEngine *pyxisEngine
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/projects/certification/id/", &pyxisProjectHandler{})
@@ -24,7 +22,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("when a project is submitted", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
@@ -46,7 +44,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("updateProject 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the client sends a bad token", func() {
@@ -67,7 +65,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createImage 409 Conflict", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the image already exists", func() {
@@ -91,7 +89,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createImage 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-image-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-image-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the api token is invalid", func() {
@@ -112,7 +110,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createImage 409 Conflict and getImage 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-image-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-image-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad token is sent to getImage and createImage is in conflict", func() {
@@ -133,7 +131,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createRPMManifest 409 Conflict", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the RPM manifest already exists", func() {
@@ -157,7 +155,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createRPMManifest 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-rpmmanifest-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-rpmmanifest-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad token is sent to createRPMManifest", func() {
@@ -178,7 +176,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createRPMManifest 409 Conflict and getRPMManifest 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-rpmmanifest-api-token", "my-manifest-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-rpmmanifest-api-token", "my-manifest-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad token is sent to getRPMManifest and createRPMManifest is in conflict", func() {
@@ -199,7 +197,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createTestResults 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-testresults-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-testresults-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad api token is sent to createTestResults", func() {
@@ -220,7 +218,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("GetProject", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and it is not already In Progress", func() {
@@ -235,7 +233,7 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("GetProject 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when trying to retrieve a project", func() {
 			Context("and the API token is bad", func() {

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -81,7 +81,7 @@ var checkContainerCmd = &cobra.Command{
 			viper.Set("certification_project_id", projectId)
 		}
 		apiToken := viper.GetString("pyxis_api_token")
-		pyxisEngine := pyxis.NewPyxisEngine(apiToken, projectId, &http.Client{Timeout: 60 * time.Second})
+		pyxisEngine := pyxis.NewPyxisEngine(viper.GetString("pyxis_host"), apiToken, projectId, &http.Client{Timeout: 60 * time.Second})
 		certProject, err := pyxisEngine.GetProject(ctx)
 		if err != nil {
 			log.Error(err, "could not retrieve project")


### PR DESCRIPTION
Lower pyxis envs cannot be relied upon to have correct/up-to-date
data relating to base images. This forces the check to use that
external prod instance.

Fixes #517

Signed-off-by: Brad P. Crochet <brad@redhat.com>