### PR TITLE
Fix errors and return values

### DIFF
--- a/certification/internal/openshift/errors.go
+++ b/certification/internal/openshift/errors.go
@@ -1,0 +1,8 @@
+package openshift
+
+import "errors"
+
+var (
+	ErrNotFound      = errors.New("not found")
+	ErrAlreadyExists = errors.New("already exists")
+)

--- a/certification/internal/openshift/openshift.go
+++ b/certification/internal/openshift/openshift.go
@@ -11,6 +11,7 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,33 +47,42 @@ func AddSchemes(scheme *apiruntime.Scheme) error {
 	return nil
 }
 
+// CreateNamespace can return an ErrAlreadyExists
 func (oe *openshiftClient) CreateNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	log.Tracef("Creating namespace: %q", name)
 	nsSpec := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
 	err := oe.Client.Create(ctx, &nsSpec, &crclient.CreateOptions{})
-	if err != nil {
-		log.Error(fmt.Errorf("%w: error while creating Namespace: %s", err, name))
-		return nil, err
+	if k8serr.IsAlreadyExists(err) {
+		return &nsSpec, fmt.Errorf("could not create namespace: %s: %w: %v", name, ErrAlreadyExists, err)
 	}
-	log.Debug("Namespace created: ", name)
+	if err != nil {
+		return nil, fmt.Errorf("could not create namespace: %s: %v", name, err)
+	}
 	return &nsSpec, nil
 }
 
 func (oe *openshiftClient) DeleteNamespace(ctx context.Context, name string) error {
-	log.Debugf("Deleting namespace: %s", name)
+	log.Tracef("Deleting namespace: %q", name)
 	nsSpec := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
-	return oe.Client.Delete(ctx, &nsSpec, &crclient.DeleteOptions{})
+	err := oe.Client.Delete(ctx, &nsSpec, &crclient.DeleteOptions{})
+	if err != nil && !k8serr.IsNotFound(err) {
+		return fmt.Errorf("could not delete namespace: %s: %v", name, err)
+	}
+
+	return nil
 }
 
+// GetNamespace can return am ErrNotFound
 func (oe *openshiftClient) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
-	log.Debugf("fetching namespace %s", name)
+	log.Tracef("fetching namespace %q", name)
 	nsSpec := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -82,15 +92,18 @@ func (oe *openshiftClient) GetNamespace(ctx context.Context, name string) (*core
 	err := oe.Client.Get(ctx, crclient.ObjectKey{
 		Name: name,
 	}, &nsSpec)
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve namespace: %s: %w: %v", name, ErrNotFound, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: could not retrieve namespace: %s", err, name))
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve namespace: %s: %v", name, err)
 	}
 	return &nsSpec, nil
 }
 
+// CreateOperatorGroup can return an ErrAlreadyExists
 func (oe *openshiftClient) CreateOperatorGroup(ctx context.Context, data OperatorGroupData, namespace string) (*operatorv1.OperatorGroup, error) {
-	log.Debugf("Creating OperatorGroup %s in namespace %s", data.Name, namespace)
+	log.Tracef("Creating OperatorGroup %q in namespace %q", data.Name, namespace)
 	operatorGroup := &operatorv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      data.Name,
@@ -101,17 +114,18 @@ func (oe *openshiftClient) CreateOperatorGroup(ctx context.Context, data Operato
 		},
 	}
 	err := oe.Client.Create(ctx, operatorGroup)
+	if k8serr.IsAlreadyExists(err) {
+		return operatorGroup, fmt.Errorf("could not create operatorgroup: %s/%s: %w: %v", namespace, data.Name, ErrAlreadyExists, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while creating OperatorGroup: %s", err, data.Name))
-		return nil, err
+		return nil, fmt.Errorf("could not create operatorgroup: %s/%s: %v", namespace, data.Name, err)
 	}
 
-	log.Debugf("OperatorGroup %s is created successfully in namespace %s", data.Name, namespace)
 	return operatorGroup, nil
 }
 
 func (oe *openshiftClient) DeleteOperatorGroup(ctx context.Context, name string, namespace string) error {
-	log.Debugf("Deleting OperatorGroup %s in namespace %s", name, namespace)
+	log.Tracef("Deleting OperatorGroup %q in namespace %q", name, namespace)
 	operatorGroup := operatorv1.OperatorGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -120,29 +134,32 @@ func (oe *openshiftClient) DeleteOperatorGroup(ctx context.Context, name string,
 	}
 	err := oe.Client.Delete(ctx, &operatorGroup)
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while deleting OperatorGroup: %s in namespace: %s", err, name, namespace))
-		return err
+		return fmt.Errorf("could not delete operatorgroup: %s/%s: %v", namespace, name, err)
 	}
 
