### PR TITLE
Pass a noop logger to crane fake registry

### DIFF
--- a/certification/internal/engine/engine_test.go
+++ b/certification/internal/engine/engine_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -22,7 +24,8 @@ var _ = Describe("Execute Checks tests", func() {
 	var engine CraneEngine
 	BeforeEach(func() {
 		// Set up a fake registry.
-		s := httptest.NewServer(registry.New())
+		registryLogger := log.New(io.Discard, "", log.Ldate)
+		s := httptest.NewServer(registry.New(registry.Logger(registryLogger)))
 		DeferCleanup(func() {
 			s.Close()
 		})

--- a/certification/internal/policy/container/has_unique_tag_test.go
+++ b/certification/internal/policy/container/has_unique_tag_test.go
@@ -3,6 +3,8 @@ package container
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"net/http/httptest"
 	"net/url"
 
@@ -20,7 +22,8 @@ var _ = Describe("UniqueTag", func() {
 
 	BeforeEach(func() {
 		// Set up a fake registry.
-		s := httptest.NewServer(registry.New())
+		registryLogger := log.New(io.Discard, "", log.Ldate)
+		s := httptest.NewServer(registry.New(registry.Logger(registryLogger)))
 		DeferCleanup(func() {
 			s.Close()
 		})

--- a/certification/runtime/assets_test.go
+++ b/certification/runtime/assets_test.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"net/http/httptest"
 	"net/url"
 
@@ -20,7 +22,8 @@ var _ = Describe("Runtime assets tests", func() {
 	var digest v1.Hash
 	BeforeEach(func() {
 		// Set up a fake registry.
-		s := httptest.NewServer(registry.New())
+		registryLogger := log.New(io.Discard, "", log.Ldate)
+		s := httptest.NewServer(registry.New(registry.Logger(registryLogger)))
 		DeferCleanup(func() {
 			s.Close()
 		})


### PR DESCRIPTION
The fake registry we set up for testing was a bit verbose in its
logging. This passes a no-op logger to cut down on verbosity.

Signed-off-by: Brad P. Crochet <brad@redhat.com>