### PR TITLE
adding in RootExceptionContainerPolicy check list

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -137,6 +137,18 @@ var scratchContainerPolicy = map[string]certification.Check{
 	// runSystemContainerCheck.Name(): runSystemContainerCheck,
 }
 
+var rootExceptionContainerPolicy = map[string]certification.Check{
+	hasLicenseCheck.Name():        hasLicenseCheck,
+	hasUniqueTagCheck.Name():      hasUniqueTagCheck,
+	maxLayersCheck.Name():         maxLayersCheck,
+	hasNoProhibitedCheck.Name():   hasNoProhibitedCheck,
+	hasRequiredLabelsCheck.Name(): hasRequiredLabelsCheck,
+	basedOnUbiCheck.Name():        basedOnUbiCheck,
+	hasModifiedFilesCheck.Name():  hasModifiedFilesCheck,
+	// runnableContainerCheck.Name():  runnableContainerCheck,
+	// runSystemContainerCheck.Name(): runSystemContainerCheck,
+}
+
 func makeCheckList(checkMap map[string]certification.Check) []string {
 	checks := make([]string, 0, len(checkMap))
 
@@ -157,4 +169,8 @@ func ContainerPolicy() []string {
 
 func ScratchContainerPolicy() []string {
 	return makeCheckList(scratchContainerPolicy)
+}
+
+func RootExceptionContainerPolicy() []string {
+	return makeCheckList(rootExceptionContainerPolicy)
 }

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -102,6 +102,7 @@ type Container struct {
 	Registry         string `json:"registry,omitempty"`
 	Repository       string `json:"repository,omitempty"`
 	OsContentType    string `json:"os_content_type,omitempty"`
+	Privileged       bool   `json:"privileged,omitempty"`
 }
 
 type Layer struct {

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -95,6 +95,11 @@ var checkContainerCmd = &cobra.Command{
 				cfg.EnabledChecks = engine.ScratchContainerPolicy()
 				cfg.Scratch = true
 			}
+
+			// if a partner sets `Host Level Access` in connect to `Privileged`, enable RootExceptionContainerPolicy checks
+			if certProject.Container.Privileged {
+				cfg.EnabledChecks = engine.RootExceptionContainerPolicy()
+			}
 		}
 
 		engine, err := engine.NewForConfig(cfg)


### PR DESCRIPTION
- Fixes: #568 
- Adding in RootExceptionContainerPolicy which is to be used to exclude RunAsNonRoot check for projects that have Host level access set to `Privileged` in connect project setup
- The above value is determined from pyxis `certProject.container.privileged` value

## Connect Setup
-  https://connect.uat.redhat.com/projects/6258a3c3170e7478b8eab726/settings
<img width="921" alt="image" src="https://user-images.githubusercontent.com/88156657/163493500-c3930b3a-0c14-4a80-b5ee-2596e94f7fe2.png">

## Test Results
- https://connect.uat.redhat.com/projects/6258a3c3170e7478b8eab726/images/6258a52a170e7478b8eab727/scan-results (The `BasedOnUBI` error can be ignored, Pyxis is currently having issues and will retest on Monday)
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/88156657/163493620-a972cff6-2f06-42e5-b820-d1da8e1f5296.png">

You will notice no `RunAsNonRootCheck`

Signed-off-by: Adam D. Cornett <adc@redhat.com>