### PR TITLE
Fix the coverage of the certification package

### DIFF
--- a/certification/certification_suite_test.go
+++ b/certification/certification_suite_test.go
@@ -1,0 +1,13 @@
+package certification
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestBundle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Certification Suite")
+}


### PR DESCRIPTION
* Add a test suite to make adding tests in the future easier, and
  to have it reported in the test coverage reports.
* Add tests for the GenericCheck
* Coverage: 100%

Fixes #613

Signed-off-by: Brad P. Crochet <brad@redhat.com>