### PR TITLE
Add FindImagesByDigest to the pyxis client

### DIFF
--- a/certification/pyxis/pyxis_suite_test.go
+++ b/certification/pyxis/pyxis_suite_test.go
@@ -41,11 +41,13 @@ func mustWrite(w io.Writer, s string) {
 }
 
 type (
-	pyxisProjectHandler      struct{}
-	pyxisImageHandler        struct{}
-	pyxisRPMManifestHandler  struct{}
-	pyxisTestResultsHandler  struct{}
-	pyxisGraphqlLayerHandler struct{}
+	pyxisProjectHandler           struct{}
+	pyxisImageHandler             struct{}
+	pyxisRPMManifestHandler       struct{}
+	pyxisTestResultsHandler       struct{}
+	pyxisGraphqlLayerHandler      struct{}
+	pyxisGraphqlFindImagesHandler struct{}
+	errorHandler                  struct{}
 )
 
 // For each of these ServeHTTP methods, there is a main switch statement that controls what response will
@@ -150,7 +152,7 @@ func (p *pyxisTestResultsHandler) ServeHTTP(response http.ResponseWriter, reques
 }
 
 func (p *pyxisGraphqlLayerHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	log.Trace("In the graphql ServeHTTP")
+	log.Trace("In the graphql Layers ServeHTTP")
 	response.Header().Set("Content-Type", "application/json")
 	if request.Body != nil {
 		defer request.Body.Close()
@@ -178,6 +180,23 @@ func (p *pyxisGraphqlLayerHandler) ServeHTTP(response http.ResponseWriter, reque
 		}
 	}`)
 	return
+}
+
+func (p *pyxisGraphqlFindImagesHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	log.Trace("In the graphql FindImages ServeHTTP")
+	response.Header().Set("Content-Type", "application/json")
+	if request.Body != nil {
+		defer request.Body.Close()
+	}
+	mustWrite(response, `{"data":{"find_images":{"error":null,"total":1,"page":0,"data":[{"_id":"deadb33f","certified":true}]}}}`)
+}
+
+func (p *errorHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	response.Header().Set("Content-Type", "application/json")
+	if request.Body != nil {
+		defer request.Body.Close()
+	}
+	response.WriteHeader(http.StatusBadGateway)
 }
 
 // In order to test some negative paths, this io.Reader will just throw an error

--- a/certification/pyxis/pyxis_test.go
+++ b/certification/pyxis/pyxis_test.go
@@ -1,0 +1,41 @@
+package pyxis
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pyxis", func() {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.Handle("/query/", &pyxisGraphqlFindImagesHandler{})
+	pyxisClient := NewPyxisClient("my.pyxis.host/query/", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
+
+	Context("Find Images", func() {
+		Context("and one image is passed", func() {
+			It("should return one image", func() {
+				certImages, err := pyxisClient.FindImagesByDigest(ctx, []string{"sha256:deadb33f"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(certImages).ToNot(BeNil())
+				Expect(certImages).ToNot(BeZero())
+				Expect(certImages[0].Certified).To(BeTrue())
+			})
+		})
+		Context("and an error occurs", func() {
+			It("should return nil and an error", func() {
+				errorMux := http.NewServeMux()
+				errorMux.Handle("/query/", &errorHandler{})
+				pyxisClient.Client = &http.Client{Transport: localRoundTripper{handler: errorMux}}
+				certImages, err := pyxisClient.FindImagesByDigest(ctx, []string{"sha256:dontmatter"})
+				Expect(err).To(HaveOccurred())
+				Expect(certImages).To(BeNil())
+			})
+			AfterEach(func() {
+				pyxisClient.Client = &http.Client{Transport: localRoundTripper{handler: mux}}
+			})
+		})
+	})
+})


### PR DESCRIPTION
* Add a method to the Pyxis client that accepts a slice of digests,
  and returns a slice of CertImages.
* So far, it only fills in the ID and Certified fields of the image.

This will be used in the upcoming CsvImagesCertified check.

Signed-off-by: Brad P. Crochet <brad@redhat.com>