### PR TITLE
Remove redundant alpha tag from the version displayed in results.json/test_library

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -37,7 +37,7 @@ jobs:
         archs: ${{ matrix.architecture }}
         build-args: |
           quay_expiration=1w
-          release_tag=${{ env.RELEASE_TAG }}-alpha+${{ github.sha }}
+          release_tag=${{ env.RELEASE_TAG }}+${{ github.sha }}
           ARCH=${{ matrix.architecture }}
         dockerfiles: |
           ./Dockerfile


### PR DESCRIPTION
The version currently displayed in results.json for check operator tests contains a redundant alpha tag:
```
"test_library": {
  "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
  "version": "1.1.0-beta6-alpha+478d6d7db0afac422c122e1a8800760fd6426a6c",
  "commit": "478d6d7db0afac422c122e1a8800760fd6426a6c"
},
```