### PR TITLE
Build make target only looks for the preflight binary on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ARCHITECTURES=amd64 arm64 ppc64le s390x
 .PHONY: build
 build:
 	go build -o $(BINARY) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" main.go
-	@ls | grep preflight
+	@ls | grep -e '^preflight$$' &> /dev/null
 
 .PHONY: build-multi-arch
 build-multi-arch: $(addprefix build-linux-,$(ARCHITECTURES))


### PR DESCRIPTION
Micro PR, but I couldn't unsee it once I saw it.

The `make build` target has an `ls` that looks for the preflight binary, presumably to ensure that the output file is on disk as expected. The grep also hits the preflight.log on my machine if I've been testing things, so this just changes the grep to look specifically for the preflight binary.

Before:

```
$ make build
go build -o preflight -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=558391c44c0a20c2d807b6859843a7650b53e16b -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version="0.0.0"" main.go
preflight
preflight.log    <-- this line is not expected
```
I also redirect the output to /dev/null so in effect we just get a non-zero return code if the file isn't there, and a zero return code if it is.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>