### PR TITLE
Update container certification doc url #648

### DIFF
--- a/certification/internal/policy/container/defaults.go
+++ b/certification/internal/policy/container/defaults.go
@@ -7,5 +7,5 @@ import (
 var (
 	checkContainerTimeout time.Duration = 10 * time.Second
 	waitContainer         time.Duration = 2 * time.Second
-	certDocumentationURL                = "https://access.redhat.com/documentation/en-us/red_hat_openshift_certification/4.9/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
+	certDocumentationURL                = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
 )


### PR DESCRIPTION
Let's get this change in since we don't know when the anchors will be available and keep this issue open to track work being done for adding anchors.