### PR TITLE
HasNoProhibitedPackages check has an incorrect name. Fix it.

### DIFF
--- a/certification/internal/policy/container/has_prohibited_packages.go
+++ b/certification/internal/policy/container/has_prohibited_packages.go
@@ -62,7 +62,7 @@ func (p *HasNoProhibitedPackagesCheck) validate(ctx context.Context, pkgList []s
 }
 
 func (p *HasNoProhibitedPackagesCheck) Name() string {
-	return "HasNoProhibitedPackagesMounted"
+	return "HasNoProhibitedPackages"
 }
 
 func (p *HasNoProhibitedPackagesCheck) Metadata() certification.Metadata {


### PR DESCRIPTION
The Name() function still has "Mounted" in the returned name. That
needs to go.

Signed-off-by: Brad P. Crochet <brad@redhat.com>