### PR TITLE
Enable coverage for main branch

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -59,6 +59,40 @@ jobs:
       imageName: ${{ env.IMAGE_NAME }}
       imageVersion: ${{ env.SHA_SHORT }}
 
+  build-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install system deps
+      run: 'sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev'
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Tidy
+      run: make tidy
+
+    - name: Vet
+      run: make vet
+
+    - name: Format
+      run: make fmt
+
+    - name: Test
+      run: make cover
+
+    - name: Convert coverage.out to coverage.lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.9
+    
+    - name: Coveralls
+      uses: coverallsapp/github-action@v1.1.2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage.lcov
+
   build-multiarch:
     needs: build-main
     uses: ./.github/workflows/build-multiarch.yml


### PR DESCRIPTION
After a PR is merged, we want the main branch to have a coverage run
in order to generate the proper badge.

Signed-off-by: Brad P. Crochet <brad@redhat.com>