### PR TITLE
Fix source rpm name parsing

### DIFF
--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -421,6 +421,11 @@ func writeCertImage(ctx context.Context, imageRef certification.ImageReference) 
 	return nil
 }
 
+func getBgName(srcrpm string) string {
+	parts := strings.Split(srcrpm, "-")
+	return strings.Join(parts[0:len(parts)-2], "-")
+}
+
 func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 	pkgList, err := rpm.GetPackageList(ctx, containerFSPath)
 	if err != nil {
@@ -435,7 +440,7 @@ func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 
 		// accounting for the fact that not all packages have a source rpm
 		if len(packageInfo.SourceRpm) > 0 {
-			bgName = packageInfo.SourceRpm[0:strings.LastIndex(strings.SplitAfter(packageInfo.SourceRpm, ".")[0], "-")]
+			bgName = getBgName(packageInfo.SourceRpm)
 			endChop = strings.TrimPrefix(strings.TrimSuffix(regexp.MustCompile("(-[0-9].*)").FindString(packageInfo.SourceRpm), ".rpm"), "-")
 
 			srpmNevra = fmt.Sprintf("%s-%d:%s", bgName, packageInfo.Epoch, endChop)

--- a/certification/internal/engine/engine_test.go
+++ b/certification/internal/engine/engine_test.go
@@ -1,0 +1,32 @@
+package engine
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Source RPM name function", func() {
+	Context("With a source rpm name", func() {
+		Context("And a normal source rpm name", func() {
+			It("should parse bash-5.1.8-2.el9.src.rpm to bash", func() {
+				expected := "bash"
+				actual := getBgName("bash-5.1.8-2.el9.src.rpm")
+				Expect(actual).To(Equal(expected))
+			})
+		})
+		Context("And a slightly annoying source rpm name", func() {
+			It("should parse python3.9-3.9.6-6.el9.src.rpm to python3.9", func() {
+				expected := "python3.9"
+				actual := getBgName("python3.9-3.9.6-6.el9.src.rpm")
+				Expect(actual).To(Equal(expected))
+			})
+		})
+		Context("And a source rpm name with a bunch of -'s", func() {
+			It("should parse python-pip-21.0.1-6.el9.src.rpm to bash", func() {
+				expected := "python-pip"
+				actual := getBgName("python-pip-21.0.1-6.el9.src.rpm")
+				Expect(actual).To(Equal(expected))
+			})
+		})
+	})
+})

--- a/certification/internal/engine/internal_engine_suite_test.go
+++ b/certification/internal/engine/internal_engine_suite_test.go
@@ -1,0 +1,13 @@
+package engine
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternalEngine(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Engine Suite")
+}


### PR DESCRIPTION
Some source rpm names are breaking the parsing logic we have (that was
very close to the CVP version). We couldn't use the CVP version, as the
golang regex engine does not support positive lookaheads. So, this patch
instead utilizes Split on '-', then puts the source name back together
with any '-', minus the last two entries. Unit tests provided.

Signed-off-by: Brad P. Crochet <brad@redhat.com>