### PR TITLE
Simplify the install of go tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,6 @@ gofumpt: ## Download envtest-setup locally if necessary.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-install-tool
 @[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
This strips out some of the hacky 'make a temp module' stuff that was
necessary prior to Go 1.17. This still wraps in a function, but only
does 'go install' and only when it needs to.

Signed-off-by: Brad P. Crochet <brad@redhat.com>