### PR TITLE
Add e2e variant that modifies common environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,13 @@ results.json
 cert-image.json
 rpm-manifest.json
 results-junit.xml
+# E2E customzied env log file.
+sgol.txt
 
 # Testing dirs
 /artifacts
+# E2E customized env artifacts dir
+stcafitra/
 
 # But we don't want to ignore the artifacts package
 !/certification/artifacts

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ vet:
 test-e2e:
 	./test/e2e/operator-test.sh
 
+.PHONY: test-e2e-customized-env
+test-e2e-customized-env:
+	./test/e2e/operator-test-customized-env.sh
+
 .PHONY: clean
 clean:
 	@go clean

--- a/test/e2e/operator-test-customized-env.sh
+++ b/test/e2e/operator-test-customized-env.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -e
+
+DEFAULT_PREFLIGHT_BIN="preflight"
+DEFAULT_OPERATOR_BUNDLE="quay.io/opdev/simple-demo-operator-bundle:latest"
+DEFAULT_OPERATOR_INDEXIMAGE="quay.io/opdev/simple-demo-operator-catalog:latest"
+
+PREFLIGHT_BIN=${PREFLIGHT_BIN:-"$DEFAULT_PREFLIGHT_BIN"}
+OPERATOR_BUNDLE=${OPERATOR_BUNDLE:-"$DEFAULT_OPERATOR_BUNDLE"}
+OPERATOR_INDEXIMAGE=${OPERATOR_INDEXIMAGE:-"$DEFAULT_OPERATOR_INDEXIMAGE"}
+
+# This test sets preflight's environment variables to ensure that
+# expectations as to what they mean are consistent.
+customized_sa="customsa" \
+customized_ns="customns" \
+customized_logfile="sgol.txt" \
+customized_artifacts="stcafitra" \
+results_file="./${customized_artifacts}/results.json"
+
+
+ USAGE=" 
+ Usage: 
+   $(basename "$0")
+
+   This script will run the preflight binary against an operator test. To be used in e2e testing.
+   
+   Environment variables required by preflight that are not otherwise reflected here are still
+   required (e.g. KUBECONFIG), and must be set in the environment prior to running this script.
+  
+ Environment variables: 
+   PREFLIGHT_BIN:           Specify the path to the compiled preflight binary.
+                            If this is not provided, this script will execute the
+                            preflight binary relative to the current working directory.
+                            Default: "./$DEFAULT_PREFLIGHT_BIN"
+   OPERATOR_BUNDLE:         Specify the registry path of the operator bundle under test.
+                            Default: $DEFAULT_OPERATOR_BUNDLE
+   OPERATOR_INDEXIMAGE      Specify the index image containing the operator bundle under
+                            test.
+                            Default: $DEFAULT_OPERATOR_INDEXIMAGE
+ "
+
+# This script doesn't take positional arguments. If the user provided one,
+# assume they are asking for help and print the usage statement.
+ if [ $# -ne 0 ]; then 
+     echo "$USAGE" 
+     exit 1 
+ fi 
+
+# Emit the runtime values for this script stdout.
+echo "Preflight binary value: $PREFLIGHT_BIN"
+echo "Operator bundle being tested: $OPERATOR_BUNDLE"
+echo "Operator index for test: $OPERATOR_INDEXIMAGE"
+
+echo "Creating custom namespace and service account for tests"
+kubebin=$(which oc 2>/dev/null || which kubectl 2>/dev/null)
+if [ "$kubebin" == "" ]; then
+    echo "ERR could not find kubectl or oc which is required for this test."
+    exit 5
+fi
+
+cleanupCluster() {
+    echo "running cleanup."
+    "$kubebin" delete ns --force customns || true
+}
+
+"$kubebin" create ns customns \
+    || { echo "ERR unable to create custom namespace for this test" &&  exit 6 ;}
+"$kubebin" create serviceaccount --namespace customns customsa \
+    || { echo "ERR unable to create custom namespace for this test" && cleanupCluster && exit 6 ;}
+
+# Run preflight with customized env.
+echo "Running preflight"
+echo -e "========================"
+PFLT_LOGLEVEL=trace \
+PFLT_INDEXIMAGE="${OPERATOR_INDEXIMAGE}" \
+PFLT_SERVICEACCOUNT="$customized_sa" \
+PFLT_NAMESPACE="$customized_ns" \
+PFLT_LOGFILE="$customized_logfile" \
+PFLT_ARTIFACTS="$customized_artifacts" \
+    "./${PREFLIGHT_BIN}" check operator "${OPERATOR_BUNDLE}"
+
+echo -e "\n========================"
+
+# Check to make sure that the customized artifacts directory exists
+test -d "$customized_artifacts" \
+    || { echo "ERR the customized artifacts directory wasn't created." \
+        && cleanupCluster \
+        && exit 7 ;}
+
+# Check to make sure that the logfile we customized via environment exists
+test -f "$customized_logfile" \
+    || { echo "ERR the customized results file wasn't created in the customized artifacts directry." \
+        && cleanupCluster \
+        && exit 7 ;}
+
+# Before we check the error count, make sure that it still
+# exists at the expected path in the results.json
+errors=$(jq -r .results.errors < $results_file)
+if [ "$errors" == "null" ]; then
+    echo "ERR results file did not contain errors at the expected location (.results.errors)."
+    echo "It's impossible to determine if the tests all passed for this asset."
+    
+    exit 2
+fi
+
+# Check the error count to make sure it's zero.
+errorcount=$(jq -r '.results.errors | length'  < $results_file)
+if [ "$errorcount" -ne "0" ]; then
+    echo "ERR preflight tests threw an error for this asset."
+    echo "This asset should pass all checks."
+    cleanupCluster
+    exit 3
+fi
+
+# Before we check the failure count, make sure that it still
+# exists at the expected path in the results.json
+failures=$(jq -r .results.failed < $results_file)
+if [ "$failures" == "null" ]; then
+    echo "ERR results file did not contain failures at the expected location (.results.failed)."
+    echo "It's impossible to determine if the tests all passed for this asset."
+    cleanupCluster
+    exit 4
+fi
+
+# Check the failure count to make sure it's zero.
+failurecount=$(jq -r '.results.failed | length'  < $results_file)
+if [ "$failurecount" -ne "0" ]; then
+    echo "ERR preflight tests threw an error for this asset."
+    echo "This asset should pass all checks."
+    cleanupCluster
+    exit 3
+fi
+
+echo "Everything appears to have passed!"


### PR DESCRIPTION
Part of #646 

The pipeline is using environment variables to configure preflight. No flags.

To a certain extent, we have a degree of testing ensuring that the environment variables (that make it to viper) end up in our runtime configs. What they do, however, could probably use more coverage.

Ideal case would be to run the pipeline's tekton task, but that requires an entire cluster + tekton installed. For the moment, I've added a variant of our existing e2e script that modifies things using the environment. Those that can be tested somewhat reliably have been added to this script.

I'm considering either running this in lieu of our current e2e (which requires changing some of our e2e tests in openshift/release), or running it as a second task. As of right now, it does not run in our e2e pipeline.

I was able to get this to pass using the default operator listed in the script.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>