### PR TITLE
Produce errors more consistently in operator policy package

### DIFF
--- a/certification/internal/policy/operator/errors.go
+++ b/certification/internal/policy/operator/errors.go
@@ -1,8 +1,0 @@
-package operator
-
-import "errors"
-
-var (
-	ErrK8sAPICallFailed  = errors.New("unable to fetch the requested resource from k8s API server")
-	ErrUnsupportedGoType = errors.New("go type unsupported")
-)

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
@@ -26,13 +27,13 @@ func NewScorecardBasicSpecCheck(operatorSdkEngine *cli.OperatorSdkEngine) *Score
 }
 
 func (p *ScorecardBasicSpecCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
-	log.Debug("Running operator-sdk scorecard check for ", bundleRef.ImageURI)
+	log.Trace("Running operator-sdk scorecard check for ", bundleRef.ImageURI)
 	selector := []string{"test=basic-check-spec-test"}
-	log.Debugf("--selector=%s", selector)
+	log.Tracef("--selector=%s", selector)
 	scorecardReport, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath, selector, scorecardBasicCheckResult)
 	if err != nil {
 		p.fatalError = true
-		return false, err
+		return false, fmt.Errorf("%v", err)
 	}
 
 	return p.validate(ctx, scorecardReport.Items)

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardBasicCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
@@ -26,13 +27,13 @@ func NewScorecardOlmSuiteCheck(operatorSdkEngine *cli.OperatorSdkEngine) *Scorec
 }
 
 func (p *ScorecardOlmSuiteCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
-	log.Debug("Running operator-sdk scorecard Check for ", bundleRef.ImageURI)
+	log.Trace("Running operator-sdk scorecard Check for ", bundleRef.ImageURI)
 	selector := []string{"suite=olm"}
-	log.Debugf("--selector=%s", selector)
+	log.Tracef("--selector=%s", selector)
 	scorecardReport, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath, selector, scorecardOlmSuiteResult)
 	if err != nil {
 		p.fatalError = true
-		return false, err
+		return false, fmt.Errorf("%v", err)
 	}
 
 	return p.validate(ctx, scorecardReport.Items)

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardOlmSuiteCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/certification/internal/policy/operator/validate_operator_bundle.go
+++ b/certification/internal/policy/operator/validate_operator_bundle.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/bundle"
@@ -26,8 +27,7 @@ const ocpVerV1beta1Unsupported = "4.9"
 func (p ValidateOperatorBundleCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
 	report, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath)
 	if err != nil {
-		log.Error("Error while executing operator-sdk bundle validate: ", err)
-		return false, err
+		return false, fmt.Errorf("error while executing operator-sdk bundle validate: %v", err)
 	}
 
 	return p.validate(ctx, report)


### PR DESCRIPTION
* Remove errors.go
* Make sure error types are not leaked from the checks
* Remove extraneous logging

Fixes #662

Signed-off-by: Brad P. Crochet <brad@redhat.com>