-	log.Debugf("OperatorGroup %s is deleted successfully from namespace %s", name, namespace)
 	return nil
 }
 
+// GetOperatorGroup can return an ErrNotFound
 func (oe *openshiftClient) GetOperatorGroup(ctx context.Context, name string, namespace string) (*operatorv1.OperatorGroup, error) {
-	log.Debugf("fetching operatorgroup %s from namespace %s", name, namespace)
+	log.Tracef("fetching operatorgroup %q from namespace %q", name, namespace)
 	operatorGroup := operatorv1.OperatorGroup{}
 	err := oe.Client.Get(ctx, crclient.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, &operatorGroup)
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve operatorgroup: %s/%s: %w: %v", namespace, name, ErrNotFound, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while retrieving OperatorGroup %s in namespace %s", err, name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve operatorgroup: %s/%s: %v", namespace, name, err)
 	}
 	return &operatorGroup, nil
 }
 
+// CreateSecret can return an ErrAlreadyExists
 func (oe openshiftClient) CreateSecret(ctx context.Context, name string, content map[string]string, secretType corev1.SecretType, namespace string) (*corev1.Secret, error) {
+	log.Tracef("Creating secret %q in namespace %q", name, namespace)
 	secret := corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -156,42 +173,52 @@ func (oe openshiftClient) CreateSecret(ctx context.Context, name string, content
 		Type:       secretType,
 	}
 	err := oe.Client.Create(ctx, &secret, &crclient.CreateOptions{})
+	if k8serr.IsAlreadyExists(err) {
+		return &secret, fmt.Errorf("could not create secret: %s/%s: %w: %v", namespace, name, ErrAlreadyExists, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while creating secret: %s in namespace: %s", err, name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not create secret: %s/%s: %v", namespace, name, err)
 	}
 
-	log.Debugf("Secret %s created successfully in namespace %s", name, namespace)
 	return &secret, nil
 }
 
 func (oe openshiftClient) DeleteSecret(ctx context.Context, name string, namespace string) error {
+	log.Tracef("Deleting secret %q from namespace %q", name, namespace)
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 	}
-	log.Debugf("Deleting secret %s from namespace %s", name, namespace)
-	return oe.Client.Delete(ctx, &secret, &crclient.DeleteOptions{})
+	err := oe.Client.Delete(ctx, &secret, &crclient.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("could not delete secret: %s/%s: %v", namespace, name, err)
+	}
+
+	return nil
 }
 
+// GetSecret can return an ErrNotFound
 func (oe openshiftClient) GetSecret(ctx context.Context, name string, namespace string) (*corev1.Secret, error) {
-	log.Debugf("fetching secrets %s from namespace %s", name, namespace)
+	log.Tracef("fetching secret %q from namespace %q", name, namespace)
 	secret := corev1.Secret{}
 	err := oe.Client.Get(ctx, crclient.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, &secret)
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retreive secret %s/%s: %w: %v", namespace, name, ErrNotFound, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while retrieving secret: %s in namespace: %s", err, name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve secret %s/%s: %v", namespace, name, err)
 	}
 	return &secret, nil
 }
 
+// CreateCatalogSource can return an ErrAlreadyExists
 func (oe openshiftClient) CreateCatalogSource(ctx context.Context, data CatalogSourceData, namespace string) (*operatorv1alpha1.CatalogSource, error) {
-	log.Debugf("Creating CatalogSource %s in namespace %s", data.Name, namespace)
+	log.Tracef("Creating CatalogSource %q in namespace %q", data.Name, namespace)
 	catalogSource := &operatorv1alpha1.CatalogSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      data.Name,
@@ -205,16 +232,17 @@ func (oe openshiftClient) CreateCatalogSource(ctx context.Context, data CatalogS
 		},
 	}
 	err := oe.Client.Create(ctx, catalogSource)
