### PR TITLE
Refactor and simplify some of the file reading

### DIFF
--- a/certification/pyxis/builder_test.go
+++ b/certification/pyxis/builder_test.go
@@ -1,0 +1,42 @@
+package pyxis
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pyxis Builder tests", func() {
+	var tmpdir string
+	var err error
+
+	BeforeEach(func() {
+		// create tmpdir to receive extracted fs
+		tmpdir, err = os.MkdirTemp(os.TempDir(), "builder-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.RemoveAll(tmpdir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("When reading a file with ReadFile", func() {
+		It("should be the same size as file.Stat().Size()", func() {
+			f := filepath.Join(tmpdir, "test.txt")
+			os.WriteFile(f, []byte("\tHello world!\n"), 0o0755)
+
+			file, err := os.Open(f)
+			Expect(err).ToNot(HaveOccurred())
+
+			info, err := file.Stat()
+			Expect(err).ToNot(HaveOccurred())
+
+			fileBytes, err := os.ReadFile(f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(int64(len(fileBytes))).To(Equal(info.Size()))
+		})
+	})
+})

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -166,13 +166,7 @@ var checkContainerCmd = &cobra.Command{
 			log.Tracef("CertProject: %+v", certProject)
 
 			// read the provided docker config
-			dockerConfigJsonFile, err := os.Open(viper.GetString("dockerConfig"))
-			if err != nil {
-				return err
-			}
-			defer dockerConfigJsonFile.Close()
-
-			dockerConfigJsonBytes, err := io.ReadAll(dockerConfigJsonFile)
+			dockerConfigJsonBytes, err := os.ReadFile(viper.GetString("dockerConfig"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This simplifies and refactors some of our file reading.

* Extracts all of the "read file, unmarshal" in builder to a common
  function
* Uses os.ReadFile() to get the docker config instead of open, read,
  close
* Use os.ReadFile() with Artifacts, and just get the length from the
  bytes read, instead of using io.Stat()

Signed-off-by: Brad P. Crochet <brad@redhat.com>