### PR TITLE
Add capability to extract images from a bundle

### DIFF
--- a/certification/internal/bundle/bundle_test.go
+++ b/certification/internal/bundle/bundle_test.go
@@ -1,10 +1,10 @@
 package bundle
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,6 +23,21 @@ var _ = Describe("BundleValidateCheck", func() {
   operators.operatorframework.io.bundle.package.v1: testPackage
   operators.operatorframework.io.bundle.channel.default.v1: testChannel
 `
+		csvContents = `spec:
+  install:
+    spec:
+      deployments:
+      - spec:
+          template:
+            spec:
+              containers:
+              - image: registry.example.io/foo/bar@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176
+
+  relatedImages:
+  - name: the-operator
+    image: registry.example.io/foo/bar@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176
+  - name: the-proxy
+    image: registry.example.io/foo/proxy@sha256:5e33f9d095952866b9743cc8268fb740cce6d93439f00ce333a2de1e5974837e`
 	)
 
 	Describe("Bundle validation", func() {
@@ -106,6 +121,30 @@ var _ = Describe("BundleValidateCheck", func() {
 				err := os.WriteFile(filepath.Join(manifestsPath, clusterServiceVersionFilename), []byte(""), 0o644)
 				Expect(err).ToNot(HaveOccurred())
 			})
+			Context("the CSV contains images", func() {
+				It("should get the images", func() {
+					r := strings.NewReader(csvContents)
+					images, err := ExtractImagesFromBundle(context.TODO(), r)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(images).To(HaveLen(2))
+					Expect(images).To(ContainElement("registry.example.io/foo/bar@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176"))
+				})
+			})
+			Context("the CSV is malformed", func() {
+				It("should error", func() {
+					r := strings.NewReader("badcsv::bad")
+					images, err := ExtractImagesFromBundle(context.TODO(), r)
+					Expect(err).To(HaveOccurred())
+					Expect(images).To(BeNil())
+				})
+			})
+			Context("the CSV could not be read", func() {
+				It("should error", func() {
+					images, err := ExtractImagesFromBundle(context.TODO(), errReader(0))
+					Expect(err).To(HaveOccurred())
+					Expect(images).To(BeNil())
+				})
+			})
 			Context("the CSV exists by itself", func() {
 				It("should return the filename", func() {
 					filename, err := GetCsvFilePathFromBundle(imageRef.ImageFSPath)
@@ -159,7 +198,7 @@ var _ = Describe("BundleValidateCheck", func() {
 
 		Context("CSV is valid", func() {
 			It("should return a map of 3", func() {
-				installModes, err := GetSupportedInstallModes(context.Background(), bytes.NewBufferString(csv))
+				installModes, err := GetSupportedInstallModes(context.Background(), strings.NewReader(csv))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(installModes).ToNot(BeNil())
 				Expect(len(installModes)).To(Equal(3))
@@ -180,7 +219,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				csv = `invalid`
 			})
 			It("should error", func() {
-				installModes, err := GetSupportedInstallModes(context.Background(), bytes.NewBufferString(csv))
+				installModes, err := GetSupportedInstallModes(context.Background(), strings.NewReader(csv))
 				Expect(err).To(HaveOccurred())
 				Expect(installModes).To(BeNil())
 			})

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,11 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.10.1
-	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	sigs.k8s.io/controller-runtime v0.12.0
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -93,6 +93,7 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.24.0 // indirect
 	k8s.io/client-go v0.24.0 // indirect
@@ -102,7 +103,6 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1 => github.com/opdev/go-rpmdb v0.0.0-20220329221310-ca9c80a97804


### PR DESCRIPTION
* ExtractImagesFromBundle will pull all of the images out of a
  bundle dir in the ClusterServiceVersion. It reads both the
  container section and the relatedImages section.
* It dedupes the slice along the way.

Signed-off-by: Brad P. Crochet <brad@redhat.com>