-	if err != nil {
-		log.Error(fmt.Errorf("%w: error while creating CatalogSource: %s", err, data.Name))
-		return nil, err
+	if k8serr.IsAlreadyExists(err) {
+		return catalogSource, fmt.Errorf("could not create catalogsource: %s/%s: %w: %v", namespace, data.Name, ErrAlreadyExists, err)
 	}
-	log.Debugf("CatalogSource %s is created successfully in namespace %s", data.Name, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("could not create catalogsource: %s/%s: %v", namespace, data.Name, err)
+	}
 	return catalogSource, nil
 }
 
 func (oe *openshiftClient) DeleteCatalogSource(ctx context.Context, name string, namespace string) error {
-	log.Debugf("Deleting CatalogSource %s in namespace %s", name, namespace)
+	log.Tracef("Deleting CatalogSource %q in namespace %q", name, namespace)
 	catalogSource := operatorv1alpha1.CatalogSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -223,29 +251,31 @@ func (oe *openshiftClient) DeleteCatalogSource(ctx context.Context, name string,
 	}
 	err := oe.Client.Delete(ctx, &catalogSource)
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while deleting CatalogSource: %s in namespace: %s", err, name, namespace))
-		return err
+		return fmt.Errorf("could not delete catalogsource: %s/%s: %v", namespace, name, err)
 	}
-	log.Debugf("CatalogSource %s is deleted successfully from namespace %s", name, namespace)
 	return nil
 }
 
+// GetCatalogSource cat return an ErrNotFound
 func (oe *openshiftClient) GetCatalogSource(ctx context.Context, name string, namespace string) (*operatorv1alpha1.CatalogSource, error) {
-	log.Debug("fetching catalogsource: " + name)
+	log.Tracef("fetching catalogsource: %q", name)
 	catalogSource := &operatorv1alpha1.CatalogSource{}
 	err := oe.Client.Get(ctx, crclient.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, catalogSource)
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve catalogsource: %s/%s: %w: %v", namespace, name, ErrNotFound, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while retieving CatalogSource: %s in namespace: %s", err, name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve catalogsource: %s/%s: %v", namespace, name, err)
 	}
 	return catalogSource, nil
 }
 
+// CreateSubscription can return an ErrAlreadyExists
 func (oe openshiftClient) CreateSubscription(ctx context.Context, data SubscriptionData, namespace string) (*operatorv1alpha1.Subscription, error) {
-	log.Debugf("Creating Subscription %s in namespace %s", data.Name, namespace)
+	log.Tracef("Creating Subscription %q in namespace %q", data.Name, namespace)
 	subscription := &operatorv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      data.Name,
@@ -259,31 +289,34 @@ func (oe openshiftClient) CreateSubscription(ctx context.Context, data Subscript
 		},
 	}
 	err := oe.Client.Create(ctx, subscription)
-	if err != nil {
-		log.Error(fmt.Errorf("%w: error while creating Subscription: %s", err, data.Name))
-		return nil, err
+	if k8serr.IsAlreadyExists(err) {
+		return subscription, fmt.Errorf("could not create subscription: %s/%s: %w: %v", namespace, data.Name, ErrAlreadyExists, err)
 	}
-	log.Debugf("Subscription %s is created successfully in namespace %s", data.Name, namespace)
-
+	if err != nil {
+		return nil, fmt.Errorf("could not create subscription: %s/%s: %v", namespace, data.Name, err)
+	}
 	return subscription, nil
 }
 
