### PR TITLE
Make the Connect URLs match the environment given

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -71,12 +70,9 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 
 func buildConnectURL(projectID string) string {
 	connectURL := fmt.Sprintf("https://connect.redhat.com/projects/%s", projectID)
-	pyxisHost := viper.GetString("pyxis_host")
-	s := strings.Split(pyxisHost, ".")
 
-	if pyxisHost != certification.DefaultPyxisHost && len(s) > 3 {
-		env := s[1]
-		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/projects/%s", env, projectID)
+	if viper.GetString("pyxis_env") != "prod" {
+		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/projects/%s", viper.GetString("pyxis_env"), projectID)
 	}
 
 	return connectURL

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -19,7 +19,7 @@ var _ = Describe("cmd package utility functions", func() {
 
 			It("should be results.txt", func() {
 				actual := resultsFilenameWithExtension(extension)
-				Expect(actual).To(Equal(expected))
+				Expect(expected).To(Equal(actual))
 			})
 		})
 
@@ -29,51 +29,74 @@ var _ = Describe("cmd package utility functions", func() {
 
 			It("should be results.json", func() {
 				actual := resultsFilenameWithExtension(extension)
-				Expect(actual).To(Equal(expected))
+				Expect(expected).To(Equal(actual))
 			})
 		})
 	})
 
 	Describe("Test Connect URL builders", func() {
+		var (
+			projectId string = "this-is-my-project-id"
+			imageId   string = "my-image-id"
+		)
 		BeforeEach(func() {
 			viper.SetEnvPrefix("pflt")
 			viper.AutomaticEnv()
 		})
+		AfterEach(func() {
+			os.Unsetenv("PFLT_PYXIS_ENV")
+			os.Unsetenv("PFLT_PYXIS_HOST")
+		})
 		Context("Regular Connect URL", func() {
-			expected := "https://connect.redhat.com/projects/this-is-my-project-id"
 			It("should return a URL with just a project ID", func() {
-				actual := buildConnectURL("this-is-my-project-id")
-				Expect(actual).To(Equal(expected))
+				expected := "https://connect.redhat.com/projects/this-is-my-project-id"
+				actual := buildConnectURL(projectId)
+				Expect(expected).To(Equal(actual))
 			})
 		})
 		Context("QA Connect URL", func() {
 			BeforeEach(func() {
-				os.Setenv("PFLT_PYXIS_HOST", "catalog.qa.redhat.com")
+				os.Setenv("PFLT_PYXIS_ENV", "qa")
 			})
-			expected := "https://connect.qa.redhat.com/projects/this-is-my-project-id"
 			It("should return a URL for QA", func() {
-				actual := buildConnectURL("this-is-my-project-id")
-				Expect(actual).To(Equal(expected))
+				expected := "https://connect.qa.redhat.com/projects/this-is-my-project-id"
+				actual := buildConnectURL(projectId)
+				Expect(expected).To(Equal(actual))
 			})
 		})
 		Context("UAT Scan Results URL", func() {
 			BeforeEach(func() {
-				os.Setenv("PFLT_PYXIS_HOST", "catalog.uat.redhat.com")
+				os.Setenv("PFLT_PYXIS_ENV", "uat")
 			})
-			expected := "https://connect.uat.redhat.com/projects/this-is-my-project-id/images/my-image-id/scan-results"
 			It("should return a URL for UAT", func() {
-				actual := buildScanResultsURL("this-is-my-project-id", "my-image-id")
-				Expect(actual).To(Equal(expected))
+				expected := "https://connect.uat.redhat.com/projects/this-is-my-project-id/images/my-image-id/scan-results"
+				actual := buildScanResultsURL(projectId, imageId)
+				Expect(expected).To(Equal(actual))
 			})
 		})
 		Context("QA Overview URL", func() {
 			BeforeEach(func() {
-				os.Setenv("PFLT_PYXIS_HOST", "catalog.qa.redhat.com")
+				os.Setenv("PFLT_PYXIS_ENV", "qa")
 			})
-			expected := "https://connect.qa.redhat.com/projects/this-is-my-project-id/overview"
 			It("should return a URL for QA", func() {
-				actual := buildOverviewURL("this-is-my-project-id")
-				Expect(actual).To(Equal(expected))
+				expected := "https://connect.qa.redhat.com/projects/this-is-my-project-id/overview"
+				actual := buildOverviewURL(projectId)
+				Expect(expected).To(Equal(actual))
+			})
+		})
+		Context("Override Pyxis Host", func() {
+			BeforeEach(func() {
+				os.Setenv("PFLT_PYXIS_HOST", "my.pyxis.host/some/path")
+			})
+			It("should return a Prod overview URL", func() {
+				expected := "https://connect.redhat.com/projects/this-is-my-project-id/overview"
+				actual := buildOverviewURL(projectId)
+				Expect(expected).To(Equal(actual))
+			})
+			It("should return a Prod scan URL", func() {
+				expected := "https://connect.redhat.com/projects/this-is-my-project-id/images/my-image-id/scan-results"
+				actual := buildScanResultsURL(projectId, imageId)
+				Expect(expected).To(Equal(actual))
 			})
 		})
 	})


### PR DESCRIPTION
The major change here is that if a user provides a Pyxis host directly
(which should not be usual) then the URL returned for connect will
just be prod.

Also refactor tests a little bit to make them more readable. Was already
in the file adding tests for this patch so made them more consistent.

Fixes #576 

Signed-off-by: Brad P. Crochet <brad@redhat.com>