### PR TITLE
Fix docker-config flag to come from cobra.PersistentFlags, not cobra.Flags.

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -23,7 +23,7 @@ func init() {
 	checkCmd.PersistentFlags().BoolP("list-checks", "l", false, "lists all the checks run for a given check")
 
 	checkCmd.PersistentFlags().StringP("docker-config", "d", "", "path to docker config.json file (env: PFLT_DOCKERCONFIG)")
-	viper.BindPFlag("dockerConfig", checkCmd.Flags().Lookup("docker-config"))
+	viper.BindPFlag("dockerConfig", checkCmd.PersistentFlags().Lookup("docker-config"))
 
 	rootCmd.AddCommand(checkCmd)
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cmd package check command", func() {
+	Describe("Test Flags", func() {
+		Context("Docker Config", func() {
+			It("docker-config from Flags() should be nil, but PersistentFlags() should be set", func() {
+				expected := "/my/docker/config.json"
+				checkCmd.PersistentFlags().Set("docker-config", expected)
+				Expect(checkCmd.Flags().Lookup("docker-config")).To(BeNil())
+				Expect(checkCmd.PersistentFlags().Lookup("docker-config").Value.String()).To(Equal(expected))
+			})
+		})
+	})
+})


### PR DESCRIPTION
The `docker-config` Flags in the check command is a persistent flag,  not a flag.  Passing anything to this flag, and then subsequently running `viper.GetString("dockerConfig")` returns nothing.  

see
https://github.com/spf13/viper/issues/292#issuecomment-327996518

Test added showing that this flag is coming from persistentflags, not flags.