### PR TITLE
Prefer the usage of pyxis env instead of pyxis host

### DIFF
--- a/certification/defaults.go
+++ b/certification/defaults.go
@@ -5,5 +5,6 @@ var (
 	DefaultRPMManifestFilename = "rpm-manifest.json"
 	DefaultTestResultsFilename = "results.json"
 	DefaultPyxisHost           = "catalog.redhat.com/api/containers"
+	DefaultPyxisEnv            = "prod"
 	SystemdDir                 = "/etc/systemd/system"
 )


### PR DESCRIPTION
Create a map, and use that map to lookup what the pyxis host and
path should be, rather than forcing the user to know that information.

If pyxis host is set, it will override the env. It is assumed that the
user knows what they are doing.

Signed-off-by: Brad P. Crochet <brad@redhat.com>