### PR TITLE
normalize docker registries to `docker.io` for the cert image

### DIFF
--- a/certification/pyxis/pyxis_suite_test.go
+++ b/certification/pyxis/pyxis_suite_test.go
@@ -105,6 +105,8 @@ func (p *pyxisImageHandler) ServeHTTP(response http.ResponseWriter, request *htt
 		response.WriteHeader(http.StatusUnauthorized)
 	case request.Method == http.MethodPost && request.Header["X-Api-Key"][0] == "my-bad-500-image-api-token":
 		response.WriteHeader(http.StatusInternalServerError)
+	case request.Header["X-Api-Key"][0] == "my-index-docker-io-project-api-token":
+		mustWrite(response, `{"_id": "blah", "architecture": "amd64", "object_type": "containerImage", "repositories": [ {"published": false, "registry": "docker.io", "repository": "my/repo", "tags": [{"name": "docker_io_v3"}]}]}`)
 	case request.Method == http.MethodPost:
 		mustWrite(response, responseString)
 	default:

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Pyxis Submit", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(certResults).ToNot(BeNil())
 				Expect(certResults.CertProject.Container.Registry).Should(Equal(defaultRegistryAlias))
-				Expect(certResults.CertImage).ToNot(BeNil())
+				Expect(certResults.CertImage.Repositories[0].Registry).Should(Equal(defaultRegistryAlias))
 				Expect(certResults.TestResults).ToNot(BeNil())
 			})
 		})


### PR DESCRIPTION
- Fixes: #650 
- It seems some of the backend processes use `project` level data and some use `image` level data, and the tools they use do not normalize this information, so we need to normalize it beforehand.
- I probably should have listened to @komish when I normalized the `project` level data, but in my testing everything worked fine and I was worried we break something. 🤷🏻 

 
Signed-off-by: Adam D. Cornett <adc@redhat.com>