### PR TITLE
updating check container to only read the docker file from disk if present

### DIFF
--- a/cmd/check_container_test.go
+++ b/cmd/check_container_test.go
@@ -156,6 +156,20 @@ var _ = Describe("Check Container Command", func() {
 			})
 		})
 
+		Context("and no docker config command argument was provided", func() {
+			BeforeEach(func() {
+				fakePC.setSRFuncSubmitSuccessfully("", "")
+			})
+			It("should not throw an error", func() {
+				sbmt.dockerConfig = ""
+				err := os.Remove(dockerConfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = sbmt.Submit(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
 		Context("and the cert image cannot be read from disk", func() {
 			It("should throw an error", func() {
 				err := os.Remove(path.Join(artifactsDir, certification.DefaultCertImageFilename))


### PR DESCRIPTION
- Fixes: #685 
- updating to only read the docker file from dish if the user passes in a value
- updating to not set pyxis docker config json if a user did not pass the value, for the case where a docker config is already on the project
- adding in a warning if a user does not provide a docker config file for a github repo 
   - I'm on the fence about if we want to do this or not, it almost seems that Clair should create tokens for our backend systems for dockerhub

Signed-off-by: Adam D. Cornett <adc@redhat.com>