+// GetSubscription can return an ErrNotFound
 func (oe *openshiftClient) GetSubscription(ctx context.Context, name string, namespace string) (*operatorv1alpha1.Subscription, error) {
-	log.Debugf("fetching subscription %s from namespace %s ", name, namespace)
+	log.Tracef("fetching subscription %q from namespace %q", name, namespace)
 	subscription := &operatorv1alpha1.Subscription{}
 	err := oe.Client.Get(ctx, crclient.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, subscription)
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve subscription: %s/%s: %w: %v", namespace, name, ErrNotFound, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while retrieving Subscription: %s in namespace: %s", err, name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve subscription: %s/%s: %v", namespace, name, err)
 	}
 	return subscription, nil
 }
 
 func (oe openshiftClient) DeleteSubscription(ctx context.Context, name string, namespace string) error {
-	log.Debugf("Deleting Subscription %s in namespace %s", name, namespace)
+	log.Tracef("Deleting Subscription %q in namespace %q", name, namespace)
 
 	subscription := &operatorv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
@@ -293,30 +326,33 @@ func (oe openshiftClient) DeleteSubscription(ctx context.Context, name string, n
 	}
 	err := oe.Client.Delete(ctx, subscription)
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while deleting Subscription: %s in namespace: %s", err, name, namespace))
-		return err
+		return fmt.Errorf("could not delete subscription: %s/%s: %v", namespace, name, err)
 	}
-	log.Debugf("Subscription %s is deleted successfully from namespace %s", name, namespace)
 	return nil
 }
 
