### PR TITLE
Move OsContentType to CertProjectContainer

### DIFF
--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -93,7 +93,6 @@ type CertProject struct {
 	Name                string    `json:"name"`                      // required
 	ProjectStatus       string    `json:"project_status"`            // required
 	Type                string    `json:"type" default:"Containers"` // required
-	OsContentType       string    `json:"os_content_type,omitempty"`
 }
 
 type Container struct {
@@ -102,6 +101,7 @@ type Container struct {
 	ISVPID           string `json:"isv_pid,omitempty"`         // required
 	Registry         string `json:"registry,omitempty"`
 	Repository       string `json:"repository,omitempty"`
+	OsContentType    string `json:"os_content_type,omitempty"`
 }
 
 type Layer struct {

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -83,7 +83,7 @@ var checkContainerCmd = &cobra.Command{
 			return err
 		}
 		log.Debugf("Certification project name is: %s", certProject.Name)
-		if certProject.OsContentType == "scratch" {
+		if certProject.Container.OsContentType == "scratch" {
 			cfg.EnabledChecks = engine.ScratchContainerPolicy()
 			cfg.Scratch = true
 		}


### PR DESCRIPTION
The OsContentType field is actually under the CertProjectContainer,
not the project itself.

Signed-off-by: Brad P. Crochet <brad@redhat.com>