### PR TITLE
Utilize built-in cache of crane library

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -36,4 +36,5 @@ var (
 	ErrRetrievingLayers                = errors.New("could not get container layers")
 	ErrNotSupportedBaseImage           = errors.New("unsupported image. only RHEL/UBI or scratch base images are supported")
 	ErrInvalidCertImage                = errors.New("certImage has not been properly populated")
+	ErrWriteImageTarball               = errors.New("could not write image tarball to path")
 )

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
@@ -73,6 +74,13 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 			log.Error("unable to clean up tmpdir", tmpdir, err)
 		}
 	}()
+
+	imageTarPath := path.Join(tmpdir, "cache")
+	if err := os.Mkdir(imageTarPath, 0o755); err != nil {
+		return fmt.Errorf("%w: %s: %s", errors.ErrCreateTempDir, imageTarPath, err)
+	}
+
+	img = cache.Image(img, cache.NewFilesystemCache(imageTarPath))
 
 	containerFSPath := path.Join(tmpdir, "fs")
 	if err := os.Mkdir(containerFSPath, 0o755); err != nil {


### PR DESCRIPTION
It was discovered that the HasModifiedFiles check was having to re-
pull the image under test. With this simple patch, we now utilize
the caching mechanism of crane, which has reduced the runtime of
HasModifiedFiles by an order of magnitude. It ends up being a
transparent change to the entire codebase, as the v1.Image passed
around in the ImageRef is an instance of the cached Image.

Fixes #533

Signed-off-by: Brad P. Crochet <brad@redhat.com>