### PR TITLE
add preflight-specific labels to the resulting container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-# golang:1.16 image created 2021-06-24T00:31:06.02014601Z 
 FROM docker.io/golang:1.17 AS builder
 ARG quay_expiration
 ARG release_tag
@@ -18,8 +17,22 @@ RUN make build RELEASE_TAG=${release_tag}
 # ubi8:latest
 FROM registry.access.redhat.com/ubi8/ubi:latest
 ARG quay_expiration
+ARG release_tag
+ARG preflight_commit
 ARG ARCH
 ARG OS
+
+# Metadata
+LABEL name="Preflight" \
+      vendor="Red Hat, Inc." \
+      maintainer="Red Hat OpenShift Ecosystem" \
+      version="1" \
+      summary="Provides the OpenShift Preflight certification tool." \
+      description="Preflight runs certification checks against containers and Operators." \
+      url="https://github.com/redhat-openshift-ecosystem/openshift-preflight" \
+      release=${release_tag} \
+      vcs-ref=${preflight_commit}
+
 
 # Define that tags should expire after 1 week. This should not apply to versioned releases.
 LABEL quay.expires-after=${quay_expiration}

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ tidy:
 
 .PHONY: image-build
 image-build:
-	$(IMAGE_BUILDER) build -t $(IMAGE_REPO)/preflight:$(VERSION) .
+	$(IMAGE_BUILDER) build --build-arg release_tag=$(RELEASE_TAG) --build-arg preflight_commit=$(VERSION) -t $(IMAGE_REPO)/preflight:$(VERSION) .
 
 .PHONY: image-push
 image-push:


### PR DESCRIPTION
We pass through UBI's labels, so I figured we should add some of our own.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>