### PR TITLE
Reverting user changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,5 @@ RUN curl --fail -Lo /usr/local/bin/operator-sdk https://github.com/operator-fram
 #copy license
 COPY LICENSE /licenses/LICENSE
 
-WORKDIR /home/nonroot
-RUN chown -R 65532:65532 /home/nonroot
-
-USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/preflight"]
 CMD ["--help"]
-


### PR DESCRIPTION
Reverting user changes for the following reasons:
- impacts current functionality for running as a container with volume mounts. Fixes #543.
- may impact Pipeline runs with a need to adjust SC(C) compared to the current state.