### PR TITLE
Fix a panic in DeployableByOLM

### DIFF
--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -391,7 +391,7 @@ func csvStatusSucceeded(ctx context.Context, client openshift.Client, name, name
 		return "", false, err
 	}
 	// if the CSV phase is succeeded, stop the querying
-	if csv.Status.Phase == operatorv1alpha1.CSVPhaseSucceeded {
+	if csv != nil && csv.Status.Phase == operatorv1alpha1.CSVPhaseSucceeded {
 		log.Debugf("CSV %s is created successfully in namespace %s", name, namespace)
 		return name, true, nil
 	}


### PR DESCRIPTION
When the OpenShift client was refactored, a subtle timing bug was
introduced. The openshift.GetCsv function was now returning a nil
for the CSV when not found. The csvStatusSucceeded function was
then checking for a value in the CSV, but not checking whether it
was nil or not. If it happened to be called before the CSV was at
least partially established, it would panic. This should take care
of that.

Signed-off-by: Brad P. Crochet <brad@redhat.com>