### PR TITLE
Encapsulate authn errors

### DIFF
--- a/certification/internal/authn/keychain.go
+++ b/certification/internal/authn/keychain.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/docker/cli/cli/config"
@@ -21,6 +22,7 @@ var PreflightKeychain craneauthn.Keychain = &preflightKeychain{}
 //
 // If the viper config is empty, assume Anonymous.
 // If the file cannot be found or read, that constitues an error.
+// Can return os.IsNotExist.
 func (k *preflightKeychain) Resolve(target craneauthn.Resource) (craneauthn.Authenticator, error) {
 	log.Trace("entering preflight keychain Resolve")
 
@@ -32,18 +34,15 @@ func (k *preflightKeychain) Resolve(target craneauthn.Resource) (craneauthn.Auth
 
 	r, err := os.Open(configFile)
 	if os.IsNotExist(err) {
-		log.Errorf("could not find authfile: %s", configFile)
-		return nil, err
+		return nil, fmt.Errorf("could not find authfile: %s: %w", configFile, err)
 	}
 	if err != nil {
-		log.Errorf("Could not open authfile: %s", configFile)
-		return nil, err
+		return nil, fmt.Errorf("could not open authfile: %s: %v", configFile, err)
 	}
 	defer r.Close()
 	cf, err := config.LoadFromReader(r)
 	if err != nil {
-		log.Errorf("Could not load authfile: %s", configFile)
-		return nil, err
+		return nil, fmt.Errorf("could not load authfile from reader: %v", err)
 	}
 
 	var cfg, empty types.AuthConfig
@@ -57,7 +56,7 @@ func (k *preflightKeychain) Resolve(target craneauthn.Resource) (craneauthn.Auth
 
 		cfg, err = cf.GetAuthConfig(key)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not get auth config: %v", err)
 		}
 		if cfg != empty {
 			break


### PR DESCRIPTION
* Only allow os.ErrNotExist to be returned without change
* Wrap all other errors to sanitize them from unwrapping themselves

Fixes #656

Signed-off-by: Brad P. Crochet <brad@redhat.com>