### PR TITLE
Increase coverage of the internal/bundle package

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -43,4 +43,5 @@ var (
 	ErrExtractingLayer                 = errors.New("could not extract layer")
 	ErrDetectingModifiedFiles          = errors.New("error detecting modified files")
 	ErrRetrievingProject               = errors.New("could not retrieve project")
+	ErrTooManyCSVs                     = errors.New("more than one CSV file detected in bundle")
 )

--- a/certification/internal/bundle/bundle_suite_test.go
+++ b/certification/internal/bundle/bundle_suite_test.go
@@ -1,6 +1,18 @@
 package bundle
 
-import "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+)
+
+func TestBundle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bundle Utils Suite")
+}
 
 type FakeOperatorSdkEngine struct {
 	OperatorSdkReport   cli.OperatorSdkScorecardReport
@@ -13,4 +25,11 @@ func (f FakeOperatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdk
 
 func (f FakeOperatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
 	return &f.OperatorSdkReport, nil
+}
+
+// In order to test some negative paths, this io.Reader will just throw an error
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("test error")
 }

--- a/certification/internal/bundle/bundle_test.go
+++ b/certification/internal/bundle/bundle_test.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -8,21 +9,184 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 )
 
 var _ = Describe("BundleValidateCheck", func() {
 	const (
-		metadataDir        = "metadata"
-		annotationFilename = "annotations.yaml"
-		annotations        = `annotations:
+		clusterServiceVersionFilename = "myoperator.clusterserviceversion.yaml"
+		manifestsDir                  = "manifests"
+		metadataDir                   = "metadata"
+		annotationFilename            = "annotations.yaml"
+		annotations                   = `annotations:
   com.redhat.openshift.versions: "v4.6-v4.9"
   operators.operatorframework.io.bundle.package.v1: testPackage
   operators.operatorframework.io.bundle.channel.default.v1: testChannel
 `
 	)
 
-	// fakeEngine cli.OperatorSdkEngine
-	var imageRef certification.ImageReference
+	Describe("Bundle validation", func() {
+		var (
+			imageRef   certification.ImageReference
+			fakeEngine cli.OperatorSdkEngine
+		)
+
+		BeforeEach(func() {
+			// mock bundle directory
+			tmpDir, err := os.MkdirTemp("", "bundle-metadata-*")
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.Mkdir(filepath.Join(tmpDir, metadataDir), 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.Mkdir(filepath.Join(tmpDir, manifestsDir), 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(tmpDir, metadataDir, annotationFilename), []byte(annotations), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			imageRef.ImageFSPath = tmpDir
+			fakeEngine = FakeOperatorSdkEngine{}
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(imageRef.ImageFSPath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("the annotations file is valid", func() {
+			It("should pass", func() {
+				report, err := ValidateBundle(context.Background(), fakeEngine, imageRef.ImageFSPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(report).ToNot(BeNil())
+			})
+		})
+
+		Context("the annotations file does not exist", func() {
+			JustBeforeEach(func() {
+				err := os.Remove(filepath.Join(imageRef.ImageFSPath, metadataDir, annotationFilename))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should error", func() {
+				report, err := ValidateBundle(context.Background(), fakeEngine, imageRef.ImageFSPath)
+				Expect(err).To(HaveOccurred())
+				Expect(report).To(BeNil())
+			})
+		})
+
+		Context("the annotations file is malformed", func() {
+			JustBeforeEach(func() {
+				err := os.WriteFile(filepath.Join(imageRef.ImageFSPath, metadataDir, annotationFilename), []byte("badAnnotations"), 0o644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should error", func() {
+				report, err := ValidateBundle(context.Background(), fakeEngine, imageRef.ImageFSPath)
+				Expect(err).To(HaveOccurred())
+				Expect(report).To(BeNil())
+			})
+		})
+
+		Context("the annotations file is valid but has no annotations", func() {
+			JustBeforeEach(func() {
+				err := os.WriteFile(filepath.Join(imageRef.ImageFSPath, metadataDir, annotationFilename), []byte("annotations:"), 0o644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should fail gracefully", func() {
+				report, err := ValidateBundle(context.Background(), fakeEngine, imageRef.ImageFSPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(report).ToNot(BeNil())
+			})
+		})
+
+		Context("getting the CSV file from the bundle", func() {
+			var manifestsPath string
+
+			BeforeEach(func() {
+				manifestsPath = filepath.Join(imageRef.ImageFSPath, manifestsDir)
+				err := os.WriteFile(filepath.Join(manifestsPath, clusterServiceVersionFilename), []byte(""), 0o644)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			Context("the CSV exists by itself", func() {
+				It("should return the filename", func() {
+					filename, err := GetCsvFilePathFromBundle(imageRef.ImageFSPath)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(filename).To(Equal(filepath.Join(manifestsPath, clusterServiceVersionFilename)))
+				})
+			})
+			Context("the CSV doesn't exist", func() {
+				JustBeforeEach(func() {
+					err := os.Remove(filepath.Join(manifestsPath, clusterServiceVersionFilename))
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should return an error", func() {
+					filename, err := GetCsvFilePathFromBundle(imageRef.ImageFSPath)
+					Expect(err).To(HaveOccurred())
+					Expect(filename).To(Equal(""))
+				})
+			})
+			Context("there is more than one CSV", func() {
+				JustBeforeEach(func() {
+					err := os.WriteFile(filepath.Join(manifestsPath, "otheroperator.clusterserviceversion.yaml"), []byte(""), 0o664)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should return an error", func() {
+					filename, err := GetCsvFilePathFromBundle(imageRef.ImageFSPath)
+					Expect(err).To(HaveOccurred())
+					Expect(filename).To(Equal(""))
+				})
+			})
+			Context("there is a bad mount dir", func() {
+				It("should return an error", func() {
+					filename, err := GetCsvFilePathFromBundle("[]")
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(Equal(filepath.ErrBadPattern))
+					Expect(filename).To(Equal(""))
+				})
+			})
+		})
+	})
+
+	Describe("Supported Install Modes", func() {
+		var csv string = `spec:
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces`
+
+		Context("CSV is valid", func() {
+			It("should return a map of 3", func() {
+				installModes, err := GetSupportedInstallModes(context.Background(), bytes.NewBufferString(csv))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(installModes).ToNot(BeNil())
+				Expect(len(installModes)).To(Equal(3))
+				Expect("MultiNamespace").ToNot(BeElementOf(installModes))
+			})
+		})
+
+		Context("reader is not valid", func() {
+			It("should error", func() {
+				installModes, err := GetSupportedInstallModes(context.Background(), errReader(0))
+				Expect(err).To(HaveOccurred())
+				Expect(installModes).To(BeNil())
+			})
+		})
+
+		Context("CSV is invalid", func() {
+			JustBeforeEach(func() {
+				csv = `invalid`
+			})
+			It("should error", func() {
+				installModes, err := GetSupportedInstallModes(context.Background(), bytes.NewBufferString(csv))
+				Expect(err).To(HaveOccurred())
+				Expect(installModes).To(BeNil())
+			})
+		})
+	})
 
 	Describe("While ensuring that container util is working", func() {
 		// tests: extractAnnotationsBytes
@@ -54,36 +218,15 @@ var _ = Describe("BundleValidateCheck", func() {
 					Expect(err).To(HaveOccurred())
 				})
 			})
+
+			Context("a bad reader is sent to GetAnnotations", func() {
+				It("should return an error", func() {
+					annotations, err := GetAnnotations(context.Background(), errReader(0))
+					Expect(err).To(HaveOccurred())
+					Expect(annotations).To(BeNil())
+				})
+			})
 		})
-	})
-
-	BeforeEach(func() {
-		// 		stdout := `{
-		// 	"passed": true,
-		// 	"outputs": null
-		// }`
-		// 		stderr := ""
-		// report := cli.OperatorSdkBundleValidateReport{
-		// 	Stdout:  stdout,
-		// 	Stderr:  stderr,
-		// 	Passed:  true,
-		// 	Outputs: []cli.OperatorSdkBundleValidateOutput{},
-		// }
-		// fakeEngine = FakeOperatorSdkEngine{
-		// 	OperatorSdkBVReport: report,
-		// }
-
-		// mock bundle directory
-		tmpDir, err := os.MkdirTemp("", "bundle-metadata-*")
-		Expect(err).ToNot(HaveOccurred())
-
-		err = os.Mkdir(filepath.Join(tmpDir, metadataDir), 0o755)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = os.WriteFile(filepath.Join(tmpDir, metadataDir, annotationFilename), []byte(annotations), 0o644)
-		Expect(err).ToNot(HaveOccurred())
-
-		imageRef.ImageFSPath = tmpDir
 	})
 
 	DescribeTable("Image Registry validation",
@@ -97,9 +240,8 @@ var _ = Describe("BundleValidateCheck", func() {
 		Entry("range 4.6 to 4.9", "v4.6-v4.9", true),
 		Entry(">= 4.8", "v4.8", true),
 		Entry(">= 4.9", "v4.9", true),
+		Entry("begins = with error", "=foo", false),
+		Entry("bare version with error", "vfoo", false),
+		Entry("range with error", "v4.6-vfoo", false),
 	)
-	AfterEach(func() {
-		err := os.RemoveAll(imageRef.ImageFSPath)
-		Expect(err).ToNot(HaveOccurred())
-	})
 })

--- a/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
+++ b/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -38,7 +40,14 @@ type packageData struct {
 type OperatorPkgNameIsUniqueCheck struct{}
 
 func (p *OperatorPkgNameIsUniqueCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
-	annotations, err := bundle.GetAnnotations(ctx, bundleRef.ImageFSPath)
+	// retrieve the operator metadata from bundle image
+	annotationsFileName := filepath.Join(bundleRef.ImageFSPath, "metadata", "annotations.yaml")
+	annotationsFile, err := os.Open(annotationsFileName)
+	if err != nil {
+		log.Error(fmt.Errorf("%w: could not open annotations.yaml", err))
+		return false, err
+	}
+	annotations, err := bundle.GetAnnotations(ctx, annotationsFile)
 	if err != nil {
 		log.Error("unable to get annotations.yaml from the bundle")
 		return false, err


### PR DESCRIPTION
Changes made to increase coverage:

* Add TestBundle to enable the suite. 0% -> 40%.
* Add ValidateBundle tests. 40% -> 97.2%.
* Refactor to use io.Reader for easier testing
* Fixed bug in finding CSV files

Fixes #615

Signed-off-by: Brad P. Crochet <brad@redhat.com>