### PR TITLE
Copy release images to redhat-isv on quay

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -77,3 +77,16 @@ jobs:
     secrets:
       registry: ${{ secrets.IMAGE_REGISTRY }}
       token: ${{ secrets.GITHUB_TOKEN }}
+
+  copy-to-rhisv:
+    needs: [build-release, build-multiarch]
+    uses: ./.github/workflows/copy-to-rhisv.yml
+    with:
+      sourceImageName: ${{ needs.build-release.outputs.imageName }}
+      sourceImageTag: ${{ needs.build-release.outputs.imageVersion }}
+      destImageName: preflight-test
+    secrets:
+      sourceImageRegistry: ${{ secrets.IMAGE_REGISTRY }}
+      destImageRegistry: ${{ secrets.RHISV_IMAGE_REGISTRY }}
+      destRegistryUser: ${{ secrets.RHISV_REGISTRY_USER }}
+      destRegistryPassword: ${{ secrets.RHISV_REGISTRY_PASSWORD }}

--- a/.github/workflows/copy-to-rhisv.yml
+++ b/.github/workflows/copy-to-rhisv.yml
@@ -1,0 +1,56 @@
+name: Mirror images to RHISV Quay Org
+
+on:
+  workflow_call:
+    inputs:
+      sourceImageName:
+        required: true
+        type: string
+      sourceImageTag:
+        required: true
+        type: string
+      destImageName:
+        required: true
+        type: string
+    secrets:
+      sourceImageRegistry:
+        required: true
+      destImageRegistry:
+        required: true
+      destRegistryUser:
+        required: true
+      destRegistryPassword:
+        required: true
+
+jobs:
+  mirror-images-to-rhisv:
+    name: Mirror Images
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Install Skopeo
+      run: |
+        sudo apt-get update && sudo apt-get install libgpgme-dev libdevmapper-dev libbtrfs-dev -y
+        go install github.com/containers/skopeo/cmd/skopeo@v1.7.0
+        skopeo -v
+
+    - name: Podman Login
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ${{ secrets.destImageRegistry }}
+        username: ${{ secrets.destRegistryUser }}
+        password: ${{ secrets.destRegistryPassword }}
+
+    - name: Copy Images from Source to Dest
+      id: skopeo-copy-image
+      run: |
+        skopeo -v
+        skopeo copy --all --preserve-digests docker://${{ secrets.sourceImageRegistry }}/${{ inputs.sourceImageName }}:${{ inputs.sourceImageTag }}-linux-amd64 docker://${{ secrets.destImageRegistry }}/${{ inputs.destImageName }}:${{ inputs.sourceImageTag }}-linux-amd64
+        skopeo copy --all --preserve-digests docker://${{ secrets.sourceImageRegistry }}/${{ inputs.sourceImageName }}:${{ inputs.sourceImageTag }}-linux-ppc64le docker://${{ secrets.destImageRegistry }}/${{ inputs.destImageName }}:${{ inputs.sourceImageTag }}-linux-ppc64le
+        skopeo copy --all --preserve-digests docker://${{ secrets.sourceImageRegistry }}/${{ inputs.sourceImageName }}:${{ inputs.sourceImageTag }}-linux-arm64 docker://${{ secrets.destImageRegistry }}/${{ inputs.destImageName }}:${{ inputs.sourceImageTag }}-linux-arm64
+        skopeo copy --all --preserve-digests docker://${{ secrets.sourceImageRegistry }}/${{ inputs.sourceImageName }}:${{ inputs.sourceImageTag }}-linux-s390x docker://${{ secrets.destImageRegistry }}/${{ inputs.destImageName }}:${{ inputs.sourceImageTag }}-linux-s390x
+        skopeo copy --all --preserve-digests docker://${{ secrets.sourceImageRegistry }}/${{ inputs.sourceImageName }}:${{ inputs.sourceImageTag }} docker://${{ secrets.destImageRegistry }}/${{ inputs.destImageName }}:${{ inputs.sourceImageTag }}


### PR DESCRIPTION
This PR introduces an action that's invoked via workflow call. 

It waits for build-release and build-multiarch to complete, and then copy all of those images to the redhat-isv organization in Quay.

This should push a little more than we want (e.g. rc, betas, etc), but we don't automatically use these images in pipelines. To use it in pipelines, we must submit a PR to the pipeline to point to the new images in redhat-isv. From that perspective, adding extra images to the org should cause no problems.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>