### PR TITLE
updating a few of the help texts

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -22,7 +22,9 @@ func init() {
 
 	checkCmd.PersistentFlags().BoolP("list-checks", "l", false, "lists all the checks run for a given check")
 
-	checkCmd.PersistentFlags().StringP("docker-config", "d", "", "path to docker config.json file (env: PFLT_DOCKERCONFIG)")
+	checkCmd.PersistentFlags().StringP("docker-config", "d", "", "Path to docker config.json file. This value is optional for publicly accessible images.\n"+
+		"However, it is strongly encouraged for public Docker Hub images,\n"+
+		"due to the rate limit imposed for unauthenticated requests. (env: PFLT_DOCKERCONFIG)")
 	viper.BindPFlag("dockerConfig", checkCmd.PersistentFlags().Lookup("docker-config"))
 
 	rootCmd.AddCommand(checkCmd)

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -248,13 +248,15 @@ func init() {
 	checkContainerCmd.Flags().String("pyxis-api-token", "", "API token for Pyxis authentication (env: PFLT_PYXIS_API_TOKEN)")
 	viper.BindPFlag("pyxis_api_token", checkContainerCmd.Flags().Lookup("pyxis-api-token"))
 
-	checkContainerCmd.Flags().String("pyxis-host", "", fmt.Sprintf("Host to use for Pyxis submissions.\nThis will override Pyxis Env.\nOnly set this if you know what you are doing.\nIf you do set it, it should include just the host, and the URI path.\n(env: PFLT_PYXIS_HOST)"))
+	checkContainerCmd.Flags().String("pyxis-host", "", fmt.Sprintf("Host to use for Pyxis submissions. This will override Pyxis Env. Only set this if you know what you are doing.\n"+
+		"If you do set it, it should include just the host, and the URI path. (env: PFLT_PYXIS_HOST)"))
 	viper.BindPFlag("pyxis_host", checkContainerCmd.Flags().Lookup("pyxis-host"))
 
 	checkContainerCmd.Flags().String("pyxis-env", certification.DefaultPyxisEnv, "Env to use for Pyxis submissions.")
 	viper.BindPFlag("pyxis_env", checkContainerCmd.Flags().Lookup("pyxis-env"))
 
-	checkContainerCmd.Flags().String("certification-project-id", "", fmt.Sprintf("Certification Project ID from connect.redhat.com.\nShould be supplied without the ospid- prefix.\n(env: PFLT_CERTIFICATION_PROJECT_ID)"))
+	checkContainerCmd.Flags().String("certification-project-id", "", fmt.Sprintf("Certification Project ID from connect.redhat.com/projects/{certification-project-id}/overview\n"+
+		"URL paramater. This value may differ from the PID on the overview page. (env: PFLT_CERTIFICATION_PROJECT_ID)"))
 	viper.BindPFlag("certification_project_id", checkContainerCmd.Flags().Lookup("certification-project-id"))
 
 	checkCmd.AddCommand(checkContainerCmd)


### PR DESCRIPTION
- Updating a few of the help cmd text values since a few partners have had confusion around these values.

Below is the new output
```
Flags:
      --certification-project-id string   Certification Project ID from connect.redhat.com/projects/{certification-project-id}/overview
                                          URL paramater. This value may differ from the PID on the overview page. (env: PFLT_CERTIFICATION_PROJECT_ID)
  -h, --help                              help for container
      --pyxis-api-token string            API token for Pyxis authentication (env: PFLT_PYXIS_API_TOKEN)
      --pyxis-env string                  Env to use for Pyxis submissions. (default "prod")
      --pyxis-host string                 Host to use for Pyxis submissions. This will override Pyxis Env. Only set this if you know what you are doing.
                                          If you do set it, it should include just the host, and the URI path. (env: PFLT_PYXIS_HOST)
  -s, --submit                            submit check container results to red hat

Global Flags:
  -d, --docker-config string   Path to docker config.json file. This value is optional for publicly accessible images.
                               However, it is strongly encouraged for public Docker Hub images,
                               due to the rate limit imposed for unauthenticated requests. (env: PFLT_DOCKERCONFIG)
  -l, --list-checks            lists all the checks run for a given check

```

Signed-off-by: Adam D. Cornett <adc@redhat.com>