### PR TITLE
Detect if layer 0 is non-zero length and shift to layer 1

### DIFF
--- a/certification/internal/policy/container/has_modified_files.go
+++ b/certification/internal/policy/container/has_modified_files.go
@@ -14,11 +14,16 @@ import (
 )
 
 // HasModifiedFilesCheck evaluates that no files from the base layer have been modified by
-// subsequent layers.
+// subsequent layers by comparing the file list installed by Packages against the file list
+// modified in subsequent layers.
 type HasModifiedFilesCheck struct{}
 
 type packageFilesRef struct {
-	LayerFiles   [][]string
+	// LayerFiles contains a slice of files modified by layer.
+	LayerFiles [][]string
+	// PackagesFiles is a map of modified files. the anonymous struct
+	// here is just used to allow us to search package files by name
+	// as the key of this map, and doesn't have any value.
 	PackageFiles map[string]struct{}
 }
 
@@ -30,11 +35,19 @@ func (p *HasModifiedFilesCheck) Validate(ctx context.Context, imgRef certificati
 	return p.validate(packageFiles)
 }
 
+// getDataToValidate returns the list of files (packageFilesRef.PackageFiles)
+// installed via packages from the container image,and the list of files (packageFilesRef.LayerFiles)
+// modified/added via layers in the image.
 func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef certification.ImageReference) (*packageFilesRef, error) {
+	// Get a list of packages from the RPM database. This avoids having to rely on
+	// rpm, dnf, yum, etc. being installed in the image.
 	pkgList, err := rpm.GetPackageList(ctx, imgRef.ImageFSPath)
 	if err != nil {
 		return nil, err
 	}
+
+	// Get the files put in place on the filesystem by the
+	// installed packages.
 	packageFiles := make(map[string]struct{}, len(pkgList))
 	for _, pkg := range pkgList {
 		filenames, err := pkg.InstalledFiles()
@@ -42,6 +55,8 @@ func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef ce
 			return nil, err
 		}
 		for _, file := range filenames {
+			// A struct is used here, but it is unimportant and
+			// should not have value.
 			packageFiles[file] = struct{}{}
 		}
 	}
@@ -53,6 +68,8 @@ func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef ce
 
 	files := make([][]string, 0, len(layers))
 
+	// Uncompress each layer and build a slice containing the files
+	// modified by each layer.
 	for _, layer := range layers {
 		r, err := layer.Uncompressed()
 		if err != nil {
@@ -61,24 +78,47 @@ func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef ce
 		pathChan := make(chan string)
 
 		go func() {
+			// For each path in the pathChan, add it to the layer's
+			// list of files.
 			layerFiles := make([]string, 0)
 			for path := range pathChan {
 				layerFiles = append(layerFiles, path)
 			}
+			// also add it to the overall list of files.
 			files = append(files, layerFiles)
 		}()
+		// add paths to the pathChan
 		err = untar(pathChan, r)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
 		}
 	}
 
+	// In cases where the image was built FROM scratch,
+	// we drop the empty layer. This should be relatively rare,
+	// but it is the case in images such as ubi-micro. This works
+	// around using that empty layer as a base layer in Validate().
+	if len(files[0]) == 0 {
+		diff0, _ := layers[0].DiffID()
+		diff1, _ := layers[1].DiffID()
+		log.Debugf(
+			"The first layer (%s) contained no files, so the next layer (%s) is being used as the base layer.",
+			diff0.String(),
+			diff1.String(),
+		)
+		files = files[1:] // shift the empty layer out.
+	}
+
 	return &packageFilesRef{files, packageFiles}, nil
 }
 
+// validate compares the list of LayerFiles and PackageFiles to see what PackageFiles
+// have been modified within the additional layers.
 func (p *HasModifiedFilesCheck) validate(packageFilesRef *packageFilesRef) (bool, error) {
 	layerFiles := packageFilesRef.LayerFiles
 	packageFiles := packageFilesRef.PackageFiles
+
+	// Determine the list of files that were a part of the base layer.
 	baseLayer := make(map[string]struct{}, len(layerFiles[0]))
 	for _, filename := range layerFiles[0] {
 		if _, ok := packageFiles[filename]; ok {
@@ -87,6 +127,8 @@ func (p *HasModifiedFilesCheck) validate(packageFilesRef *packageFilesRef) (bool
 	}
 	layers := layerFiles[1:]
 
+	// Look for modifications in subsequent layers by determining
+	// if a file in a base layer exists in a subsequent layer.
 	modifiedFilesDetected := false
 	for _, layer := range layers {
 		for _, file := range layer {

--- a/certification/internal/rpm/rpm.go
+++ b/certification/internal/rpm/rpm.go
@@ -10,6 +10,9 @@ import (
 	preflightErrors "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 )
 
+// GetPackageList returns the list of packages in the rpm database from either
+// /var/lib/rpm/rpmdb.sqlite, or /var/lib/rpm/Packages if the former does not exist.
+// If neither exists, this returns an error.
 func GetPackageList(ctx context.Context, basePath string) ([]*rpmdb.PackageInfo, error) {
 	rpmdirPath := filepath.Join(basePath, "var", "lib", "rpm")
 	rpmdbPath := filepath.Join(rpmdirPath, "rpmdb.sqlite")

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -55,13 +55,8 @@ var checkContainerCmd = &cobra.Command{
 	Example: fmt.Sprintf("  %s", "preflight check container quay.io/repo-name/container-name:version"),
 	PreRun:  preRunConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Expect exactly one positional arg. Check here instead of using builtin Args key
-		// so that we can get a more user-friendly error message
-
 		log.Info("certification library version ", version.Version.String())
-
 		ctx := context.Background()
-
 		containerImage := args[0]
 
 		cfg := runtime.Config{


### PR DESCRIPTION
In `preflight check container`, if the base image of the container under test has a zero length (e.g. `FROM scratch` in the Containerfile), then there will be no files to use to evaluate if something was changed in a subsequent layer.

This patch shifts the `layerFiles` over one layer if the first layer is deemed to be a zero-length file. I don't believe it's plausible to get additional layers with zero length, so we don't account for it.

This also adds comments throughout the files associated with the check, and also removes a deprecated comment in another, unrelated file in a separate commit.

Fixed #523 