### PR TITLE
Refactor OpenShift client wrapper to its own package

### DIFF
--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/authn"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/openshift"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/rpm"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/pyxis"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
@@ -144,7 +145,7 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 
 	if c.IsBundle {
 		// Record test cluster version
-		c.results.TestedOn, err = GetOpenshiftClusterVersion()
+		c.results.TestedOn, err = openshift.GetOpenshiftClusterVersion()
 		if err != nil {
 			log.Error("Unable to determine test cluster version: ", err)
 		}

--- a/certification/internal/openshift/openshift_suite_test.go
+++ b/certification/internal/openshift/openshift_suite_test.go
@@ -1,0 +1,13 @@
+package openshift
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpenshift(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Openshift Client Suite")
+}

--- a/certification/internal/openshift/openshift_test.go
+++ b/certification/internal/openshift/openshift_test.go
@@ -1,4 +1,4 @@
-package engine
+package openshift
 
 import (
 	"context"
@@ -7,11 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	imagestreamv1 "github.com/openshift/api/image/v1"
-	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 
@@ -19,7 +16,7 @@ import (
 )
 
 var _ = Describe("OpenShift Engine", func() {
-	var oe *openshiftEngine
+	var oc Client
 
 	BeforeEach(func() {
 		pod1 := corev1.Pod{
@@ -96,35 +93,32 @@ var _ = Describe("OpenShift Engine", func() {
 		}
 
 		scheme := apiruntime.NewScheme()
-		Expect(operatorv1.AddToScheme(scheme)).To(Succeed())
-		Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
-		Expect(imagestreamv1.AddToScheme(scheme)).To(Succeed())
-		Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+		Expect(AddSchemes(scheme)).To(Succeed())
 		cl := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(&csv).
 			WithLists(&pods, &isList).
 			Build()
-		oe = &openshiftEngine{Client: cl}
+		oc = NewClient(cl)
 	})
 	Context("Namespaces", func() {
 		It("should exercise Namespaces", func() {
 			By("creating a Namespace", func() {
-				ns, err := oe.CreateNamespace(context.TODO(), "testns")
+				ns, err := oc.CreateNamespace(context.TODO(), "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ns).ToNot(BeNil())
 			})
 			By("getting that Namespace", func() {
-				ns, err := oe.GetNamespace(context.TODO(), "testns")
+				ns, err := oc.GetNamespace(context.TODO(), "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ns).ToNot(BeNil())
 			})
 			By("deleting that Namespace", func() {
-				err := oe.DeleteNamespace(context.TODO(), "testns")
+				err := oc.DeleteNamespace(context.TODO(), "testns")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("trying to get it again, but failing", func() {
-				ns, err := oe.GetNamespace(context.TODO(), "testns")
+				ns, err := oc.GetNamespace(context.TODO(), "testns")
 				Expect(err).To(HaveOccurred())
 				Expect(ns).To(BeNil())
 			})
@@ -132,27 +126,27 @@ var _ = Describe("OpenShift Engine", func() {
 	})
 	Context("OperatorGroups", func() {
 		It("should exercise OperatorGroups", func() {
-			operatorGroupData := cli.OperatorGroupData{
+			operatorGroupData := OperatorGroupData{
 				Name:             "testog",
 				TargetNamespaces: []string{"default", "testns"},
 			}
 			By("creating a OperatorGroup", func() {
-				og, err := oe.CreateOperatorGroup(context.TODO(), operatorGroupData, "testns")
+				og, err := oc.CreateOperatorGroup(context.TODO(), operatorGroupData, "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(og).ToNot(BeNil())
 			})
 			By("getting that OperatorGroup", func() {
-				og, err := oe.GetOperatorGroup(context.TODO(), "testog", "testns")
+				og, err := oc.GetOperatorGroup(context.TODO(), "testog", "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(og).ToNot(BeNil())
 				Expect(og.Spec.TargetNamespaces).To(ContainElement("testns"))
 			})
 			By("deleting that OperatorGroup", func() {
-				err := oe.DeleteOperatorGroup(context.TODO(), "testog", "testns")
+				err := oc.DeleteOperatorGroup(context.TODO(), "testog", "testns")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("trying to get it again, but failing", func() {
-				og, err := oe.GetOperatorGroup(context.TODO(), "testog", "testns")
+				og, err := oc.GetOperatorGroup(context.TODO(), "testog", "testns")
 				Expect(err).To(HaveOccurred())
 				Expect(og).To(BeNil())
 			})
@@ -163,12 +157,12 @@ var _ = Describe("OpenShift Engine", func() {
 			By("creating a Secret", func() {
 				content := make(map[string]string, 1)
 				content["test"] = "testdata"
-				secret, err := oe.CreateSecret(context.TODO(), "testsecret", content, corev1.SecretTypeDockerConfigJson, "testns")
+				secret, err := oc.CreateSecret(context.TODO(), "testsecret", content, corev1.SecretTypeDockerConfigJson, "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(secret).ToNot(BeNil())
 			})
 			By("getting that Secret", func() {
-				secret, err := oe.GetSecret(context.TODO(), "testsecret", "testns")
+				secret, err := oc.GetSecret(context.TODO(), "testsecret", "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(secret).ToNot(BeNil())
 				// This wouldn't be a readable field in "normal" client operations. But rather
@@ -177,11 +171,11 @@ var _ = Describe("OpenShift Engine", func() {
 				Expect(secret.StringData).To(ContainElement("testdata"))
 			})
 			By("deleting that Secret", func() {
-				err := oe.DeleteSecret(context.TODO(), "testsecret", "testns")
+				err := oc.DeleteSecret(context.TODO(), "testsecret", "testns")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("trying to get it again, but failing", func() {
-				secret, err := oe.GetSecret(context.TODO(), "testsecret", "testns")
+				secret, err := oc.GetSecret(context.TODO(), "testsecret", "testns")
 				Expect(err).To(HaveOccurred())
 				Expect(secret).To(BeNil())
 			})
@@ -190,27 +184,27 @@ var _ = Describe("OpenShift Engine", func() {
 	Context("CatalogSources", func() {
 		It("should exercise CatalogSources", func() {
 			By("creating a CatalogSource", func() {
-				csData := cli.CatalogSourceData{
+				csData := CatalogSourceData{
 					Name:    "testcs",
 					Image:   "this/is/my-image:now",
 					Secrets: []string{"my-secrets"},
 				}
-				cs, err := oe.CreateCatalogSource(context.TODO(), csData, "testns")
+				cs, err := oc.CreateCatalogSource(context.TODO(), csData, "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cs).ToNot(BeNil())
 			})
 			By("getting that CatalogSource", func() {
-				cs, err := oe.GetCatalogSource(context.TODO(), "testcs", "testns")
+				cs, err := oc.GetCatalogSource(context.TODO(), "testcs", "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cs).ToNot(BeNil())
 				Expect(cs.Spec.Image).To(Equal("this/is/my-image:now"))
 			})
 			By("deleting that CatalogSource", func() {
-				err := oe.DeleteCatalogSource(context.TODO(), "testcs", "testns")
+				err := oc.DeleteCatalogSource(context.TODO(), "testcs", "testns")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("trying to get it again, but failing", func() {
-				cs, err := oe.GetCatalogSource(context.TODO(), "testcs", "testns")
+				cs, err := oc.GetCatalogSource(context.TODO(), "testcs", "testns")
 				Expect(err).To(HaveOccurred())
 				Expect(cs).To(BeNil())
 			})
@@ -219,29 +213,29 @@ var _ = Describe("OpenShift Engine", func() {
 	Context("Subscriptions", func() {
 		It("should exercise Subscriptions", func() {
 			By("creating a Subscription", func() {
-				subData := cli.SubscriptionData{
+				subData := SubscriptionData{
 					Name:                   "testsub",
 					Channel:                "testchannel",
 					CatalogSource:          "testcs",
 					CatalogSourceNamespace: "testns",
 					Package:                "testpackage",
 				}
-				sub, err := oe.CreateSubscription(context.TODO(), subData, "testns")
+				sub, err := oc.CreateSubscription(context.TODO(), subData, "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sub).ToNot(BeNil())
 			})
 			By("getting that Subscription", func() {
-				sub, err := oe.GetSubscription(context.TODO(), "testsub", "testns")
+				sub, err := oc.GetSubscription(context.TODO(), "testsub", "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sub).ToNot(BeNil())
 				Expect(sub.Spec.Channel).To(Equal("testchannel"))
 			})
 			By("deleting that Subscription", func() {
-				err := oe.DeleteSubscription(context.TODO(), "testsub", "testns")
+				err := oc.DeleteSubscription(context.TODO(), "testsub", "testns")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("trying to get it again, but failing", func() {
-				sub, err := oe.GetSubscription(context.TODO(), "testsub", "testns")
+				sub, err := oc.GetSubscription(context.TODO(), "testsub", "testns")
 				Expect(err).To(HaveOccurred())
 				Expect(sub).To(BeNil())
 			})
@@ -250,28 +244,28 @@ var _ = Describe("OpenShift Engine", func() {
 	Context("RoleBindings", func() {
 		It("should exercise RoleBindings", func() {
 			By("creating a RoleBinding", func() {
-				rbData := cli.RoleBindingData{
+				rbData := RoleBindingData{
 					Name:      "testrb",
 					Subjects:  []string{"testsubject"},
 					Role:      "testrole",
 					Namespace: "testns",
 				}
-				rb, err := oe.CreateRoleBinding(context.TODO(), rbData, "testns")
+				rb, err := oc.CreateRoleBinding(context.TODO(), rbData, "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rb).ToNot(BeNil())
 			})
 			By("getting that RoleBinding", func() {
-				rb, err := oe.GetRoleBinding(context.TODO(), "testrb", "testns")
+				rb, err := oc.GetRoleBinding(context.TODO(), "testrb", "testns")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rb).ToNot(BeNil())
 				Expect(rb.Name).To(Equal("testrb"))
 			})
 			By("deleting that RoleBinding", func() {
-				err := oe.DeleteRoleBinding(context.TODO(), "testrb", "testns")
+				err := oc.DeleteRoleBinding(context.TODO(), "testrb", "testns")
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("trying to get it again, but failing", func() {
-				rb, err := oe.GetRoleBinding(context.TODO(), "testrb", "testns")
+				rb, err := oc.GetRoleBinding(context.TODO(), "testrb", "testns")
 				Expect(err).To(HaveOccurred())
 				Expect(rb).To(BeNil())
 			})
@@ -279,14 +273,14 @@ var _ = Describe("OpenShift Engine", func() {
 	})
 	Context("Images", func() {
 		It("should exercise GetImages", func() {
-			images, err := oe.GetImages(context.TODO())
+			images, err := oc.GetImages(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(images).ToNot(BeNil())
 		})
 	})
 	Context("CSVs", func() {
 		It("should exercise GetCSV", func() {
-			csv, err := oe.GetCSV(context.TODO(), "testcsv", "testns")
+			csv, err := oc.GetCSV(context.TODO(), "testcsv", "testns")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(csv).ToNot(BeNil())
 		})

--- a/certification/internal/openshift/openshift_version.go
+++ b/certification/internal/openshift/openshift_version.go
@@ -1,4 +1,4 @@
-package engine
+package openshift
 
 import (
 	"context"

--- a/certification/internal/openshift/types.go
+++ b/certification/internal/openshift/types.go
@@ -1,4 +1,4 @@
-package cli
+package openshift
 
 import (
 	"context"
@@ -35,7 +35,7 @@ type RoleBindingData struct {
 	Namespace string
 }
 
-type OpenshiftEngine interface {
+type Client interface {
 	CreateNamespace(ctx context.Context, name string) (*corev1.Namespace, error)
 	DeleteNamespace(ctx context.Context, name string) error
 	GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error)

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -10,10 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
-	imagestreamv1 "github.com/openshift/api/image/v1"
-	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
-	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +17,7 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/openshift"
 )
 
 var _ = Describe("DeployableByOLMCheck", func() {
@@ -107,10 +104,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 		og.Status.LastUpdated = &now
 		deployableByOLMCheck = *NewDeployableByOlmCheck(&fakeEngine)
 		scheme := apiruntime.NewScheme()
-		Expect(operatorv1.AddToScheme(scheme)).To(Succeed())
-		Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
-		Expect(imagestreamv1.AddToScheme(scheme)).To(Succeed())
-		Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+		Expect(openshift.AddSchemes(scheme)).To(Succeed())
 		client = fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(&csv, &csvDefault, &csvMarketplace, &ns, &secret, &sub, &og).


### PR DESCRIPTION
The OpenShift client wrapper should not have been named 'OpenshiftEngine'.
It isn't an engine. It's just a convenience wrapper around a k8s, and more
specifically, a controller-runtime, client.

* Move all openshift*.go files out of engine into new openshift package
* Move the openshift types out of cli package and into openshift package
* Modify deployable_by_olm to use the new package

Signed-off-by: Brad P. Crochet <brad@redhat.com>