### PR TITLE
Fix nonroot home directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,10 @@ RUN curl --fail -Lo /usr/local/bin/operator-sdk https://github.com/operator-fram
 #copy license
 COPY LICENSE /licenses/LICENSE
 
-USER 65532:65532
 WORKDIR /home/nonroot
+RUN chown -R 65532:65532 /home/nonroot
+
+USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/preflight"]
 CMD ["--help"]
+


### PR DESCRIPTION
The permissions on the /home/nonroot WORKDIR were set to root:root.
This caused any commands to fail that tried to create directories
in the preflight image. This sets the ownership properly.

Signed-off-by: Brad P. Crochet <brad@redhat.com>