### PR TITLE
removing pyxis host and api key from viper in init

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -162,7 +162,7 @@ var checkContainerCmd = &cobra.Command{
 
 			// establish a pyxis client.
 			apiToken := viper.GetString("pyxis_api_token")
-			pyxisClient := pyxis.NewPyxisClient(viper.GetString("pyxis_host"), apiToken, projectId, &http.Client{Timeout: 60 * time.Second})
+			pyxisClient := pyxis.NewPyxisClient(pyxisHost, apiToken, projectId, &http.Client{Timeout: 60 * time.Second})
 
 			// get the project info from pyxis
 			certProject, err := pyxisClient.GetProject(ctx)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -46,10 +46,6 @@ func initConfig() {
 
 	// Set up scorecard wait time default
 	viper.SetDefault("scorecard_wait_time", DefaultScorecardWaitTime)
-
-	// Set up pyxis host
-	viper.SetDefault("pyxis_host", certification.DefaultPyxisHost)
-	viper.SetDefault("pyxis_api_token", "")
 }
 
 // preRunConfig is used by cobra.PreRun in all non-root commands to load all necessary configurations


### PR DESCRIPTION
- Fixes: #571 
- Due to the oder of operators and how `init()`s load, removing the `pyxis_host` from viper so that `pyxisHostLookup` returns the `env` that the user asked for with the `--pyxis-env` flag 

Signed-off-by: Adam D. Cornett <adc@redhat.com>