### PR TITLE
Increase test coverage of the version package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,16 @@ image-push:
 
 .PHONY: test
 test:
-	go test -v $$(go list ./... | grep -v e2e)
+	go test -v $$(go list ./... | grep -v e2e) \
+	-ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo"
 
 .PHONY: cover
 cover:
-	go test -v $$(go list ./... | grep -v e2e) -race -cover -coverprofile=coverage.out
+	go test -v \
+	 -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo" \
+	 $$(go list ./... | grep -v e2e) \
+	 -race \
+	 -cover -coverprofile=coverage.out
 
 .PHONY: vet
 vet:

--- a/version/version_suite_test.go
+++ b/version/version_suite_test.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,54 @@
+package version
+
+import (
+	"reflect"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("version package utility", func() {
+	// Values assumed to be passed when calling make test.
+	ldflagVersionOverride := "foo"
+	ldflagCommitOverride := "bar"
+
+	// These tests validate that we can override the version and commit information successfully,
+	// and that our string representation includes that information.
+	Context("When being passed version and commit information via ldflags", func() {
+		It("should contain the passed in version and commit information in internal data structures", func() {
+			Expect(Version.Version).To(Equal(ldflagVersionOverride))
+			Expect(Version.Commit).To(Equal(ldflagCommitOverride))
+		})
+	})
+
+	Context("When printing the VersionContext", func() {
+		It("should display the version and the commit information as a string", func() {
+			Expect(strings.Contains(Version.String(), ldflagVersionOverride)).To(BeTrue())
+			Expect(strings.Contains(Version.String(), ldflagCommitOverride)).To(BeTrue())
+		})
+	})
+
+	// These tests confirm that we have appropriate JSON struct tags because we include
+	// this in Preflight Results.
+	Context("When using a VersionContext", func() {
+		It("should have JSON struct tags on fields", func() {
+			nf, nexists := reflect.TypeOf(&Version).Elem().FieldByName("Name") // The struct key!
+			Expect(nexists).To(BeTrue())
+			Expect(string(nf.Tag)).To(Equal(`json:"name"`)) // the tag
+
+			vf, vexists := reflect.TypeOf(&Version).Elem().FieldByName("Version")
+			Expect(vexists).To(BeTrue())
+			Expect(string(vf.Tag)).To(Equal(`json:"version"`))
+
+			cf, cexists := reflect.TypeOf(&Version).Elem().FieldByName("Commit")
+			Expect(cexists).To(BeTrue())
+			Expect(string(cf.Tag)).To(Equal(`json:"commit"`))
+		})
+
+		It("should only have three struct keys for tests to be valid", func() {
+			keys := reflect.TypeOf(Version).NumField()
+			Expect(keys).To(Equal(3))
+		})
+	})
+})


### PR DESCRIPTION
Version is tiny, so fairly easy to get 100% here. I added a few extra tests relevant to how we use version.

- Checks to make sure we have JSON struct tags, since we marshal the VersionContext into Preflight Results IIRC
- ensures that ldflags can properly replace these values. Updated the Makefile to make sure we pass these flags during tests (with prepared values)
- Makes sure that the implemented Stringer interface includes the commit and version.

Fixes #621 

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>