### PR TITLE
Rename pyxisEngine to pyxisClient

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -97,7 +97,7 @@ var (
 	hasModifiedFilesCheck  certification.Check = &containerpol.HasModifiedFilesCheck{}
 
 	// Since the Pyxis data for checking UBI is only correct in prod, force the use of external prod
-	basedOnUbiCheck certification.Check = containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisEngine(
+	basedOnUbiCheck certification.Check = containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisClient(
 		certification.DefaultPyxisHost,
 		viper.GetString("pyxis_api_token"),
 		viper.GetString("certification_project_id"),

--- a/certification/pyxis/layers.go
+++ b/certification/pyxis/layers.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *pyxisEngine) CheckRedHatLayers(ctx context.Context, layerHashes []cranev1.Hash) ([]CertImage, error) {
+func (p *pyxisClient) CheckRedHatLayers(ctx context.Context, layerHashes []cranev1.Hash) ([]CertImage, error) {
 	layerIds := make([]string, 0, len(layerHashes))
 	for _, layer := range layerHashes {
 		layerIds = append(layerIds, layer.String())

--- a/certification/pyxis/pyxis.go
+++ b/certification/pyxis/pyxis.go
@@ -20,19 +20,19 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-type pyxisEngine struct {
+type pyxisClient struct {
 	ApiToken  string
 	ProjectId string
 	Client    HTTPClient
 	PyxisHost string
 }
 
-func (p *pyxisEngine) getPyxisUrl(path string) string {
+func (p *pyxisClient) getPyxisUrl(path string) string {
 	return fmt.Sprintf("https://%s/%s/%s", p.PyxisHost, apiVersion, path)
 }
 
-func NewPyxisEngine(pyxisHost string, apiToken string, projectId string, httpClient HTTPClient) *pyxisEngine {
-	return &pyxisEngine{
+func NewPyxisClient(pyxisHost string, apiToken string, projectId string, httpClient HTTPClient) *pyxisClient {
+	return &pyxisClient{
 		ApiToken:  apiToken,
 		ProjectId: projectId,
 		Client:    httpClient,
@@ -40,7 +40,7 @@ func NewPyxisEngine(pyxisHost string, apiToken string, projectId string, httpCli
 	}
 }
 
-func (p *pyxisEngine) createImage(ctx context.Context, certImage *CertImage) (*CertImage, error) {
+func (p *pyxisClient) createImage(ctx context.Context, certImage *CertImage) (*CertImage, error) {
 	b, err := json.Marshal(certImage)
 	if err != nil {
 		log.Error(err)
@@ -86,7 +86,7 @@ func (p *pyxisEngine) createImage(ctx context.Context, certImage *CertImage) (*C
 	return &newCertImage, nil
 }
 
-func (p *pyxisEngine) getImage(ctx context.Context, dockerImageDigest string) (*CertImage, error) {
+func (p *pyxisClient) getImage(ctx context.Context, dockerImageDigest string) (*CertImage, error) {
 	req, err := p.newRequestWithApiToken(ctx, http.MethodGet,
 		p.getPyxisUrl(fmt.Sprintf("projects/certification/id/%s/images?filter=docker_image_digest==%s", p.ProjectId, dockerImageDigest)), nil)
 	if err != nil {
@@ -128,7 +128,7 @@ func (p *pyxisEngine) getImage(ctx context.Context, dockerImageDigest string) (*
 	return &data.Data[0], nil
 }
 
-func (p *pyxisEngine) createRPMManifest(ctx context.Context, rpmManifest *RPMManifest) (*RPMManifest, error) {
+func (p *pyxisClient) createRPMManifest(ctx context.Context, rpmManifest *RPMManifest) (*RPMManifest, error) {
 	b, err := json.Marshal(rpmManifest)
 	if err != nil {
 		log.Error(err)
@@ -174,7 +174,7 @@ func (p *pyxisEngine) createRPMManifest(ctx context.Context, rpmManifest *RPMMan
 	return &newRPMManifest, nil
 }
 
-func (p *pyxisEngine) getRPMManifest(ctx context.Context, imageID string) (*RPMManifest, error) {
+func (p *pyxisClient) getRPMManifest(ctx context.Context, imageID string) (*RPMManifest, error) {
 	req, err := p.newRequestWithApiToken(ctx, http.MethodGet, p.getPyxisUrl(fmt.Sprintf("images/id/%s/rpm-manifest", imageID)), nil)
 	if err != nil {
 		log.Error(err)
@@ -211,7 +211,7 @@ func (p *pyxisEngine) getRPMManifest(ctx context.Context, imageID string) (*RPMM
 	return &newRPMManifest, nil
 }
 
-func (p *pyxisEngine) GetProject(ctx context.Context) (*CertProject, error) {
+func (p *pyxisClient) GetProject(ctx context.Context) (*CertProject, error) {
 	req, err := p.newRequestWithApiToken(ctx, http.MethodGet, p.getPyxisUrl(fmt.Sprintf("projects/certification/id/%s", p.ProjectId)), nil)
 	if err != nil {
 		log.Error(err)
@@ -247,7 +247,7 @@ func (p *pyxisEngine) GetProject(ctx context.Context) (*CertProject, error) {
 	return &certProject, nil
 }
 
-func (p *pyxisEngine) updateProject(ctx context.Context, certProject *CertProject) (*CertProject, error) {
+func (p *pyxisClient) updateProject(ctx context.Context, certProject *CertProject) (*CertProject, error) {
 	b, err := json.Marshal(certProject)
 	if err != nil {
 		log.Error(err)
@@ -289,7 +289,7 @@ func (p *pyxisEngine) updateProject(ctx context.Context, certProject *CertProjec
 	return &newCertProject, nil
 }
 
-func (p *pyxisEngine) createTestResults(ctx context.Context, testResults *TestResults) (*TestResults, error) {
+func (p *pyxisClient) createTestResults(ctx context.Context, testResults *TestResults) (*TestResults, error) {
 	b, err := json.Marshal(testResults)
 	if err != nil {
 		log.Error(err)
@@ -329,7 +329,7 @@ func (p *pyxisEngine) createTestResults(ctx context.Context, testResults *TestRe
 	return &newTestResults, nil
 }
 
-func (p *pyxisEngine) createArtifact(ctx context.Context, artifact *Artifact) (*Artifact, error) {
+func (p *pyxisClient) createArtifact(ctx context.Context, artifact *Artifact) (*Artifact, error) {
 	b, err := json.Marshal(artifact)
 	if err != nil {
 		log.Error(err)
@@ -371,7 +371,7 @@ func (p *pyxisEngine) createArtifact(ctx context.Context, artifact *Artifact) (*
 	return &newArtifact, nil
 }
 
-func (p *pyxisEngine) newRequestWithApiToken(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
+func (p *pyxisClient) newRequestWithApiToken(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
 	req, err := p.newRequest(ctx, method, url, body)
 	if err != nil {
 		return nil, err
@@ -382,7 +382,7 @@ func (p *pyxisEngine) newRequestWithApiToken(ctx context.Context, method string,
 	return req, nil
 }
 
-func (p *pyxisEngine) newRequest(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
+func (p *pyxisClient) newRequest(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err

--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *pyxisEngine) SubmitResults(ctx context.Context, certInput *CertificationInput) (*CertificationResults, error) {
+func (p *pyxisClient) SubmitResults(ctx context.Context, certInput *CertificationInput) (*CertificationResults, error) {
 	var err error
 
 	certProject := certInput.CertProject

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -13,7 +13,7 @@ import (
 var ctx = context.Background()
 
 var _ = Describe("Pyxis Submit", func() {
-	var pyxisEngine *pyxisEngine
+	var pyxisClient *pyxisClient
 	mux := http.NewServeMux()
 	mux.Handle("/api/v1/projects/certification/id/", &pyxisProjectHandler{})
 	mux.Handle("/api/v1/images", &pyxisImageHandler{})
@@ -22,11 +22,11 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("when a project is submitted", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("and it is not already In Progress", func() {
 			It("should switch to In Progress", func() {
-				certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+				certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 					CertProject: &CertProject{CertificationStatus: "Started"},
 					CertImage:   &CertImage{},
 					RpmManifest: &RPMManifest{},
@@ -44,12 +44,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("updateProject 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the client sends a bad token", func() {
 				It("should get an unauthorized", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{CertificationStatus: "Started"},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -65,12 +65,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createImage 409 Conflict", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-spiffy-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the image already exists", func() {
 				It("should get a conflict and handle it", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -89,12 +89,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createImage 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-image-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-image-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the api token is invalid", func() {
 				It("should get an unauthorized result", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{CertificationStatus: "Started"},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -110,12 +110,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createImage 409 Conflict and getImage 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-image-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-image-api-token", "my-image-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad token is sent to getImage and createImage is in conflict", func() {
 				It("should error", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{CertificationStatus: "Started"},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -131,12 +131,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createRPMManifest 409 Conflict", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and the RPM manifest already exists", func() {
 				It("should retry and return success", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -155,12 +155,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createRPMManifest 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-rpmmanifest-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-rpmmanifest-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad token is sent to createRPMManifest", func() {
 				It("should error", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{CertificationStatus: "Started"},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -176,12 +176,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createRPMManifest 409 Conflict and getRPMManifest 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-rpmmanifest-api-token", "my-manifest-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-rpmmanifest-api-token", "my-manifest-409-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad token is sent to getRPMManifest and createRPMManifest is in conflict", func() {
 				It("should error", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{CertificationStatus: "Started"},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -197,12 +197,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("createTestResults 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-testresults-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-testresults-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and a bad api token is sent to createTestResults", func() {
 				It("should error", func() {
-					certResults, err := pyxisEngine.SubmitResults(ctx, &CertificationInput{
+					certResults, err := pyxisClient.SubmitResults(ctx, &CertificationInput{
 						CertProject: &CertProject{CertificationStatus: "Started"},
 						CertImage:   &CertImage{},
 						RpmManifest: &RPMManifest{},
@@ -218,12 +218,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("GetProject", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when a project is submitted", func() {
 			Context("and it is not already In Progress", func() {
 				It("should switch to In Progress", func() {
-					certProject, err := pyxisEngine.GetProject(context.Background())
+					certProject, err := pyxisClient.GetProject(context.Background())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(certProject).ToNot(BeNil())
 				})
@@ -233,12 +233,12 @@ var _ = Describe("Pyxis Submit", func() {
 
 	Context("GetProject 401 Unauthorized", func() {
 		BeforeEach(func() {
-			pyxisEngine = NewPyxisEngine("my.pyxis.host/api", "my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+			pyxisClient = NewPyxisClient("my.pyxis.host/api", "my-bad-project-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 		})
 		Context("when trying to retrieve a project", func() {
 			Context("and the API token is bad", func() {
 				It("should get an unauthorized response", func() {
-					certProject, err := pyxisEngine.GetProject(context.Background())
+					certProject, err := pyxisClient.GetProject(context.Background())
 					Expect(err).To(MatchError(errors.New("error calling remote API")))
 					Expect(certProject).To(BeNil())
 				})

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -81,8 +81,8 @@ var checkContainerCmd = &cobra.Command{
 			viper.Set("certification_project_id", projectId)
 		}
 		apiToken := viper.GetString("pyxis_api_token")
-		pyxisEngine := pyxis.NewPyxisEngine(viper.GetString("pyxis_host"), apiToken, projectId, &http.Client{Timeout: 60 * time.Second})
-		certProject, err := pyxisEngine.GetProject(ctx)
+		pyxisClient := pyxis.NewPyxisClient(viper.GetString("pyxis_host"), apiToken, projectId, &http.Client{Timeout: 60 * time.Second})
+		certProject, err := pyxisClient.GetProject(ctx)
 		if err != nil {
 			log.Error(err, "could not retrieve project")
 			return err
@@ -252,7 +252,7 @@ var checkContainerCmd = &cobra.Command{
 				TestResults: testResults,
 				Artifacts:   artifacts,
 			}
-			certResults, err := pyxisEngine.SubmitResults(ctx, certInput)
+			certResults, err := pyxisClient.SubmitResults(ctx, certInput)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
pyxisClient is a much more apt name for what this struct does. This
does not change any functionality at all.

Signed-off-by: Brad P. Crochet <brad@redhat.com>