### PR TITLE
updating vagrant file to change the port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/fedora35"
   config.vm.synced_folder ".", "/home/vagrant/preflight"
+  config.vm.network :forwarded_port, guest: 22, host: 2322, id: "ssh"
   config.vm.provision "shell", inline: <<-SHELL
     dnf -y update
    


### PR DESCRIPTION
- updating the vagrant file so that prelfight vm and CRC can run at the same time. CRC runs on the default port of `2222` and so does `vagrant` since CRC is harder to configure, updating here.

Signed-off-by: Adam D. Cornett <adc@redhat.com>