### PR TITLE
add an option for insecure or self-signed pulling

### DIFF
--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -55,6 +55,9 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 
 	// prepare crane runtime options, if necessary
 	options := make([]crane.Option, 0)
+	
+	// add an insecure registry option for pulling
+	options = append(options, crane.Insecure)
 
 	// pull the image and save to fs
 	log.Debug("pulling image from target registry")


### PR DESCRIPTION
adding a crane engine option for insecure registries.
Fixes #577 