### PR TITLE
Clarify the graphql layer checking logic

### DIFF
--- a/certification/internal/policy/container/base_on_ubi_test.go
+++ b/certification/internal/policy/container/base_on_ubi_test.go
@@ -21,7 +21,7 @@ func ConfigFile() (*cranev1.ConfigFile, error) {
 
 type fakeLayerHashChecker struct{}
 
-func (flhc *fakeLayerHashChecker) CheckRedHatLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
+func (flhc *fakeLayerHashChecker) CertifiedImagesContainingLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
 	var matchingImages []pyxis.CertImage
 	matchingImages = append(matchingImages, pyxis.CertImage{})
 	return matchingImages, nil
@@ -29,14 +29,14 @@ func (flhc *fakeLayerHashChecker) CheckRedHatLayers(ctx context.Context, layers 
 
 type fakeLayerHashCheckerNoMatch struct{}
 
-func (flhc *fakeLayerHashCheckerNoMatch) CheckRedHatLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
+func (flhc *fakeLayerHashCheckerNoMatch) CertifiedImagesContainingLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
 	var matchingImages []pyxis.CertImage
 	return matchingImages, nil
 }
 
 type fakeLayerHashCheckerTimeout struct{}
 
-func (flhc *fakeLayerHashCheckerTimeout) CheckRedHatLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
+func (flhc *fakeLayerHashCheckerTimeout) CertifiedImagesContainingLayers(ctx context.Context, layers []cranev1.Hash) ([]pyxis.CertImage, error) {
 	return nil, http.ErrHandlerTimeout
 }
 

--- a/certification/pyxis/layers.go
+++ b/certification/pyxis/layers.go
@@ -11,12 +11,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *pyxisClient) CheckRedHatLayers(ctx context.Context, layerHashes []cranev1.Hash) ([]CertImage, error) {
-	layerIds := make([]graphql.String, 0, len(layerHashes))
-	for _, layer := range layerHashes {
+// CertifiedImagesContainingLayers takes uncompressedLayerHashes and queries to a Red Hat Pyxis,
+// returning existing certified images from registry.access.redhat.com that contain any of the
+// IDs as its uncompressed top layer id.
+func (p *pyxisClient) CertifiedImagesContainingLayers(ctx context.Context, uncompressedLayerHashes []cranev1.Hash) ([]CertImage, error) {
+	layerIds := make([]graphql.String, 0, len(uncompressedLayerHashes))
+	for _, layer := range uncompressedLayerHashes {
 		layerIds = append(layerIds, graphql.String(layer.String()))
 	}
 
+	// our graphQL query
 	var query struct {
 		FindImages struct {
 			ContainerImage []struct {
@@ -29,14 +33,17 @@ func (p *pyxisClient) CheckRedHatLayers(ctx context.Context, layerHashes []crane
 			} `graphql:"error"`
 			Total graphql.Int
 			Page  graphql.Int
+			// filter to make sure we get exact results
 		} `graphql:"find_images(filter: {and:[{repositories:{registry:{in:$registries}}}{uncompressed_top_layer_id:{in:$contImageLayers}}]})"`
 	}
 
+	// variables to feed to our graphql filter
 	variables := map[string]interface{}{
 		"contImageLayers": layerIds,
 		"registries":      []graphql.String{"registry.access.redhat.com"},
 	}
 
+	// make our query
 	httpClient, ok := p.Client.(*http.Client)
 	if !ok {
 		return nil, errors.ErrInvalidHttpClient

--- a/certification/pyxis/layers_test.go
+++ b/certification/pyxis/layers_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Pyxis CheckRedHatLayers", func() {
 		})
 		Context("and a layer is a known good layer", func() {
 			It("should be a good layer", func() {
-				certImages, err := pyxisClient.CheckRedHatLayers(ctx, []cranev1.Hash{{}})
+				certImages, err := pyxisClient.CertifiedImagesContainingLayers(ctx, []cranev1.Hash{{}})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certImages).ToNot(BeNil())
 				Expect(certImages).ToNot(BeZero())


### PR DESCRIPTION
## Motivation

The BasedOnUBI check had a few opportunities where clarification could help future developers make changes, so this PR intends to clean some of those things.

The logic itself doesn't change much, but there are some method name changes for very specific reasons (detailed before). Otherwise, the code is functionally the same.

I think there's room to make further distinction between just "layers" and the uncompressed layer IDs that we're working with here, but I haven't figured out what makes the most sense there yet, so I'll have to revisit.

I mostly just wanted to change `CheckRedHatLayers` (see below).

## Change summary, by file

**certification/internal/policy/container/based_on_ubi.go**

- The comment describing the check was no longer correct. We perform a more granular check now than simply checking OS files to see if we're using the Red Hat UBI
- Several other method/function comments were put in place.
- The `CheckRedHatLayers` method has been renamed (starting at the interface, and all implementations I found). The `CheckRedHatLayers` name wasn't clear as to what we expected to get out of the method, so the new name `CertifiedImagesContainingLayers`, while longer, does include the inputs (Layers) and the output (CertifiedImages containing... well you get the idea).
- StaticCheck complained that checking `certImages` for nil before checking length is greater than 1 was redundant, so I complied.

**certification/pyxis/layers.go**

- Mostly comments here, and making sure the method name matched the interface's new definition.

**certification/pyxis/layers_test.go**
**certification/internal/policy/container/based_on_ubi_test.go**

- Nothing to note, other than making sure Fakes are in line.





Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>