### PR TITLE
ioutil calls deprecated

### DIFF
--- a/certification/internal/authn/keychain_test.go
+++ b/certification/internal/authn/keychain_test.go
@@ -17,7 +17,6 @@ package authn
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -41,7 +40,7 @@ func setupConfigDir(t *testing.T) string {
 	tmpdir := os.Getenv("TEST_TMPDIR")
 	if tmpdir == "" {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "keychain_test")
+		tmpdir, err = os.MkdirTemp("", "keychain_test")
 		if err != nil {
 			t.Fatalf("creating temp dir: %v", err)
 		}
@@ -58,7 +57,7 @@ func setupConfigDir(t *testing.T) string {
 func setupConfigFile(t *testing.T, content string) string {
 	cd := setupConfigDir(t)
 	p := filepath.Join(cd, "config.json")
-	if err := ioutil.WriteFile(p, []byte(content), 0o600); err != nil {
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %q: %v", p, err)
 	}
 	os.Setenv("PFLT_DOCKERCONFIG", p)


### PR DESCRIPTION
Similar to #209 

Was just looking through some of my previous commits and decided to look again for ioutil calls.

https://golang.org/doc/go1.16#ioutil