### PR TITLE
Fix a data race exposed by race checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ image-push:
 test:
 	go test -v $$(go list ./... | grep -v e2e)
 
+.PHONY: cover
+cover:
+	go test -v $$(go list ./... | grep -v e2e) -race -cover -coverprofile=coverage.out
+
 .PHONY: vet
 vet:
 	go vet ./...


### PR DESCRIPTION
When adding the -race flag to go test along with -cover, a couple of
data races were exposed by the tool. This fixes those data races, and
introduces 'make cover' as a target in the Makefile.

The wg.Wait() was being executed before anything as added to the
WaitGroup. Therefore, it was possible that the channel might close
before any work was done. This makes sure that the WaitGroup has
something to wait on before calling Wait.

Signed-off-by: Brad P. Crochet <brad@redhat.com>