### PR TITLE
Use valid UID/GUID for nobody user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,9 @@ RUN curl --fail -Lo /usr/local/bin/operator-sdk https://github.com/operator-fram
 COPY LICENSE /licenses/LICENSE
 
 WORKDIR /home/nonroot
-RUN chown -R 65532:65532 /home/nonroot
+RUN chown -R 65534:65534 /home/nonroot
 
-USER 65532:65532
+USER 65534:65534
 ENTRYPOINT ["/usr/local/bin/preflight"]
 CMD ["--help"]
 


### PR DESCRIPTION
The old UID does not exist in the image 

```Shell
$ podman run -it --rm registry.access.redhat.com/ubi8/ubi:latest bash -c 'id 65532; id 65534'
id: '65532': no such user
uid=65534(nobody) gid=65534(nobody) groups=65534(nobody)
```

Fixes #543 

Signed-off-by: Tony Garcia <tonysk8@gmx.net>