### PR TITLE
updating check container recipe to add in support for private registries

### DIFF
--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -198,7 +198,9 @@ $CONTAINER_TOOL run \
   --env PFLT_CERTIFICATION_PROJECT_ID=1234567890a987654321bcde \
   --env PFLT_PYXIS_API_TOKEN=abcdefghijklmnopqrstuvwxyz123456 \
   --env PFLT_DOCKERCONFIG=/temp-authfile.json \
+  --env DOCKER_CONFIG=/tmp/docker \
   -v /some/path/on/your/host/artifacts:/artifacts \
   -v ./temp-authfile.json:/temp-authfile.json:ro \
+  -v ./temp-authfile.json:/tmp/docker/config.json:ro \
   quay.io/opdev/preflight:stable check container registry.example.org/your-namespace/your-bundle-image:sometag --submit
 ```


### PR DESCRIPTION
- adding in `DOCKER_CONFIG` value to recipe for `check container` to support private registries

Signed-off-by: Adam D. Cornett <adc@redhat.com>