+// GetCSV can return an ErrNotFound
 func (oe *openshiftClient) GetCSV(ctx context.Context, name string, namespace string) (*operatorv1alpha1.ClusterServiceVersion, error) {
-	log.Debugf("fetching csv %s from namespace %s", name, namespace)
+	log.Debugf("fetching csv %q from namespace %q", name, namespace)
 	csv := &operatorv1alpha1.ClusterServiceVersion{}
 	err := oe.Client.Get(ctx, crclient.ObjectKey{
 		Name:      name,
 		Namespace: namespace,
 	}, csv)
-
-	return csv, err
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve csv: %s/%s: %w: %v", namespace, name, ErrNotFound, err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve csv: %s/%s: %v", namespace, name, err)
+	}
+	return csv, nil
 }
 
 func (oe *openshiftClient) GetImages(ctx context.Context) (map[string]struct{}, error) {
 	var pods corev1.PodList
 	err := oe.Client.List(ctx, &pods, &crclient.ListOptions{})
 	if err != nil {
-		log.Error("could not retrieve pod list: ", err)
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve pod list: %v", err)
 	}
 
 	imageList := make(map[string]struct{})
@@ -328,8 +364,7 @@ func (oe *openshiftClient) GetImages(ctx context.Context) (map[string]struct{}, 
 
 	var imageStreamList imagestreamv1.ImageStreamList
 	if err := oe.Client.List(ctx, &imageStreamList, &crclient.ListOptions{}); err != nil {
-		log.Error("could not list image stream: ", err)
-		return nil, err
+		return nil, fmt.Errorf("could not list image streams: %v", err)
 	}
 	for _, imageStream := range imageStreamList.Items {
 		for _, tag := range imageStream.Spec.Tags {
@@ -342,8 +377,9 @@ func (oe *openshiftClient) GetImages(ctx context.Context) (map[string]struct{}, 
 	return imageList, nil
 }
 
+// CreateRoleBinding can return an ErrAlreadyExists
 func (oe *openshiftClient) CreateRoleBinding(ctx context.Context, data RoleBindingData, namespace string) (*rbacv1.RoleBinding, error) {
-	log.Debugf("Creating RoleBinding %s in namespace %s", data.Name, namespace)
+	log.Tracef("Creating RoleBinding %q in namespace %q", data.Name, namespace)
 	subjectsObj := make([]rbacv1.Subject, 0, len(data.Subjects))
 	for _, subject := range data.Subjects {
 		subjectsObj = append(subjectsObj, rbacv1.Subject{
@@ -370,17 +406,20 @@ func (oe *openshiftClient) CreateRoleBinding(ctx context.Context, data RoleBindi
 		RoleRef:  roleObj,
 	}
 	err := oe.Client.Create(ctx, &roleBindingObj, &crclient.CreateOptions{})
+	if k8serr.IsAlreadyExists(err) {
+		return &roleBindingObj, fmt.Errorf("could not create rolebinding: %s/%s: %w: %v", namespace, data.Name, ErrAlreadyExists, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while creating rolebinding: %s in namespace: %s", err, data.Name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not create rolebinding: %s/%s: %v", namespace, data.Name, err)
 	}
 
 	log.Debugf("RoleBinding %s created in namespace %s", data.Name, namespace)
 	return &roleBindingObj, nil
 }
 
+// GetRoleBinding can return an ErrNotFound
 func (oe *openshiftClient) GetRoleBinding(ctx context.Context, name string, namespace string) (*rbacv1.RoleBinding, error) {
-	log.Debugf("fetching RoleBinding %s from namespace %s: ", name, namespace)
+	log.Tracef("fetching RoleBinding %q from namespace %q", name, namespace)
 	roleBinding := rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RoleBinding",
@@ -395,15 +434,17 @@ func (oe *openshiftClient) GetRoleBinding(ctx context.Context, name string, name
 		Name:      name,
 		Namespace: namespace,
 	}, &roleBinding)
+	if k8serr.IsNotFound(err) {
+		return nil, fmt.Errorf("could not retrieve rolebinding: %s/%s: %w: %v", namespace, name, ErrNotFound, err)
+	}
 	if err != nil {
-		log.Error(fmt.Errorf("%w: error while retrieving rolebinding: %s in namespace: %s", err, name, namespace))
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve rolebinding: %s/%s: %v", namespace, name, err)
 	}
 	return &roleBinding, nil
 }
 
 func (oe *openshiftClient) DeleteRoleBinding(ctx context.Context, name string, namespace string) error {
-	log.Debugf("Deleting RoleBinding %s in namespace %s", name, namespace)
+	log.Tracef("Deleting RoleBinding %q in namespace %q", name, namespace)
 
 	roleBinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -412,9 +453,7 @@ func (oe *openshiftClient) DeleteRoleBinding(ctx context.Context, name string, n
 		},
 	}
 	if err := oe.Client.Delete(ctx, &roleBinding, &crclient.DeleteOptions{}); err != nil {
-		log.Error(fmt.Errorf("%w: error while deleting RoleBiding: %s in namespace: %s", err, name, namespace))
-		return err
+		return fmt.Errorf("could not delete rolebinding: %s/%s: %v", namespace, name, err)
 	}
-	log.Debugf("RoleBinding %s is deleted successfully from namespace %s", name, namespace)
 	return nil
 }

--- a/certification/internal/openshift/openshift_version.go
+++ b/certification/internal/openshift/openshift_version.go
@@ -18,18 +18,15 @@ func GetOpenshiftClusterVersion() (runtime.OpenshiftClusterVersion, error) {
 	}
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
-		log.Error("unable to load the config, check if KUBECONFIG is set correctly: ", err)
-		return runtime.UnknownOpenshiftClusterVersion(), err
+		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("unable to load the config, check if KUBECONFIG is set correctly: %v", err)
 	}
 	configV1Client, err := configv1Client.NewForConfig(kubeConfig)
 	if err != nil {
-		log.Error("unable to create a client with the provided kubeconfig: ", err)
-		return runtime.UnknownOpenshiftClusterVersion(), err
+		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("unable to create a client with the provided kubeconfig: %v", err)
 	}
 	openshiftApiServer, err := configV1Client.ClusterOperators().Get(context.Background(), "openshift-apiserver", metav1.GetOptions{})
 	if err != nil {
-		log.Error("unable to get openshift-apiserver cluster operator: ", err)
-		return runtime.UnknownOpenshiftClusterVersion(), err
+		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("unable to get openshift-apiserver cluster operator: %v", err)
 	}
 
 	log.Debug(fmt.Sprintf("fetching operator version and openshift-apiserver version %s from %s", openshiftApiServer.Status.Versions, kubeConfig.Host))


### PR DESCRIPTION
* Create ErrAlreadyExists and ErrNotFound as part of the API
* Hide the k8s errors behind these to keep from exposing the
  implementation details

Fixes #659 

Signed-off-by: Brad P. Crochet <brad@redhat.com>