### PR TITLE
Run tests on release branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,9 @@ name: Go
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - release-*
 
 jobs:
   build:


### PR DESCRIPTION
Since we have release branches now, it is a good idea to run tests
on those branches so that when we cherry-pick to them, it will run
these tests.

Signed-off-by: Brad P. Crochet <brad@redhat.com>