### PR TITLE
no longer throw exceptions back for RPM manifests

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -34,7 +34,6 @@ var (
 	Err409StatusCode                   = errors.New("remote API returned conflict")
 	ErrInvalidImageUri                 = errors.New("image uri could not be parsed")
 	ErrRetrievingLayers                = errors.New("could not get container layers")
-	ErrNotSupportedBaseImage           = errors.New("unsupported image. only RHEL/UBI or scratch base images are supported")
 	ErrInvalidCertImage                = errors.New("certImage has not been properly populated")
 	ErrWriteImageTarball               = errors.New("could not write image tarball to path")
 )

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -437,7 +437,7 @@ func getBgName(srcrpm string) string {
 func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 	pkgList, err := rpm.GetPackageList(ctx, containerFSPath)
 	if err != nil {
-		return err
+		log.Error("could not get rpm list, continuing without it")
 	}
 
 	// covert rpm struct to pxyis struct
@@ -464,7 +464,7 @@ func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 			}
 		}
 
-		rpm := pyxis.RPM{
+		pyxisRPM := pyxis.RPM{
 			Architecture: packageInfo.Arch,
 			Gpg:          pgpKeyId,
 			Name:         packageInfo.Name,
@@ -476,7 +476,7 @@ func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 			Version:      packageInfo.Version,
 		}
 
-		rpms = append(rpms, rpm)
+		rpms = append(rpms, pyxisRPM)
 	}
 
 	rpmManifest := pyxis.RPMManifest{

--- a/certification/internal/rpm/rpm.go
+++ b/certification/internal/rpm/rpm.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
-	preflightErrors "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 )
 
 // GetPackageList returns the list of packages in the rpm database from either
@@ -23,7 +22,7 @@ func GetPackageList(ctx context.Context, basePath string) ([]*rpmdb.PackageInfo,
 
 		// if the fall back path does not exist - this probably isn't a RHEL or UBI based image
 		if _, err := os.Stat(rpmdbPath); errors.Is(err, os.ErrNotExist) {
-			return nil, preflightErrors.ErrNotSupportedBaseImage
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
- No longer throw exceptions when we write the RPM file to disk
- Use the empty file to post to pyxis
- Pyxis will take this empty response

The motivation behind this is to always produce an output for the user to provide a better UX. This might not make any sense, but it works for this use case. So maybe for other use cases as well, instead of trying to make the UX in preflight better per say, we make sure our tests write an output and the this information will always end up in pyxis. Where pyxis would block the certification process anyways, since not all tests have passes.

Logs:
```
time="2022-04-01T14:48:00-07:00" level=debug msg="config file not found, proceeding without it"
time="2022-04-01T14:48:00-07:00" level=info msg="certification library version unknown <commit: unknown>"
time="2022-04-01T14:48:00-07:00" level=debug msg="URL is: https://catalog.uat.redhat.com/api/containers/v1/projects/certification/id/62423f26c3466cc1dc7fae92"
time="2022-04-01T14:48:01-07:00" level=debug msg="Certification project name is: adam-test-all-the-containers"
time="2022-04-01T14:48:01-07:00" level=debug msg="target image: quay.io/acornett/container-fails-nouser:v0.0.1"
time="2022-04-01T14:48:01-07:00" level=debug msg="pulling image from target registry"
time="2022-04-01T14:48:02-07:00" level=debug msg="temporary directory is /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327"
time="2022-04-01T14:48:02-07:00" level=debug msg="exporting and flattening image"
time="2022-04-01T14:48:02-07:00" level=debug msg="extracting container filesystem to /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs"
time="2022-04-01T14:48:02-07:00" level=debug msg="writing container filesystem to output dir: /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs"
time="2022-04-01T14:48:22-07:00" level=trace msg="image config written to disk: /Users/acornett/go/src/github.com/acornett21/openshift-preflight/artifacts/cert-image.json"
time="2022-04-01T14:48:22-07:00" level=trace msg="rpm manifest written to disk: /Users/acornett/go/src/github.com/acornett21/openshift-preflight/artifacts/rpm-manifest.json"
time="2022-04-01T14:48:22-07:00" level=debug msg="Container checks do not require a cluster. skipping cluster version check."
time="2022-04-01T14:48:22-07:00" level=debug msg="executing checks"
time="2022-04-01T14:48:22-07:00" level=debug msg="running check: HasRequiredLabel"
time="2022-04-01T14:48:22-07:00" level=warning msg="expected labels are missing:[name vendor version release summary description]"
time="2022-04-01T14:48:22-07:00" level=info msg="check completed: HasRequiredLabel" result=FAILED
time="2022-04-01T14:48:22-07:00" level=debug msg="running check: RunAsNonRoot"
time="2022-04-01T14:48:22-07:00" level=info msg="detected empty USER. Presumed to be running as root"
time="2022-04-01T14:48:22-07:00" level=info msg="USER value must be provided and be a non-root value for this check to pass"
time="2022-04-01T14:48:22-07:00" level=info msg="check completed: RunAsNonRoot" result=FAILED
time="2022-04-01T14:48:22-07:00" level=debug msg="running check: BasedOnUbi"
time="2022-04-01T14:48:22-07:00" level=trace msg="the layerIds passed to pyxis are [sha256:867d0767a47c392f80acb51572851923d6d3e55289828b0cd84a96ba342660c7 sha256:1578d44c5389fa5c69a6b6b14d8656001f7ff8d09d521f7f140dde0c3434e096 sha256:824d77b02d5411cd508e313602f42c40fb559996e8f996d477f29256d82ae1c1 sha256:8bb7512f1f976131d8b87ed04cc069cd5334db5975a3566688f73ce5c09232c8 sha256:fa5bc45ea92faba0f0b5e8c96812f875ee174f6c4b1a2fce0d32c26ca9d3ff37 sha256:3dd4a5ed0a507be1998b148c2f6fa78a67a5a1ac9ccf7c47529ca9a09c57725d sha256:4029447b7f0d7d4bb980788d468ee298142ee03613073819869a14472bcb1f93 sha256:66944027e494f780301aeb76b88687fa096b73f0ecd0fff7a42a7d289b0d3a91 sha256:4ef0f16a59f6de601edd09298250e936cc31890eb176a6a9d1967abe64b6feea sha256:dc160e3bc7fb5190ec8abba969372e1c645d45d3de53ec0116c196ca09a85df5 sha256:fed831581c313259ed8024e0c0dd1f47b2f0f3f7fcf4185402440095a6d61d41 sha256:a0c22df5884a511e34a1a64202b06adf22de09324bf42a1af94612387e5dbf6e sha256:4befeee140e596edf73e3237beeca7553972f91004077f25a1ff4efadf721ff1 sha256:6b93a3d6c1af94addd3065124faaa5e2b3ad5ae34e0014798f889a8b15e13d9f sha256:d9009e9c1d7e504b3f645e1acc3ee917b25a30faf87fe8d04e2b195be4654829 sha256:d1b68bd688a4584c2585cb7dec071940c855d0f19f388fc9744579c9b10bb2c8 sha256:e51d32807b6cf383121247fb1ee26d1c50bb86501e9cfa2d74ce94315d1d1afe sha256:e1426e52579ca4e6a1919e7288f6a8815d7515136e7164a2a51d6d11b676f05e sha256:da2020061488790a7f8ec382b74e0efc9612cf1e78f29a01085986c5a395faca sha256:5cad55cd436854cf2bbf41e863fa1cf9be08fcdc163e4db56b9bb03ad8973763 sha256:9efc62eac2e4526beb012a90e8f3fd220c056b0c2855ecde642bf5b29881d360 sha256:89c36a6b4a281d4b038871324bc3f5b55973ecfe186c47034e54e1bbfb7e091a sha256:cab03b7d18fcdb8b553c1a21ade46cb6c9fa8114b214f7ab45745b55f76a30dd sha256:c49458fb825e00f25c23fe2892113f0517df46e9031fd719a45b75e0f8a51540 sha256:f2ab441f692707e86ac4eeaca635b667bea5e3a8f5ed72c70e574a92c4f53b1a sha256:493fb34dece23c709571ca925e53ce44a6bb17af6def26ea97beae9272c6386e sha256:fc71c528226c942039e49703653ddfd1f42979cfe13ff807573d14f11fb42823 sha256:53675a13a003581b468c078ee09e96ff6dee4ef2651e60823af2b0b874dc975b sha256:bb30d84d751de7642e29267172148b96ec171081b87e627794ad172057332f39 sha256:0e288d9327d8e6ac82d535a5e08af6a31bc3207b10416d623bb02f5226f1d094 sha256:02029c7d6a1910282fa2512df1d217ae1ca100c1ee63ea418b8408c327403453 sha256:f027e4aded939bdb56c9dc9dbfe85bafce4383740a67150159ebb6aeb50f3725 sha256:370d0ef20470f078e7b29eda99caf9cbe8c3e324a7a9c2022b501ff1012666c4 sha256:7c417420227c8c30db439857354573daf4d7b4819e38daa467823488f5052864 sha256:1f29229185e1a68e1d446693acc9a9e9c98750a217f1064f5b2e3f491eac6441 sha256:d3e48bffe3919de74ce98514ceed0f3d33dfad7b3a4eea6bb0dd1c7943a1e3f4 sha256:8436b9290e1bf2610c1399c5a54b153c2a570e5df39ab7fa8bf454021db807c3 sha256:eec599b81e9ae8bc756073c78a655a1ddd360301331a2eb366c4c0cca52e3766 sha256:ba98fcb60331db68b4dcea51819e4507f40fb071e21c922f320bd0442d1dd5f1 sha256:0011a535a3a888b922fd7c42fad991b632e08c772cf4987aa9397eb3b5d677fa sha256:5d2dfff5d87eb00f1b31df19d12c0f8f83991fc7335ef97d8ac6e275649c2649 sha256:542f8a14f762d9be5f30e46514d223bde1105b70972e3e21fe7c3286549ae853]"
time="2022-04-01T14:48:22-07:00" level=trace msg="URL is https://catalog.redhat.com/api/containers/v1/images?filter=repositories.registry%3D%3Dregistry.access.redhat.com+and+uncompressed_top_layer_id%3Din%3D%28sha256%3A867d0767a47c392f80acb51572851923d6d3e55289828b0cd84a96ba342660c7%2Csha256%3A1578d44c5389fa5c69a6b6b14d8656001f7ff8d09d521f7f140dde0c3434e096%2Csha256%3A824d77b02d5411cd508e313602f42c40fb559996e8f996d477f29256d82ae1c1%2Csha256%3A8bb7512f1f976131d8b87ed04cc069cd5334db5975a3566688f73ce5c09232c8%2Csha256%3Afa5bc45ea92faba0f0b5e8c96812f875ee174f6c4b1a2fce0d32c26ca9d3ff37%2Csha256%3A3dd4a5ed0a507be1998b148c2f6fa78a67a5a1ac9ccf7c47529ca9a09c57725d%2Csha256%3A4029447b7f0d7d4bb980788d468ee298142ee03613073819869a14472bcb1f93%2Csha256%3A66944027e494f780301aeb76b88687fa096b73f0ecd0fff7a42a7d289b0d3a91%2Csha256%3A4ef0f16a59f6de601edd09298250e936cc31890eb176a6a9d1967abe64b6feea%2Csha256%3Adc160e3bc7fb5190ec8abba969372e1c645d45d3de53ec0116c196ca09a85df5%2Csha256%3Afed831581c313259ed8024e0c0dd1f47b2f0f3f7fcf4185402440095a6d61d41%2Csha256%3Aa0c22df5884a511e34a1a64202b06adf22de09324bf42a1af94612387e5dbf6e%2Csha256%3A4befeee140e596edf73e3237beeca7553972f91004077f25a1ff4efadf721ff1%2Csha256%3A6b93a3d6c1af94addd3065124faaa5e2b3ad5ae34e0014798f889a8b15e13d9f%2Csha256%3Ad9009e9c1d7e504b3f645e1acc3ee917b25a30faf87fe8d04e2b195be4654829%2Csha256%3Ad1b68bd688a4584c2585cb7dec071940c855d0f19f388fc9744579c9b10bb2c8%2Csha256%3Ae51d32807b6cf383121247fb1ee26d1c50bb86501e9cfa2d74ce94315d1d1afe%2Csha256%3Ae1426e52579ca4e6a1919e7288f6a8815d7515136e7164a2a51d6d11b676f05e%2Csha256%3Ada2020061488790a7f8ec382b74e0efc9612cf1e78f29a01085986c5a395faca%2Csha256%3A5cad55cd436854cf2bbf41e863fa1cf9be08fcdc163e4db56b9bb03ad8973763%2Csha256%3A9efc62eac2e4526beb012a90e8f3fd220c056b0c2855ecde642bf5b29881d360%2Csha256%3A89c36a6b4a281d4b038871324bc3f5b55973ecfe186c47034e54e1bbfb7e091a%2Csha256%3Acab03b7d18fcdb8b553c1a21ade46cb6c9fa8114b214f7ab45745b55f76a30dd%2Csha256%3Ac49458fb825e00f25c23fe2892113f0517df46e9031fd719a45b75e0f8a51540%2Csha256%3Af2ab441f692707e86ac4eeaca635b667bea5e3a8f5ed72c70e574a92c4f53b1a%2Csha256%3A493fb34dece23c709571ca925e53ce44a6bb17af6def26ea97beae9272c6386e%2Csha256%3Afc71c528226c942039e49703653ddfd1f42979cfe13ff807573d14f11fb42823%2Csha256%3A53675a13a003581b468c078ee09e96ff6dee4ef2651e60823af2b0b874dc975b%2Csha256%3Abb30d84d751de7642e29267172148b96ec171081b87e627794ad172057332f39%2Csha256%3A0e288d9327d8e6ac82d535a5e08af6a31bc3207b10416d623bb02f5226f1d094%2Csha256%3A02029c7d6a1910282fa2512df1d217ae1ca100c1ee63ea418b8408c327403453%2Csha256%3Af027e4aded939bdb56c9dc9dbfe85bafce4383740a67150159ebb6aeb50f3725%2Csha256%3A370d0ef20470f078e7b29eda99caf9cbe8c3e324a7a9c2022b501ff1012666c4%2Csha256%3A7c417420227c8c30db439857354573daf4d7b4819e38daa467823488f5052864%2Csha256%3A1f29229185e1a68e1d446693acc9a9e9c98750a217f1064f5b2e3f491eac6441%2Csha256%3Ad3e48bffe3919de74ce98514ceed0f3d33dfad7b3a4eea6bb0dd1c7943a1e3f4%2Csha256%3A8436b9290e1bf2610c1399c5a54b153c2a570e5df39ab7fa8bf454021db807c3%2Csha256%3Aeec599b81e9ae8bc756073c78a655a1ddd360301331a2eb366c4c0cca52e3766%2Csha256%3Aba98fcb60331db68b4dcea51819e4507f40fb071e21c922f320bd0442d1dd5f1%2Csha256%3A0011a535a3a888b922fd7c42fad991b632e08c772cf4987aa9397eb3b5d677fa%2Csha256%3A5d2dfff5d87eb00f1b31df19d12c0f8f83991fc7335ef97d8ac6e275649c2649%2Csha256%3A542f8a14f762d9be5f30e46514d223bde1105b70972e3e21fe7c3286549ae853%29"
time="2022-04-01T14:48:23-07:00" level=trace msg="query response from pyxis {\n  \"data\": [],\n  \"page\": 0,\n  \"page_size\": 100,\n  \"total\": 0\n}\n"
time="2022-04-01T14:48:23-07:00" level=error msg="No matching layer ids found in pyxis db. Please verify if the image is based on a recent UBI image"
time="2022-04-01T14:48:23-07:00" level=info msg="check completed: BasedOnUbi" result=FAILED
time="2022-04-01T14:48:23-07:00" level=debug msg="running check: HasModifiedFiles"
time="2022-04-01T14:48:23-07:00" level=info msg="check completed: HasModifiedFiles" ERROR="failed to extract tarball: stat /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs/var/lib/rpm/Packages: no such file or directory" result="failed to extract tarball: stat /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs/var/lib/rpm/Packages: no such file or directory"
time="2022-04-01T14:48:23-07:00" level=debug msg="running check: HasLicense"
time="2022-04-01T14:48:23-07:00" level=error msg="Error when checking for /licenses : stat /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs/licenses: no such file or directory"
time="2022-04-01T14:48:23-07:00" level=info msg="check completed: HasLicense" result=FAILED
time="2022-04-01T14:48:23-07:00" level=debug msg="running check: HasUniqueTag"
time="2022-04-01T14:48:23-07:00" level=info msg="check completed: HasUniqueTag" result=PASSED
time="2022-04-01T14:48:23-07:00" level=debug msg="running check: LayerCountAcceptable"
time="2022-04-01T14:48:23-07:00" level=debug msg="detected 42 layers in image"
time="2022-04-01T14:48:23-07:00" level=info msg="check completed: LayerCountAcceptable" result=FAILED
time="2022-04-01T14:48:23-07:00" level=debug msg="running check: HasNoProhibitedPackagesMounted"
time="2022-04-01T14:48:23-07:00" level=error msg="unable to get a list of all packages in the image"
time="2022-04-01T14:48:23-07:00" level=info msg="check completed: HasNoProhibitedPackagesMounted" ERROR="stat /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs/var/lib/rpm/Packages: no such file or directory" result="stat /var/folders/9w/xqjxxz8927qd47f29dt49jsw0000gn/T/preflight-3039044327/fs/var/lib/rpm/Packages: no such file or directory"
{
    "image": "quay.io/acornett/container-fails-nouser:v0.0.1",
    "passed": false,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "unknown",
        "commit": "unknown"
    },
    "results": {
        "passed": [
            {
                "name": "HasUniqueTag",
                "elapsed_time": 579,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            }
        ],
        "failed": [
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata.",
                "help": "Check Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description",
                "knowledgebase_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "check_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "check_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 381,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)",
                "help": "Check BasedOnUbi encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Change the FROM directive in your Dockerfile or Containerfile to FROM registry.access.redhat.com/ubi8/ubi",
                "knowledgebase_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "check_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            },
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
                "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
                "knowledgebase_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "check_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance.",
                "help": "Check LayerCountAcceptable encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Optimize your Dockerfile to consolidate and minimize the number of layers. Each RUN command will produce a new layer. Try combining RUN commands using \u0026\u0026 where possible.",
                "knowledgebase_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "check_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            }
        ],
        "errors": [
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 0,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified",
                "help": "Check HasModifiedFiles encountered an error. Please review the preflight.log file for more information."
            },
            {
                "name": "HasNoProhibitedPackagesMounted",
                "elapsed_time": 0,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages.",
                "help": "Check HasNoProhibitedPackages encountered an error. Please review the preflight.log file for more information."
            }
        ]
    }
}
time="2022-04-01T14:48:26-07:00" level=info msg="preparing results that will be submitted to Red Hat"
time="2022-04-01T14:48:26-07:00" level=trace msg="CertProject: &{ID:62423f26c3466cc1dc7fae92 CertificationStatus:In Progress Container:{DockerConfigJSON:{\n\t\"auths\": {\n\t\t\"https://index.docker.io/v1/\": {},\n\t\t\"public.ecr.aws\": {},\n\t\t\"quay.io\": {},\n\t\t\"registry.redhat.io\": {}\n\t},\n\t\"credsStore\": \"desktop\"\n} Type:container ISVPID:ospid-62423f26c3466cc1dc7fae92 Registry:registry.redhat.io Repository:ubi9-beta/dotnet-31} Name:adam-test-all-the-containers ProjectStatus:active Type:Containers OsContentType:}"
time="2022-04-01T14:49:03-07:00" level=debug msg="URL is: https://catalog.uat.redhat.com/api/containers/v1/projects/certification/id/62423f26c3466cc1dc7fae92"
time="2022-04-01T14:49:04-07:00" level=debug msg="URL is: https://catalog.uat.redhat.com/api/containers/v1/projects/certification/id/62423f26c3466cc1dc7fae92"
time="2022-04-01T14:49:04-07:00" level=debug msg="URL is: https://catalog.uat.redhat.com/api/containers/v1/images"
time="2022-04-01T14:50:37-07:00" level=debug msg="URL is: https://catalog.uat.redhat.com/api/containers/v1/images/id/6247735109bb6caaa8e10f3f/rpm-manifest"
time="2022-04-01T14:51:06-07:00" level=debug msg="URL is: https://catalog.uat.redhat.com/api/containers/v1/projects/certification/id/62423f26c3466cc1dc7fae92/artifacts"
time="2022-04-01T14:51:07-07:00" level=info msg="Test results have been submitted to Red Hat."
time="2022-04-01T14:51:07-07:00" level=info msg="These results will be reviewed by Red Hat for final certification."
time="2022-04-01T14:51:07-07:00" level=info msg="The container's image id is: 6247735109bb6caaa8e10f3f."
time="2022-04-01T14:51:07-07:00" level=info msg="Please check https://connect.uat.redhat.com/projects/62423f26c3466cc1dc7fae92/images/6247735109bb6caaa8e10f3f/scan-results to view scan results."
time="2022-04-01T14:51:07-07:00" level=info msg="Please check https://connect.uat.redhat.com/projects/62423f26c3466cc1dc7fae92/overview to monitor the progress."
time="2022-04-01T14:51:07-07:00" level=info msg="Preflight result: FAILED"
``` 



Signed-off-by: Adam D. Cornett <adc@redhat.com>