### PR TITLE
Use the default pyxis host for BasedOnUBI

### DIFF
--- a/certification/defaults.go
+++ b/certification/defaults.go
@@ -4,5 +4,6 @@ var (
 	DefaultCertImageFilename   = "cert-image.json"
 	DefaultRPMManifestFilename = "rpm-manifest.json"
 	DefaultTestResultsFilename = "results.json"
+	DefaultPyxisHost           = "catalog.redhat.com/api/containers"
 	SystemdDir                 = "/etc/systemd/system"
 )

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -98,7 +98,7 @@ var (
 
 	// Since the Pyxis data for checking UBI is only correct in prod, force the use of external prod
 	basedOnUbiCheck certification.Check = containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisEngine(
-		"catalog.redhat.com/api/containers",
+		certification.DefaultPyxisHost,
 		viper.GetString("pyxis_api_token"),
 		viper.GetString("certification_project_id"),
 		&http.Client{Timeout: 60 * time.Second}))

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -279,7 +279,7 @@ func init() {
 	checkContainerCmd.MarkFlagRequired("pyxis-api-token")
 	viper.BindPFlag("pyxis_api_token", checkContainerCmd.Flags().Lookup("pyxis-api-token"))
 
-	checkContainerCmd.Flags().String("pyxis-host", DefaultPyxisHost, "Host to use for Pyxis submissions.")
+	checkContainerCmd.Flags().String("pyxis-host", certification.DefaultPyxisHost, "Host to use for Pyxis submissions.")
 	viper.BindPFlag("pyxis_host", checkContainerCmd.Flags().Lookup("pyxis-host"))
 
 	checkContainerCmd.Flags().String("certification-project-id", "", "Certification Project ID from conenct.redhat.com. Should be supplied without the ospid- prefix.")

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -8,5 +8,4 @@ var (
 	DefaultNamespace         = "default"
 	DefaultServiceAccount    = "default"
 	DefaultScorecardWaitTime = "240"
-	DefaultPyxisHost         = "catalog.redhat.com/api/containers"
 )

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -47,7 +48,7 @@ func initConfig() {
 	viper.SetDefault("scorecard_wait_time", DefaultScorecardWaitTime)
 
 	// Set up pyxis host
-	viper.SetDefault("pyxis_host", DefaultPyxisHost)
+	viper.SetDefault("pyxis_host", certification.DefaultPyxisHost)
 	viper.SetDefault("pyxis_api_token", "")
 }
 
@@ -77,7 +78,7 @@ func buildConnectURL(projectID string) string {
 	pyxisHost := viper.GetString("pyxis_host")
 	s := strings.Split(pyxisHost, ".")
 
-	if pyxisHost != DefaultPyxisHost && len(s) > 3 {
+	if pyxisHost != certification.DefaultPyxisHost && len(s) > 3 {
 		env := s[1]
 		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/projects/%s", env, projectID)
 	}


### PR DESCRIPTION
Since the default pyxis host is prod, that is what we should pass
to the BasedOnUBI pyxis engine. It removes the "magic constant" from
the initialization.

Signed-off-by: Brad P. Crochet <brad@redhat.com>