### PR TITLE
Increase test coverage of the certification/artifacts

### DIFF
--- a/certification/artifacts/artifacts_test.go
+++ b/certification/artifacts/artifacts_test.go
@@ -1,0 +1,50 @@
+package artifacts
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
+)
+
+var _ = Describe("Artifacts package utility functions", func() {
+	BeforeEach(func() {
+		// clean up the artifacts directory that might be created
+		// in each of these tests. This removes only the artifacts
+		// directory value, not the temporary dir established in
+		// BeforeSuite.
+		err := os.RemoveAll(viper.GetString("artifacts"))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("With an artifacts directory provided via configuration", func() {
+		It("should write the provided contents to the file with the provided name", func() {
+			contents := "hello world"
+			fullFilePath, err := WriteFile("test.txt", contents)
+			Expect(err).ToNot(HaveOccurred())
+
+			bcontents, err := os.ReadFile(fullFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(bcontents)).To(Equal(contents))
+		})
+
+		It("should be created when explicitly calling the createArtifactsDir function", func() {
+			createdDir, err := createArtifactsDir(artifactsPkgTestBaseDir)
+			Expect(err).ToNot(HaveOccurred())
+			dirInfo, err := os.Stat(createdDir)
+			// if it doesn't exist, this error will capture it.
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dirInfo.IsDir()).To(BeTrue())
+		})
+
+		It("should be created by the exported Path() function", func() {
+			createdDir := Path()
+			dirInfo, err := os.Stat(createdDir)
+			// if it doesn't exist, this error will capture it.
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dirInfo.IsDir()).To(BeTrue())
+		})
+	})
+})

--- a/certification/artifacts/suite_test.go
+++ b/certification/artifacts/suite_test.go
@@ -1,0 +1,36 @@
+package artifacts
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
+)
+
+func TestArtifacts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Artifacts Suite")
+}
+
+// Initialize an artifacts dir for the test suite. The base dir
+// must be defined here to allow AfterSuite to remove it.
+var artifactsPkgTestBaseDir string
+
+var _ = BeforeSuite(func() {
+	artifactsPkgTestBaseDir, err := os.MkdirTemp(os.TempDir(), "artifacts-pkg-test-*")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(len(artifactsPkgTestBaseDir)).ToNot(BeZero())
+	artifactsDir := path.Join(artifactsPkgTestBaseDir, "artifacts")
+
+	// Set the artifacts dir in viper. This won't have been created
+	// prior to running tests.
+	viper.Set("artifacts", artifactsDir)
+})
+
+var _ = AfterSuite(func() {
+	err := os.RemoveAll(artifactsPkgTestBaseDir)
+	Expect(err).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
Just getting the small ones done as a snowball. This adds tests for the artifacts package. Not quite 100% coverage, but the error paths are not error paths we define from what I can see. They're error paths in creating directories and such. Lower level syscalls.

```
$ go test ./certification/artifacts/ -race -cover -coverprofile=coverage.out
ok      github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts       0.271s  coverage: 71.4% of statements
```

This leverages `BeforeSuite` to set the suite-specific artifacts directory to a temporary path.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>