### PR TITLE
Enforce a single point of configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ config.yaml
 results.json
 cert-image.json
 rpm-manifest.json
+results-junit.xml
 
 # Testing dirs
 /artifacts

--- a/certification/artifacts/artifacts.go
+++ b/certification/artifacts/artifacts.go
@@ -1,3 +1,7 @@
+// Package artifacts provides functionality for writing artifact files in configured
+// artifacts directory. This package operators with a singleton directory variable that can be
+// changed and reset. It provides simple functionality that can be accessible from
+// any calling library.
 package artifacts
 
 import (
@@ -7,8 +11,29 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
+
+// ads is the artifacts directory singleton.
+var ads string
+
+// DefaultArtifactsDir is the default value for the directory.
+const DefaultArtifactsDir = "artifacts"
+
+func init() {
+	// set the singleton to the default value.
+	ads = DefaultArtifactsDir
+}
+
+// SetDir sets the package level artifacts directory. This
+// can be a relative path or a full path.
+func SetDir(s string) {
+	ads = s
+}
+
+// Reset restores the default value for the Artifacts Directory.
+func Reset() {
+	ads = DefaultArtifactsDir
+}
 
 // WriteFile will write contents of the string to a file in
 // the artifacts directory.
@@ -23,6 +48,8 @@ func WriteFile(filename, contents string) (string, error) {
 	return fullFilePath, nil
 }
 
+// createArtifactsDir creates the artifacts directory at path artifactsDir.
+// If the path is not a full path, this will resolve the full path.
 func createArtifactsDir(artifactsDir string) (string, error) {
 	if !strings.HasPrefix(artifactsDir, "/") {
 		currentDir, err := os.Getwd()
@@ -40,9 +67,9 @@ func createArtifactsDir(artifactsDir string) (string, error) {
 	return artifactsDir, nil
 }
 
-// Path will return the artifacts path from viper config
+// Path will return the artifacts directory.
 func Path() string {
-	artifactDir := viper.GetString("artifacts")
+	artifactDir := ads
 	artifactDir, err := createArtifactsDir(artifactDir)
 	if err != nil {
 		// Fatal does an os.Exit. If we can't create the artifacts directory,

--- a/certification/artifacts/artifacts_test.go
+++ b/certification/artifacts/artifacts_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
 )
 
 var _ = Describe("Artifacts package utility functions", func() {
@@ -14,8 +13,8 @@ var _ = Describe("Artifacts package utility functions", func() {
 		// in each of these tests. This removes only the artifacts
 		// directory value, not the temporary dir established in
 		// BeforeSuite.
-		err := os.RemoveAll(viper.GetString("artifacts"))
-		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.RemoveAll(ads)).To(Succeed())
 	})
 
 	Context("With an artifacts directory provided via configuration", func() {

--- a/certification/artifacts/suite_test.go
+++ b/certification/artifacts/suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
 )
 
 func TestArtifacts(t *testing.T) {
@@ -25,9 +24,8 @@ var _ = BeforeSuite(func() {
 	Expect(len(artifactsPkgTestBaseDir)).ToNot(BeZero())
 	artifactsDir := path.Join(artifactsPkgTestBaseDir, "artifacts")
 
-	// Set the artifacts dir in viper. This won't have been created
-	// prior to running tests.
-	viper.Set("artifacts", artifactsDir)
+	// Configure artifacts directory.
+	SetDir(artifactsDir)
 })
 
 var _ = AfterSuite(func() {

--- a/certification/config.go
+++ b/certification/config.go
@@ -1,0 +1,45 @@
+package certification
+
+import "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
+
+// Config is a read-only preflight configuration.
+type Config interface {
+	commonConfig
+	containerConfig
+	operatorConfig
+}
+
+// commonConfig contains configurables common
+// to all certification.
+type commonConfig interface {
+	Image() string
+	Policy() policy.Policy
+	ResponseFormat() string
+	LogFile() string
+	Artifacts() string
+	WriteJUnit() bool
+	DockerConfig() string
+}
+
+// containerConfig are configurables relevant to
+// container certification.
+type containerConfig interface {
+	IsScratch() bool
+	CertificationProjectID() string
+	PyxisHost() string
+	PyxisAPIToken() string
+	Submit() bool
+}
+
+// operatorConfig are configurables relevant to
+// operator certification.
+type operatorConfig interface {
+	IsBundle() bool
+	Namespace() string
+	ServiceAccount() string
+	ScorecardImage() string
+	ScorecardWaitTime() string
+	Channel() string
+	Kubeconfig() string
+	IndexImage() string
+}

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -1,83 +1,69 @@
 package engine
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	containerpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/container"
-	operatorpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/operator"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 )
 
-var _ = Describe("TestPolicyEngine", func() {
-	var (
-		hasNoProhibitedCheck   certification.Check = &containerpol.HasNoProhibitedPackagesCheck{}
-		validateOperatorBundle certification.Check = &operatorpol.ValidateOperatorBundleCheck{}
-	)
-
-	Describe("Querying all policies", func() {
-		Context("When it is a container policy", func() {
-			It("should return the check", func() {
-				check := queryChecks(hasNoProhibitedCheck.Name())
-				Expect(check.Name()).To(Equal(hasNoProhibitedCheck.Name()))
-			})
-		})
-		Context("When it is an operator policy", func() {
-			It("should return the check", func() {
-				check := queryChecks(validateOperatorBundle.Name())
-				Expect(check.Name()).To(Equal(validateOperatorBundle.Name()))
-			})
-		})
-		Context("When it is an invalid check name", func() {
-			It("should return nil", func() {
-				check := queryChecks("abc")
-				Expect(check).To(BeNil())
-			})
-		})
-	})
-})
-
 var _ = Describe("Engine Creation", func() {
 	Describe("When getting a new engine for a configuration", func() {
-		Context("with a valid configuration", func() {
-			cfg := runtime.Config{
-				Image:          "dummy/image",
-				EnabledChecks:  ContainerPolicy(),
-				ResponseFormat: "json",
-			}
+		Context("with a valid configurations", func() {
+			Context("for the container policy", func() {
+				cfg := runtime.Config{
+					Image:          "dummy/image",
+					Policy:         policy.PolicyContainer,
+					ResponseFormat: "json",
+				}
 
-			It("should return an engine and no error", func() {
-				engine, err := NewForConfig(cfg)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(engine).ToNot(BeNil())
+				It("should return an engine and no error", func() {
+					engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(engine).ToNot(BeNil())
+				})
 			})
-		})
-
-		Context("with a configuration that has no checks", func() {
-			cfg := runtime.Config{
-				Image:          "dummy/image",
-				EnabledChecks:  []string{},
-				ResponseFormat: "json",
-			}
-
-			It("should return an error indicating no checks were provided", func() {
-				engine, err := NewForConfig(cfg)
-				Expect(err).To(HaveOccurred())
-				Expect(engine).To(BeNil())
+			Context("for the operator policy", func() {
+				cfg := runtime.Config{
+					Image:          "dummy/image",
+					Policy:         policy.PolicyOperator,
+					ResponseFormat: "json",
+				}
+				It("should return an engine and no error", func() {
+					engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(engine).ToNot(BeNil())
+				})
 			})
-		})
 
-		Context("with a configuration that has an unknown check", func() {
-			cfg := runtime.Config{
-				Image:          "dummy/image",
-				EnabledChecks:  []string{"UnknownCheck"},
-				ResponseFormat: "json",
-			}
+			Context("for the scratch policy", func() {
+				cfg := runtime.Config{
+					Image:          "dummy/image",
+					Policy:         policy.PolicyScratch,
+					ResponseFormat: "json",
+				}
 
-			It("should return an error indicating no checks were provided", func() {
-				engine, err := NewForConfig(cfg)
-				Expect(err).To(HaveOccurred())
-				Expect(engine).To(BeNil())
+				It("should return an engine and no error", func() {
+					engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(engine).ToNot(BeNil())
+				})
+			})
+
+			Context("for the Root policy", func() {
+				cfg := runtime.Config{
+					Image:          "dummy/image",
+					Policy:         policy.PolicyRoot,
+					ResponseFormat: "json",
+				}
+
+				It("should return an engine and no error", func() {
+					engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(engine).ToNot(BeNil())
+				})
 			})
 		})
 	})

--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 )
 
@@ -28,12 +29,12 @@ type FormatterFunc = func(context.Context, runtime.Results) (response []byte, fo
 
 // NewForConfig returns a new formatter based on the user-provided configuration. It relies
 // on config values which should align with known/supported/built-in formatters.
-func NewForConfig(cfg runtime.Config) (ResponseFormatter, error) {
-	formatter, defined := availableFormatters[cfg.ResponseFormat]
+func NewForConfig(cfg certification.Config) (ResponseFormatter, error) {
+	formatter, defined := availableFormatters[cfg.ResponseFormat()]
 	if !defined {
 		return nil, fmt.Errorf(
 			"failed to create a new formatter from config: %s",
-			cfg.ResponseFormat,
+			cfg.ResponseFormat(),
 		)
 	}
 

--- a/certification/formatters/formatters_test.go
+++ b/certification/formatters/formatters_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Formatters", func() {
 			}
 
 			It("should return a formatter and no error", func() {
-				formatter, err := NewForConfig(cfg)
+				formatter, err := NewForConfig(cfg.ReadOnly())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(formatter).ToNot(BeNil())
 			})
@@ -29,7 +29,7 @@ var _ = Describe("Formatters", func() {
 			}
 
 			It("should return an error", func() {
-				formatter, err := NewForConfig(cfg)
+				formatter, err := NewForConfig(cfg.ReadOnly())
 
 				Expect(err).To(HaveOccurred())
 				Expect(formatter).To(BeNil())

--- a/certification/internal/policy/container/has_unique_tag_test.go
+++ b/certification/internal/policy/container/has_unique_tag_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var _ = Describe("UniqueTag", func() {
-	var hasUniqueTagCheck hasUniqueTagCheck = *NewHasUniqueTagCheck()
+	var hasUniqueTagCheck hasUniqueTagCheck = *NewHasUniqueTagCheck("")
 	var src, dst, host string
 
 	BeforeEach(func() {

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -13,12 +13,6 @@ const (
 	// channelKeyInBundle is the channel in annotations.yaml that contains the channel name.
 	channelKeyInBundle = "operators.operatorframework.io.bundle.channel.default.v1"
 
-	// IndexImageKey is the key in viper that contains the index (catalog) image URI
-	indexImageKey = "indexImage"
-
-	// channelKey is the key in viper that indicates the operator channel under test
-	channelKey = "channel"
-
 	// apiEndpoint is the endpoint used to query for package uniqueness.
 	apiEndpoint = "https://catalog.redhat.com/api/containers/v1/operators/packages"
 

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -11,7 +11,6 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,9 +23,6 @@ func TestOperator(t *testing.T) {
 func init() {
 	log.SetFormatter(&log.TextFormatter{})
 	log.SetLevel(log.TraceLevel)
-
-	viper.SetEnvPrefix("pflt")
-	viper.AutomaticEnv()
 }
 
 type FakeOperatorSdkEngine struct {

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -19,10 +19,16 @@ type ScorecardBasicSpecCheck struct {
 
 const scorecardBasicCheckResult string = "operator_bundle_scorecard_BasicSpecCheck.json"
 
-func NewScorecardBasicSpecCheck(operatorSdkEngine *cli.OperatorSdkEngine) *ScorecardBasicSpecCheck {
+func NewScorecardBasicSpecCheck(operatorSdkEngine *cli.OperatorSdkEngine, ns, sa, kubeconfig, waittime string) *ScorecardBasicSpecCheck {
 	return &ScorecardBasicSpecCheck{
-		scorecardCheck{OperatorSdkEngine: *operatorSdkEngine},
-		false,
+		scorecardCheck: scorecardCheck{
+			OperatorSdkEngine: *operatorSdkEngine,
+			namespace:         ns,
+			serviceAccount:    sa,
+			kubeconfig:        kubeconfig,
+			waitTime:          waittime,
+		},
+		fatalError: false,
 	}
 }
 

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		fakeEngine = FakeOperatorSdkEngine{
 			OperatorSdkReport: report,
 		}
-		scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
+		scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine, "myns", "mysa", "", "20")
 	})
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {
@@ -84,7 +84,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				engine := fakeEngine.(FakeOperatorSdkEngine)
 				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
 				fakeEngine = engine
-				scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
+				scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine, "myns", "mysa", "", "20")
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardBasicCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
@@ -96,7 +96,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Checking that OperatorSdkEngine errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdkEngine{}
-			scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine)
+			scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine, "myns", "mysa", "", "20")
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {

--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -3,16 +3,19 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type scorecardCheck struct {
 	OperatorSdkEngine cli.OperatorSdkEngine
+
+	namespace      string
+	serviceAccount string
+	kubeconfig     string
+	waitTime       string
 }
 
 func (p *scorecardCheck) validate(ctx context.Context, items []cli.OperatorSdkScorecardItem) (bool, error) {
@@ -34,20 +37,15 @@ func (p *scorecardCheck) validate(ctx context.Context, items []cli.OperatorSdkSc
 }
 
 func (p *scorecardCheck) getDataToValidate(ctx context.Context, bundleImage string, selector []string, resultFile string) (*cli.OperatorSdkScorecardReport, error) {
-	namespace := viper.GetString("namespace")
-	serviceAccount := viper.GetString("serviceaccount")
-	waitTime := viper.GetString("scorecard_wait_time")
-	kubeconfig := os.Getenv("KUBECONFIG")
-
 	opts := cli.OperatorSdkScorecardOptions{
 		OutputFormat:   "json",
 		Selector:       selector,
 		ResultFile:     resultFile,
-		Kubeconfig:     kubeconfig,
-		Namespace:      namespace,
-		ServiceAccount: serviceAccount,
+		Kubeconfig:     p.kubeconfig,
+		Namespace:      p.namespace,
+		ServiceAccount: p.serviceAccount,
 		Verbose:        true,
-		WaitTime:       fmt.Sprintf("%ss", waitTime),
+		WaitTime:       fmt.Sprintf("%ss", p.waitTime),
 	}
 	result, err := p.OperatorSdkEngine.Scorecard(bundleImage, opts)
 	if err != nil {

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -19,10 +19,16 @@ type ScorecardOlmSuiteCheck struct {
 
 const scorecardOlmSuiteResult string = "operator_bundle_scorecard_OlmSuiteCheck.json"
 
-func NewScorecardOlmSuiteCheck(operatorSdkEngine *cli.OperatorSdkEngine) *ScorecardOlmSuiteCheck {
+func NewScorecardOlmSuiteCheck(operatorSdkEngine *cli.OperatorSdkEngine, ns, sa, kubeconfig, waittime string) *ScorecardOlmSuiteCheck {
 	return &ScorecardOlmSuiteCheck{
-		scorecardCheck{OperatorSdkEngine: *operatorSdkEngine},
-		false,
+		scorecardCheck: scorecardCheck{
+			OperatorSdkEngine: *operatorSdkEngine,
+			namespace:         ns,
+			serviceAccount:    sa,
+			kubeconfig:        kubeconfig,
+			waitTime:          waittime,
+		},
+		fatalError: false,
 	}
 }
 

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		fakeEngine = FakeOperatorSdkEngine{
 			OperatorSdkReport: report,
 		}
-		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
+		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine, "myns", "mysa", "", "20")
 	})
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {
@@ -84,7 +84,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				engine := fakeEngine.(FakeOperatorSdkEngine)
 				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
 				fakeEngine = engine
-				scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
+				scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine, "myns", "mysa", "", "20")
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardOlmSuiteCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
@@ -96,7 +96,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Checking that OperatorSdkEngine errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdkEngine{}
-			scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine)
+			scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(&fakeEngine, "myns", "mysa", "", "20")
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {

--- a/certification/policy/policy.go
+++ b/certification/policy/policy.go
@@ -1,0 +1,10 @@
+package policy
+
+type Policy = string
+
+const (
+	PolicyOperator  Policy = "operator"
+	PolicyContainer Policy = "container"
+	PolicyScratch   Policy = "scratch"
+	PolicyRoot      Policy = "root"
+)

--- a/certification/pyxis/pyxis_suite_test.go
+++ b/certification/pyxis/pyxis_suite_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 func TestPyxis(t *testing.T) {
@@ -22,8 +21,6 @@ func TestPyxis(t *testing.T) {
 func init() {
 	log.SetFormatter(&log.TextFormatter{})
 	log.SetLevel(log.TraceLevel)
-	viper.SetEnvPrefix("pflt")
-	viper.AutomaticEnv()
 }
 
 type localRoundTripper struct {

--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/authn"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // images maps the images use by preflight with their purpose.
@@ -25,7 +24,7 @@ var images = map[string]string{
 func imageList(ctx context.Context) []string {
 	options := []crane.Option{
 		crane.WithContext(ctx),
-		crane.WithAuthFromKeychain(authn.PreflightKeychain),
+		crane.WithAuthFromKeychain(authn.PreflightKeychain()),
 	}
 
 	imageList := make([]string, 0, len(images))
@@ -52,12 +51,12 @@ func Assets(ctx context.Context) AssetData {
 }
 
 // ScorecardImage returns the container image used for OperatorSDK
-// Scorecard based checks.
-func ScorecardImage() string {
-	scorecardImage := viper.GetString("scorecard_image")
-	if scorecardImage != "" {
-		log.Debugf("Using %s as the scorecard test image", scorecardImage)
-		return scorecardImage
+// Scorecard based checks. If userProvidedScorecardImage is set, it is
+// returned, otherwise, the default is returned.
+func ScorecardImage(userProvidedScorecardImage string) string {
+	if userProvidedScorecardImage != "" {
+		log.Debugf("Using %s as the scorecard test image", userProvidedScorecardImage)
+		return userProvidedScorecardImage
 	}
 	return images["scorecard"]
 }

--- a/certification/runtime/assets_test.go
+++ b/certification/runtime/assets_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
 )
 
 var _ = Describe("Runtime assets tests", func() {
@@ -63,14 +62,13 @@ var _ = Describe("Scorecard Image tests", func() {
 	Context("when getting the Scorecard image", func() {
 		Context("the default is used", func() {
 			It("should return the default", func() {
-				image := ScorecardImage()
+				image := ScorecardImage("")
 				Expect(image).To(Equal(images["scorecard"]))
 			})
 		})
 		Context("the image is overriden", func() {
 			It("should return the passed param", func() {
-				viper.Set("scorecard_image", "quay.io/some/container:v1.0.0")
-				image := ScorecardImage()
+				image := ScorecardImage("quay.io/some/container:v1.0.0")
 				Expect(image).To(Equal("quay.io/some/container:v1.0.0"))
 			})
 		})

--- a/certification/runtime/config.go
+++ b/certification/runtime/config.go
@@ -1,0 +1,84 @@
+package runtime
+
+import (
+	"os"
+	"strings"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
+	"github.com/spf13/viper"
+)
+
+// Config contains configuration details for running preflight.
+type Config struct {
+	Image          string
+	Policy         policy.Policy
+	ResponseFormat string
+	Bundle         bool
+	Scratch        bool
+	LogFile        string
+	Artifacts      string
+	WriteJUnit     bool
+	// Container-Specific Fields
+	CertificationProjectID string
+	PyxisHost              string
+	PyxisAPIToken          string
+	DockerConfig           string
+	Submit                 bool
+	// Operator-Specific Fields
+	Namespace         string
+	ServiceAccount    string
+	ScorecardImage    string
+	ScorecardWaitTime string
+	Channel           string
+	IndexImage        string
+	Kubeconfig        string
+}
+
+// ReadOnly returns an uneditably configuration.
+func (c *Config) ReadOnly() *ReadOnlyConfig {
+	return &ReadOnlyConfig{
+		cfg: *c,
+	}
+}
+
+// NewConfigFrom will return a runtime.Config based on the stored inputs in
+// the provided viper.Viper. Note that shared configuration should be set
+// in this function, and not in policy-specific functions. Defaults, should
+// also be set after this function has been called.
+func NewConfigFrom(vcfg viper.Viper) (*Config, error) {
+	cfg := Config{}
+	cfg.LogFile = vcfg.GetString("logfile")
+	cfg.DockerConfig = vcfg.GetString("dockerConfig")
+	cfg.Artifacts = vcfg.GetString("artifacts")
+	cfg.WriteJUnit = viper.GetBool("junit")
+	cfg.storeContainerPolicyConfiguration(vcfg)
+	cfg.storeOperatorPolicyConfiguration(vcfg)
+	return &cfg, nil
+}
+
+// storeContainerPolicyConfiguration reads container-policy-specific config
+// items in viper, normalizes them, and stores them in Config.
+func (c *Config) storeContainerPolicyConfiguration(vcfg viper.Viper) {
+	c.PyxisAPIToken = vcfg.GetString("pyxis_api_token")
+	c.Submit = vcfg.GetBool("submit")
+	c.PyxisHost = pyxisHostLookup(vcfg.GetString("pyxis_env"), vcfg.GetString("pyxis_host"))
+
+	// Strip the ospid- prefix from the project ID if provided.
+	certificationProjectID := vcfg.GetString("certification_project_id")
+	if strings.HasPrefix(certificationProjectID, "ospid-") {
+		certificationProjectID = strings.Split(certificationProjectID, "-")[1]
+	}
+	c.CertificationProjectID = certificationProjectID
+}
+
+// storeOperatorPolicyConfiguration reads operator-policy-specific config
+// items in viper, normalizes them, and stores them in Config.
+func (c *Config) storeOperatorPolicyConfiguration(vcfg viper.Viper) {
+	c.Kubeconfig = os.Getenv("KUBECONFIG")
+	c.Namespace = viper.GetString("namespace")
+	c.ServiceAccount = viper.GetString("serviceaccount")
+	c.ScorecardImage = viper.GetString("scorecard_image")
+	c.ScorecardWaitTime = viper.GetString("scorecard_wait_time")
+	c.Channel = viper.GetString("channel")
+	c.IndexImage = viper.GetString("indeximage")
+}

--- a/certification/runtime/config_read.go
+++ b/certification/runtime/config_read.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
+)
+
+// ensure ReadOnlyConfig always implements certification.Configurable
+var _ certification.Config = &ReadOnlyConfig{}
+
+// ReadOnlyConfig is a Config that cannot be modified. It implements
+// certification.Configurable.
+type ReadOnlyConfig struct {
+	cfg Config
+}
+
+func (ro *ReadOnlyConfig) Image() string {
+	return ro.cfg.Image
+}
+
+func (ro *ReadOnlyConfig) Policy() policy.Policy {
+	return ro.cfg.Policy
+}
+
+func (ro *ReadOnlyConfig) ResponseFormat() string {
+	return ro.cfg.ResponseFormat
+}
+
+func (ro *ReadOnlyConfig) IsBundle() bool {
+	return ro.cfg.Bundle
+}
+
+func (ro *ReadOnlyConfig) IsScratch() bool {
+	return ro.cfg.Scratch
+}
+
+func (ro *ReadOnlyConfig) LogFile() string {
+	return ro.cfg.LogFile
+}
+
+func (ro *ReadOnlyConfig) CertificationProjectID() string {
+	return ro.cfg.CertificationProjectID
+}
+
+func (ro *ReadOnlyConfig) PyxisHost() string {
+	return ro.cfg.PyxisHost
+}
+
+func (ro *ReadOnlyConfig) PyxisAPIToken() string {
+	return ro.cfg.PyxisAPIToken
+}
+
+func (ro *ReadOnlyConfig) DockerConfig() string {
+	return ro.cfg.DockerConfig
+}
+
+func (ro *ReadOnlyConfig) Submit() bool {
+	return ro.cfg.Submit
+}
+
+func (ro *ReadOnlyConfig) Namespace() string {
+	return ro.cfg.Namespace
+}
+
+func (ro *ReadOnlyConfig) ServiceAccount() string {
+	return ro.cfg.ServiceAccount
+}
+
+func (ro *ReadOnlyConfig) ScorecardImage() string {
+	return ro.cfg.ScorecardImage
+}
+
+func (ro *ReadOnlyConfig) ScorecardWaitTime() string {
+	return ro.cfg.ScorecardWaitTime
+}
+
+func (ro *ReadOnlyConfig) Channel() string {
+	return ro.cfg.Channel
+}
+
+func (ro *ReadOnlyConfig) Artifacts() string {
+	return ro.cfg.Artifacts
+}
+
+func (ro *ReadOnlyConfig) WriteJUnit() bool {
+	return ro.cfg.WriteJUnit
+}
+
+func (ro *ReadOnlyConfig) Kubeconfig() string {
+	return ro.cfg.Kubeconfig
+}
+
+func (ro *ReadOnlyConfig) IndexImage() string {
+	return ro.cfg.IndexImage
+}

--- a/certification/runtime/config_read_test.go
+++ b/certification/runtime/config_read_test.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Runtime ReadOnlyConfig test", func() {
+	Context("When calling ReadOnly on a config", func() {
+		c := &Config{
+			Image:                  "image",
+			Policy:                 "policy",
+			ResponseFormat:         "format",
+			Bundle:                 true,
+			Scratch:                true,
+			LogFile:                "logfile",
+			Artifacts:              "artifacts",
+			WriteJUnit:             true,
+			CertificationProjectID: "certprojid",
+			PyxisHost:              "pyxishost",
+			PyxisAPIToken:          "pyxisapitoken",
+			DockerConfig:           "dockercfg",
+			Submit:                 true,
+			Namespace:              "ns",
+			ServiceAccount:         "sa",
+			ScorecardImage:         "scorecardimg",
+			ScorecardWaitTime:      "waittime",
+			Channel:                "channel",
+			IndexImage:             "indeximg",
+			Kubeconfig:             "kubeconfig",
+		}
+		cro := c.ReadOnly()
+		It("should return values assigned to corresponding struct fields", func() {
+			Expect(cro.Image()).To(Equal("image"))
+			Expect(cro.Policy()).To(Equal("policy"))
+			Expect(cro.ResponseFormat()).To(Equal("format"))
+			Expect(cro.IsBundle()).To(Equal(true))
+			Expect(cro.IsScratch()).To(Equal(true))
+			Expect(cro.LogFile()).To(Equal("logfile"))
+			Expect(cro.Artifacts()).To(Equal("artifacts"))
+			Expect(cro.WriteJUnit()).To(Equal(true))
+			Expect(cro.CertificationProjectID()).To(Equal("certprojid"))
+			Expect(cro.PyxisHost()).To(Equal("pyxishost"))
+			Expect(cro.PyxisAPIToken()).To(Equal("pyxisapitoken"))
+			Expect(cro.DockerConfig()).To(Equal("dockercfg"))
+			Expect(cro.Submit()).To(Equal(true))
+			Expect(cro.Namespace()).To(Equal("ns"))
+			Expect(cro.ServiceAccount()).To(Equal("sa"))
+			Expect(cro.ScorecardImage()).To(Equal("scorecardimg"))
+			Expect(cro.ScorecardWaitTime()).To(Equal("waittime"))
+			Expect(cro.Channel()).To(Equal("channel"))
+			Expect(cro.IndexImage()).To(Equal("indeximg"))
+			Expect(cro.Kubeconfig()).To(Equal("kubeconfig"))
+		})
+	})
+})

--- a/certification/runtime/pyxis.go
+++ b/certification/runtime/pyxis.go
@@ -1,0 +1,19 @@
+package runtime
+
+func pyxisHostLookup(pyxisEnv, hostOverride string) string {
+	envs := map[string]string{
+		"prod":  "catalog.redhat.com/api/containers",
+		"uat":   "catalog.uat.redhat.com/api/containers",
+		"qa":    "catalog.qa.redhat.com/api/containers",
+		"stage": "catalog.stage.redhat.com/api/containers",
+	}
+	if hostOverride != "" {
+		return hostOverride
+	}
+
+	pyxisHost, ok := envs[pyxisEnv]
+	if !ok {
+		pyxisHost = envs["prod"]
+	}
+	return pyxisHost
+}

--- a/certification/runtime/results.go
+++ b/certification/runtime/results.go
@@ -1,0 +1,22 @@
+package runtime
+
+import (
+	"time"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+)
+
+type Result struct {
+	certification.Check
+	ElapsedTime time.Duration
+}
+
+type Results struct {
+	TestedImage       string
+	PassedOverall     bool
+	TestedOn          OpenshiftClusterVersion
+	CertificationHash string
+	Passed            []Result
+	Failed            []Result
+	Errors            []Result
+}

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -2,36 +2,6 @@
 // runtime.
 package runtime
 
-import (
-	"time"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-)
-
-type Config struct {
-	Image          string
-	EnabledChecks  []string
-	ResponseFormat string
-	Mounted        bool
-	Bundle         bool
-	Scratch        bool
-}
-
-type Result struct {
-	certification.Check
-	ElapsedTime time.Duration
-}
-
-type Results struct {
-	TestedImage       string
-	PassedOverall     bool
-	TestedOn          OpenshiftClusterVersion
-	CertificationHash string
-	Passed            []Result
-	Failed            []Result
-	Errors            []Result
-}
-
 type OpenshiftClusterVersion struct {
 	Name    string
 	Version string

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -33,15 +33,12 @@ func init() {
 	rootCmd.AddCommand(checkCmd)
 }
 
+// writeJUnit will write results as JUnit XML using the built-in formatter.
 func writeJUnit(ctx context.Context, results runtime.Results) error {
-	if !viper.GetBool("junit") {
-		return nil
-	}
-
 	var cfg runtime.Config
 	cfg.ResponseFormat = "junitxml"
 
-	junitformatter, err := formatters.NewForConfig(cfg)
+	junitformatter, err := formatters.NewForConfig(cfg.ReadOnly())
 	if err != nil {
 		return err
 	}
@@ -57,6 +54,10 @@ func writeJUnit(ctx context.Context, results runtime.Results) error {
 	log.Tracef("JUnitXML written to %s", junitFilename)
 
 	return nil
+}
+
+func resultsFilenameWithExtension(ext string) string {
+	return strings.Join([]string{"results", ext}, ".")
 }
 
 func buildConnectURL(projectID string) string {
@@ -83,8 +84,4 @@ func convertPassedOverall(passedOverall bool) string {
 	}
 
 	return "FAILED"
-}
-
-func resultsFilenameWithExtension(ext string) string {
-	return strings.Join([]string{"results", ext}, ".")
 }

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -4,7 +4,6 @@ var (
 	DefaultOutputFormat      = "json"
 	DefaultLogFile           = "preflight.log"
 	DefaultLogLevel          = "info"
-	DefaultArtifactsDir      = "artifacts"
 	DefaultNamespace         = "default"
 	DefaultServiceAccount    = "default"
 	DefaultScorecardWaitTime = "240"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -60,7 +61,7 @@ func initConfig() {
 	// Set up logging config defaults
 	viper.SetDefault("logfile", DefaultLogFile)
 	viper.SetDefault("loglevel", DefaultLogLevel)
-	viper.SetDefault("artifacts", DefaultArtifactsDir)
+	viper.SetDefault("artifacts", artifacts.DefaultArtifactsDir)
 
 	// Set up cluster defaults
 	viper.SetDefault("namespace", DefaultNamespace)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,7 +31,7 @@ var _ = Describe("cmd package utility functions", func() {
 				It("should have defaults set correctly", func() {
 					initConfig()
 					Expect(viper.GetString("namespace")).To(Equal(DefaultNamespace))
-					Expect(viper.GetString("artifacts")).To(Equal(DefaultArtifactsDir))
+					Expect(viper.GetString("artifacts")).To(Equal(artifacts.DefaultArtifactsDir))
 					Expect(viper.GetString("logfile")).To(Equal(DefaultLogFile))
 					Expect(viper.GetString("loglevel")).To(Equal(DefaultLogLevel))
 				})
@@ -43,7 +44,7 @@ var _ = Describe("cmd package utility functions", func() {
 				It("should have overrides in place", func() {
 					initConfig()
 					Expect(viper.GetString("namespace")).To(Equal(DefaultNamespace))
-					Expect(viper.GetString("artifacts")).To(Equal(DefaultArtifactsDir))
+					Expect(viper.GetString("artifacts")).To(Equal(artifacts.DefaultArtifactsDir))
 					Expect(viper.GetString("logfile")).To(Equal("/tmp/foo.log"))
 					Expect(viper.GetString("loglevel")).To(Equal("trace"))
 				})
@@ -60,9 +61,7 @@ var _ = Describe("cmd package utility functions", func() {
 		BeforeEach(func() {
 			cmd = &cobra.Command{
 				PersistentPreRun: preRunConfig,
-				Run: func(cmd *cobra.Command, args []string) {
-					return
-				},
+				Run:              func(cmd *cobra.Command, args []string) {},
 			}
 			cobra.OnInitialize(initConfig)
 		})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 )
 
@@ -23,34 +24,34 @@ var _ = Describe("policy validation", func() {
 
 		Context("with a known-good image", func() {
 			cfg := runtime.Config{
-				Image:         goodImage,
-				EnabledChecks: engine.OperatorPolicy(),
+				Image:  goodImage,
+				Policy: policy.PolicyOperator,
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			e, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
 			Expect(err).ToNot(HaveOccurred())
 
 			ctx := context.TODO()
-			engine.ExecuteChecks(ctx)
-			results := engine.Results(ctx)
+			e.ExecuteChecks(ctx)
+			results := e.Results(ctx)
 
 			It("should pass all checks", func() {
-				Expect(len(results.Passed)).To(Equal(len(cfg.EnabledChecks)))
+				Expect(len(results.Passed)).To(Equal(len(engine.OperatorPolicy())))
 			})
 		})
 
 		Context("with a known-bad image", func() {
 			cfg := runtime.Config{
-				Image:         badImage,
-				EnabledChecks: engine.OperatorPolicy(),
+				Image:  badImage,
+				Policy: policy.PolicyOperator,
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			e, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
 			Expect(err).To(BeNil())
 
 			ctx := context.TODO()
-			engine.ExecuteChecks(ctx)
-			results := engine.Results(ctx)
+			e.ExecuteChecks(ctx)
+			results := e.Results(ctx)
 
 			// TODO: Replace this check so that you test for individual check failures
 			It("should not pass any checks", func() {
@@ -69,19 +70,19 @@ var _ = Describe("policy validation", func() {
 
 		Context("with a known-good image", func() {
 			cfg := runtime.Config{
-				Image:         goodImage,
-				EnabledChecks: engine.ContainerPolicy(),
+				Image:  goodImage,
+				Policy: policy.PolicyContainer,
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			e, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
 			Expect(err).ToNot(HaveOccurred())
 
 			ctx := context.TODO()
-			engine.ExecuteChecks(ctx)
-			results := engine.Results(ctx)
+			e.ExecuteChecks(ctx)
+			results := e.Results(ctx)
 
 			It("should pass all checks", func() {
-				Expect(len(results.Passed)).To(Equal(len(cfg.EnabledChecks)))
+				Expect(len(results.Passed)).To(Equal(len(engine.ContainerPolicy())))
 				Expect(len(results.Errors)).To(BeZero())
 				Expect(len(results.Failed)).To(BeZero())
 			})
@@ -92,16 +93,16 @@ var _ = Describe("policy validation", func() {
 		// check in addition to all other container checks.
 		XContext("with a known-bad image", func() {
 			cfg := runtime.Config{
-				Image:         badImage,
-				EnabledChecks: engine.ContainerPolicy(),
+				Image:  badImage,
+				Policy: policy.PolicyContainer,
 			}
 
-			engine, err := engine.NewForConfig(cfg)
+			e, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
 			Expect(err).ToNot(HaveOccurred())
 
 			ctx := context.TODO()
-			engine.ExecuteChecks(ctx)
-			results := engine.Results(ctx)
+			e.ExecuteChecks(ctx)
+			results := e.Results(ctx)
 
 			// TODO: Replace this check so that you test for individual check failures
 			It("should fail all checks", func() {


### PR DESCRIPTION
Fixes #641 

This PR reconfigures Preflight execution to utilize a single point of configuration, which is then passed through to Engines in a read-only state.

Fill disclosure, I'm still testing behavior here, but given the size, figured it wise to get eyes on things to make sure we're happy with the approaches/changes.

Notable high-level benefits include:

- Lazy initialization of checks at execution time (e.g. in preparation of the engine.)
- Configuration pass through from user all the way down to checks.
- Reduced footprint of the spf13/viper as an import. We heavily leverage it as an integration to our flag parsing, environment variable parsing, etc., but it exists in much less of our code outside of the `cmd` package.
- Inability to change configuration at any point behind the calling of `ExecuteChecks`.
- Removed reliance on environment manipulation in testing (e.g. to establish artifacts dir, set logfiles directories, etc).

This is a large PR. Viper was so deeply rooted in most of our code due to the need to access the user configuration that pulling it out often meant passing in additional data to functions/methods/structs that were previously using viper.

A lot of things changed to make this work. The spirit of most tests was kept intact (if possible) in order to reduce the likelihood that I changed a test enough to not catch an error. Still possible, but that was the goal.

Scrutinize heavily. Here are some details on things that have changed and what motivated those changes:

---

**New: `certification.Config` interface:**

This interface definition defines all the methods necessary to execute Preflight. Previously, we relied on `runtime.Configuration{}` for a similar purpose. `runtime.Config{}` now will fulfill the `certification.Config` interface when calling its `runtime.Config{}.ReadOnly()` method.

In theory, I could have just bound these methods to `runtime.Config{}`, because accepting the `certification.Config{}` interface would make access read-only in a sense, but I ran into issues with Method name and struct field collision, so it just seemed easier to roll it into its own type. 

Organizationally, this is placed in the `certification` package because I wasn't sure if there was a better place. I think, ideally, that we would have defined `runtime.Config` to be this interface, and had our implementation maybe live in the `cmd` package, but I'm not sure we want to move that around currently. 

Many functions that previously accepted `runtime.Config{}` now accept the `certification.Config` interface instead.

**Derived `runtime.Config` from viper**
To avoid fully removing Viper, which wires up our environment variables, binds with our flags, etc., I've derived our `runtime.Config` from the viper configuration using by function `runtime.NewConfigFrom(...)`.

**Removal of global check variables in favor of lazy initialization**

We previously had our checks defined globally within the `engine` package as variables. This limited our ability to configure them at runtime, leading to the use of `viper.Get<Type>(...)` to configure them within their own executions. This has been removed. Checks are now initialized within an `initializeChecks` function that accepts a `certification.Config`. This config can then inform how the checks are configured and returned to the engine for execution.

**Removal of `EnabledChecks` from runtime.Config**
In a prior use case, we had the ability to dynamically change the checks that were executed based on user configuration. We disabled part of this feature in https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/26 in favor of ensuring that users get the appropriate checks for what they're trying to certify. We had some leftover configuration from these days that are now removed, such as `runtime.Config.EnabledChecks`.

We now have a Policy type that maps to our existing policies, which we provide to our check initialization logic in our configuration.

Logic associated with asserting that the EnabledChecks in the configuration _matches_ what we know to have has been removed as unnecessary.

**Refactor the `artifacts` package into a Singleton**

The `artifacts` package was previously used to facilitate writing artifacts by not requiring the caller to know about the artifacts configuration. It did this by effectively calling viper to get the value for the `"artifacts"` key, which generally pointed to the artifacts director (either by default, or by user configuration). This package has been reconfigured to allow the same functionality by using a package-level variable.

Note that it is the responsibility of the caller to configure the new artifacts directory if the user has requested such by way of a new function `SetDir`. A `Reset` function has also been provided to return this back to default configuration (in my mind, to facilitate testing).

**Extraction of Operator and Container check logic into functions**

New functions `checkOperator` and `checkContainer` have been created, now containing the logic that previously existed within each respective cobra command's `RunE` field.

Note that these still work with concrete `runtime.Config` because they _must_ set the appropriate policy (and potentially other fields) before they execute. They pass along `certification.Config`s to the appropriate downstream methods.

This should pave the way to extracting this logic for library use in a future PR. I didn't include it here because... well, this is already massive. And also, we may want to evalute breaking them into separate, logical components as well. Story for another day.

**Authn Keychain refactor into a singleton**
The `authn` package which contains our implementation of the `craneauthn.Keychain` and related types has been refactored into a singleton as well. This is because it previously made a call out to viper to grab `dockerconfig` in its `Resolve()` chain. It's design to be initialized once, and then it doesn't have to be initialized again further downstream. That said, it totally can be.

At a high level, we were previously able to just call authn.PreflightKeychain which was a variable containing our keychain, and the `Resolve` logic read the viper configuration for a docker config.

This must now be initialized (as is being done in engine calls that set it up) with the `WithDockerConfig` option containing the dockerconfig provided by the user. The option pattern was used here because it allows downstream calls (e.g. calls after it has been initially configured) to call `PreflightKeychain()` completely without parameters. With that said, if downstream calls are passed the same parameter for dockerconfig as is in the certification.Config, subsequent calls shouldn't change anything.

**Internal crane engine has access to certification.Config**
Which means that we can technically _remove_ some fields of the internal crane engine, such as `Image`. That said, I left that for a future PR, as I want to make sure this works before we start ripping things out. That felt like a small self-encompassed change that could be whipped up and added later.

**OperatorSDK engine(s) no longer require viper**
We _heavily_ used viper in OperatorSDK based checks (think scorecard, deployablyByOLM). This is no longer the case. OperatorSDK initializes (e.g. NewOperatorSdkEngine) now accept the parameters they need when initialized. These have a lot of changes, and most of them are related to viper removal and replacement with config values.

**New `Policy` package**
Simply contains policy definitions in a common place that can be imported by many different packages without introducing cyclical import errors.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>