### PR TITLE
Make the pulling of the project to check for scratch optional

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -42,4 +42,5 @@ var (
 	ErrRPMPackageList                  = errors.New("could not get rpm list")
 	ErrExtractingLayer                 = errors.New("could not extract layer")
 	ErrDetectingModifiedFiles          = errors.New("error detecting modified files")
+	ErrRetrievingProject               = errors.New("could not retrieve project")
 )

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -150,16 +150,16 @@ You will also need:
   - This value can be obtained from the Overview page's URL
     - For the following example Overview URL of `https://connect.redhat.com/projects/1234567890aabbccddeeffgg/overview`
       - The Certification Project ID would be: `1234567890aabbccddeeffgg`
+  - Required for submit
 - A Partner Connect API Key
   - An API Key can be created in Red Hat Partner Connect at the following [URL](https://connect.redhat.com/account/api-keys)
+  - Required for submit
 
 ### Testing a Container
 Running container policy checks against a container iteratively until all tests pass.
 
 ```bash
-preflight check container registry.example.org/your-namespace/your-image:sometag \
---pyxis-api-token=abcdefghijklmnopqrstuvwxyz123456 \
---certification-project-id=1234567890a987654321bcde 
+preflight check container registry.example.org/your-namespace/your-image:sometag
 ```
 
 ### Submitting a Container's Test Results to Red Hat


### PR DESCRIPTION
In order to facilitate the running of preflight without the requirement
of a certification ID and API key, we will check if the certification
ID is provided. If it is not, we will skip checking the project before
running the checks. If --submit is given, the id and API key will become
required again.

Refers to #552
Fixes #549

Signed-off-by: Brad P. Crochet <brad@redhat.com>