### PR TITLE
Fix typos

### DIFF
--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -182,7 +182,7 @@ func (p *DeployableByOlmCheck) operatorMetadata(ctx context.Context, bundleRef c
 
 	installModes, err := bundle.GetSupportedInstallModes(ctx, csvFileReader)
 	if err != nil {
-		log.Error(fmt.Errorf("%w: unable to extract operator install modes from ClusterServicVersion", err))
+		log.Error(fmt.Errorf("%w: unable to extract operator install modes from ClusterServiceVersion", err))
 		return nil, err
 	}
 

--- a/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
+++ b/certification/internal/policy/operator/operator_pkg_name_uniqueness.go
@@ -55,7 +55,7 @@ func (p *OperatorPkgNameIsUniqueCheck) Validate(ctx context.Context, bundleRef c
 
 	packageName, err := p.getPackageName(ctx, annotations)
 	if err != nil {
-		log.Error("unable to extract package name from ClusterServicVersion", err)
+		log.Error("unable to extract package name from ClusterServiceVersion", err)
 		return false, err
 	}
 


### PR DESCRIPTION
While looking around in the operator certification I noticed this typo.