### PR TITLE
adding clarity to logs when GetPackageList is called

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -39,4 +39,7 @@ var (
 	ErrInvalidGraphqlQuery             = errors.New("could not marshal GraphQL query")
 	ErrInvalidHttpClient               = errors.New("client could not be used as http.Client")
 	ErrSubmittingToPyxis               = errors.New("unable to submit results to Red Hat")
+	ErrRPMPackageList                  = errors.New("could not get rpm list")
+	ErrExtractingLayer                 = errors.New("could not extract layer")
+	ErrDetectingModifiedFiles          = errors.New("error detecting modified files")
 )

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -439,7 +439,7 @@ func getBgName(srcrpm string) string {
 func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 	pkgList, err := rpm.GetPackageList(ctx, containerFSPath)
 	if err != nil {
-		log.Error("could not get rpm list, continuing without it")
+		log.Error(fmt.Errorf("%w: continuing without it", errors.ErrRPMPackageList))
 	}
 
 	// covert rpm struct to pxyis struct

--- a/certification/internal/policy/container/has_modified_files.go
+++ b/certification/internal/policy/container/has_modified_files.go
@@ -30,7 +30,7 @@ type packageFilesRef struct {
 func (p *HasModifiedFilesCheck) Validate(ctx context.Context, imgRef certification.ImageReference) (bool, error) {
 	packageFiles, err := p.getDataToValidate(ctx, imgRef)
 	if err != nil {
-		return false, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
+		return false, fmt.Errorf("%w: %s", errors.ErrDetectingModifiedFiles, err)
 	}
 	return p.validate(packageFiles)
 }
@@ -43,7 +43,7 @@ func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef ce
 	// rpm, dnf, yum, etc. being installed in the image.
 	pkgList, err := rpm.GetPackageList(ctx, imgRef.ImageFSPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", errors.ErrRPMPackageList, err)
 	}
 
 	// Get the files put in place on the filesystem by the
@@ -73,7 +73,7 @@ func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef ce
 	for _, layer := range layers {
 		r, err := layer.Uncompressed()
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", errors.ErrExtractingTarball, err)
+			return nil, fmt.Errorf("%w: %s", errors.ErrExtractingLayer, err)
 		}
 		pathChan := make(chan string)
 

--- a/certification/internal/policy/container/has_prohibited_packages.go
+++ b/certification/internal/policy/container/has_prohibited_packages.go
@@ -2,9 +2,11 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/rpm"
 	log "github.com/sirupsen/logrus"
 )
@@ -26,7 +28,7 @@ func (p *HasNoProhibitedPackagesCheck) Validate(ctx context.Context, imgRef cert
 func (p *HasNoProhibitedPackagesCheck) getDataToValidate(ctx context.Context, dir string) ([]string, error) {
 	pkgList, err := rpm.GetPackageList(ctx, dir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", errors.ErrRPMPackageList, err)
 	}
 	pkgs := make([]string, 0, len(pkgList))
 	for _, pkg := range pkgList {


### PR DESCRIPTION
- Since this method is called in multiple places, adding an errors to the error files
- Removing wrap of `errors.ErrExtractingTarball` in `Validate` method of since thats not the only possible error

Signed-off-by: Adam D. Cornett <adc@redhat.com>