### PR TITLE
updating RunAsNonRoot logs to be info level and provide more details

### DIFF
--- a/certification/internal/policy/container/runs_as_nonroot.go
+++ b/certification/internal/policy/container/runs_as_nonroot.go
@@ -32,16 +32,18 @@ func (p *RunAsNonRootCheck) getDataToValidate(image cranev1.Image) (string, erro
 
 func (p *RunAsNonRootCheck) validate(user string) (bool, error) {
 	if user == "" {
-		log.Debug("detected empty user. Presumed to be running as root")
+		log.Info("detected empty USER. Presumed to be running as root")
+		log.Info("USER value must be provided and be a non-root value for this check to pass")
 		return false, nil
 	}
 
 	if user == "0" || user == "root" {
-		log.Debugf("detected user specified as root: %s", user)
+		log.Infof("detected USER specified as root: %s", user)
+		log.Info("USER other than root is required for this check to pass")
 		return false, nil
 	}
 
-	log.Debug("User specified that was not root")
+	log.Infof("USER %s specified that is non-root", user)
 	return true, nil
 }
 


### PR DESCRIPTION
- Fixes: #536 
- changing RunAsNonRoot validation log level to `Info` and added more log statements for clarity.

Signed-off-by: Adam D. Cornett <adc@redhat.com>