### PR TITLE
Normalize error handling

### DIFF
--- a/certification/artifacts/artifacts.go
+++ b/certification/artifacts/artifacts.go
@@ -18,7 +18,7 @@ func WriteFile(filename, contents string) (string, error) {
 
 	err := os.WriteFile(fullFilePath, []byte(contents), 0o644)
 	if err != nil {
-		return fullFilePath, err
+		return fullFilePath, fmt.Errorf("could not write file to artifacts diretory: %v", err)
 	}
 	return fullFilePath, nil
 }
@@ -27,8 +27,7 @@ func createArtifactsDir(artifactsDir string) (string, error) {
 	if !strings.HasPrefix(artifactsDir, "/") {
 		currentDir, err := os.Getwd()
 		if err != nil {
-			log.Error(fmt.Errorf("unable to get current directory: %w", err))
-			return "", err
+			return "", fmt.Errorf("unable to get current directory: %w", err)
 		}
 
 		artifactsDir = filepath.Join(currentDir, artifactsDir)
@@ -36,8 +35,7 @@ func createArtifactsDir(artifactsDir string) (string, error) {
 
 	err := os.MkdirAll(artifactsDir, 0o777)
 	if err != nil {
-		log.Error(fmt.Errorf("unable to create artifactsDir: %w", err))
-		return "", err
+		return "", fmt.Errorf("unable to create artifactsDir: %w", err)
 	}
 	return artifactsDir, nil
 }
@@ -47,8 +45,9 @@ func Path() string {
 	artifactDir := viper.GetString("artifacts")
 	artifactDir, err := createArtifactsDir(artifactDir)
 	if err != nil {
-		log.Fatal(fmt.Errorf("could not retrieve artifact path: %w", err))
-		// Fatal does an os.Exit
+		// Fatal does an os.Exit. If we can't create the artifacts directory,
+		// we can't continue.
+		log.Fatal(fmt.Errorf("could not retrieve artifact path: %v", err))
 	}
 	return filepath.Join(artifactDir)
 }

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -31,16 +31,14 @@ type CheckEngine interface {
 func NewForConfig(config runtime.Config) (CheckEngine, error) {
 	if len(config.EnabledChecks) == 0 {
 		// refuse to run if the user has not specified any checks
-		return nil, ErrNoChecksEnabled
+		return nil, fmt.Errorf("no checks have been enabled")
 	}
 
 	checks := make([]certification.Check, 0, len(config.EnabledChecks))
 	for _, checkString := range config.EnabledChecks {
 		check := queryChecks(checkString)
 		if check == nil {
-			err := fmt.Errorf("%w: %s",
-				ErrRequestedCheckNotFound,
-				checkString)
+			err := fmt.Errorf("requested check not found: %s", checkString)
 			return nil, err
 		}
 

--- a/certification/engine/errors.go
+++ b/certification/engine/errors.go
@@ -1,8 +1,0 @@
-package engine
-
-import "errors"
-
-var (
-	ErrNoChecksEnabled        = errors.New("no checks have been enabled")
-	ErrRequestedCheckNotFound = errors.New("requested check not found")
-)

--- a/certification/formatters/errors.go
+++ b/certification/formatters/errors.go
@@ -1,9 +1,0 @@
-package formatters
-
-import "errors"
-
-var (
-	ErrRequestedFormatterNotFound = errors.New("requested formatter is not known")
-	ErrFormatterNameNotProvided   = errors.New("formatter name is required")
-	ErrFormattingResults          = errors.New("error formatting results")
-)

--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -32,9 +32,8 @@ func NewForConfig(cfg runtime.Config) (ResponseFormatter, error) {
 	formatter, defined := availableFormatters[cfg.ResponseFormat]
 	if !defined {
 		return nil, fmt.Errorf(
-			"failed to create a new formatter from config \"%s\": %w",
+			"failed to create a new formatter from config: %s",
 			cfg.ResponseFormat,
-			ErrRequestedFormatterNotFound,
 		)
 	}
 
@@ -45,8 +44,7 @@ func NewForConfig(cfg runtime.Config) (ResponseFormatter, error) {
 func New(name, extension string, fn FormatterFunc) (ResponseFormatter, error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf(
-			"failed to create a new generic formatter: %w",
-			ErrFormatterNameNotProvided,
+			"failed to create a new generic formatter: formatter name is required",
 		)
 	}
 

--- a/certification/formatters/formatters_test.go
+++ b/certification/formatters/formatters_test.go
@@ -39,8 +39,7 @@ var _ = Describe("Formatters", func() {
 
 	Describe("When creating a new generic formatter", func() {
 		Context("with improper arguments", func() {
-			expectedResult := []byte(fmt.Errorf("failed to create a new generic formatter: %w",
-				ErrFormatterNameNotProvided).Error())
+			expectedResult := []byte(fmt.Errorf("failed to create a new generic formatter: formatter name is required").Error())
 			var fn FormatterFunc = func(context.Context, runtime.Results) ([]byte, error) {
 				return expectedResult, nil
 			}

--- a/certification/formatters/generic.go
+++ b/certification/formatters/generic.go
@@ -20,8 +20,7 @@ func genericJSONFormatter(ctx context.Context, r runtime.Results) ([]byte, error
 
 	responseJSON, err := jsonMarshalIndent(response, "", "    ")
 	if err != nil {
-		e := fmt.Errorf("%w with formatter %s: %s",
-			ErrFormattingResults,
+		e := fmt.Errorf("error formatting results with formatter %s: %w",
 			"json",
 			err,
 		)
@@ -36,16 +35,15 @@ func genericJSONFormatter(ctx context.Context, r runtime.Results) ([]byte, error
 func genericXMLFormatter(ctx context.Context, r runtime.Results) ([]byte, error) {
 	response := getResponse(r)
 
-	responseJSON, err := xmlMarshalIndent(response, "", "    ")
+	responseXML, err := xmlMarshalIndent(response, "", "    ")
 	if err != nil {
-		e := fmt.Errorf("%w with formatter %s: %s",
-			ErrFormattingResults,
-			"json",
+		e := fmt.Errorf("error formatting results with formatter %s: %w",
+			"xml",
 			err,
 		)
 
 		return nil, e
 	}
 
-	return responseJSON, nil
+	return responseXML, nil
 }

--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -95,8 +95,7 @@ func junitXMLFormatter(ctx context.Context, r runtime.Results) ([]byte, error) {
 
 	bytes, err := xml.MarshalIndent(suites, "", "\t")
 	if err != nil {
-		o := fmt.Errorf("%w with formatter %s: %s",
-			ErrFormattingResults,
+		o := fmt.Errorf("error formatting results with formatter %s: %v",
 			"junitxml",
 			err,
 		)


### PR DESCRIPTION
Fix the error handling in three packages:
* artifacts
* external engine
* formatters
    
Just going alphabetical through the packages and normalizing error
handling, and removing errors.go from packages when and where
appropriate.
    
Signed-off-by: Brad P. Crochet <brad@redhat.com>