### PR TITLE
add list-checks and remove --list-checks

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -20,8 +20,6 @@ var checkCmd = &cobra.Command{
 }
 
 func init() {
-	checkCmd.PersistentFlags().BoolP("list-checks", "l", false, "lists all the checks run for a given check")
-
 	checkCmd.PersistentFlags().StringP("docker-config", "d", "", "Path to docker config.json file. This value is optional for publicly accessible images.\n"+
 		"However, it is strongly encouraged for public Docker Hub images,\n"+
 		"due to the rate limit imposed for unauthenticated requests. (env: PFLT_DOCKERCONFIG)")

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -31,14 +30,6 @@ var checkContainerCmd = &cobra.Command{
 	Short: "Run checks for a container",
 	Long:  `This command will run the Certification checks for a container image. `,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if l, _ := cmd.Flags().GetBool("list-checks"); l {
-			fmt.Printf("\n%s\n%s%s\n", "The checks that will be executed are the following:", "- ",
-				strings.Join(engine.ContainerPolicy(), "\n- "))
-
-			// exiting gracefully instead of retuning, otherwise cobra calls RunE
-			os.Exit(0)
-		}
-
 		if len(args) != 1 {
 			return fmt.Errorf("a container image positional argument is required")
 		}

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
@@ -24,14 +23,6 @@ var checkOperatorCmd = &cobra.Command{
 	Short: "Run checks for an Operator",
 	Long:  `This command will run the Certification checks for an Operator bundle image. `,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if l, _ := cmd.Flags().GetBool("list-checks"); l {
-			fmt.Printf("\n%s\n%s%s\n", "The checks that will be executed are the following:", "- ",
-				strings.Join(engine.OperatorPolicy(), "\n- "))
-
-			// exiting gracefully instead of retuning, otherwise cobra calls RunE
-			os.Exit(0)
-		}
-
 		if len(args) != 1 {
 			return fmt.Errorf("an operator image positional argument is required")
 		}

--- a/cmd/list_checks.go
+++ b/cmd/list_checks.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+	"github.com/spf13/cobra"
+)
+
+var listChecksCmd = &cobra.Command{
+	Use:   "list-checks",
+	Short: "List all checks that will be executed for each policy",
+	Long:  "This command will list all checks that preflight uses against an asset by policy type",
+	Run:   listChecksRunFunc,
+}
+
+// listChecksRunFunc binds printChecks to cobra's Run function
+// definition, passing the cobra command's output as an io.Writer.
+func listChecksRunFunc(cmd *cobra.Command, args []string) {
+	printChecks(cmd.OutOrStdout())
+}
+
+// printChecks writes the formatted check list output to w.
+func printChecks(w io.Writer) {
+	fmt.Fprintln(w, "These are the available checks for each policy:")
+	fmt.Fprintln(w, formattedPolicyBlock("Operator", engine.OperatorPolicy(), "invoked on operator bundles"))
+	fmt.Fprintln(w, formattedPolicyBlock("Container", engine.ContainerPolicy(), "invoked on container images"))
+	fmt.Fprintln(w, formattedPolicyBlock("Container Root Exception", engine.RootExceptionContainerPolicy(),
+		"automatically applied for container images if preflight determines a root exception flag has been added to your Red Hat Connect project"))
+	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch Exception", engine.ScratchContainerPolicy(),
+		"automatically applied for container checks if preflight determines a scratch exception flag has been added to your Red Hat Connect project"))
+}
+
+// formattedPolicyBlock accepts information about the checklist
+// and formats it for output.
+func formattedPolicyBlock(policyName string, checkList []string, desc string) string {
+	title := fmt.Sprintf("[%s Policy]: %s", policyName, desc) // the name in brackets
+	list := formatList(checkList)
+
+	return strings.Join([]string{title, list}, "\n")
+}
+
+// formatList returns list as a hyphen-prefixed, newline delimited string.
+func formatList(list []string) string {
+	var s string
+	for _, v := range list {
+		s += dashPrefix(v) + "\n"
+	}
+
+	return s
+}
+
+// dashPrefix prefixes string s with a hyphen.
+func dashPrefix(s string) string {
+	return fmt.Sprintf("- %s", s)
+}
+
+func init() {
+	rootCmd.AddCommand(listChecksCmd)
+}

--- a/cmd/list_checks_test.go
+++ b/cmd/list_checks_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+)
+
+var _ = Describe("list checks subcommand", func() {
+	Context("When formatting check lists for print", func() {
+		testList := []string{"foo", "bar", "baz"}
+		It("should have the same number of items", func() {
+			res := formatList(testList)
+			resSplit := strings.Split(res, "\n")
+			Expect(len(resSplit)).To(Equal(len(testList) + 1)) // account for newline at the end.
+		})
+	})
+
+	Context("When calling dashPrefix on an input string", func() {
+		inputString := "foo"
+		It("should be prepended with a hyphen and a space", func() {
+			res := dashPrefix(inputString)
+			Expect(strings.HasPrefix(res, "- ")).To(BeTrue())
+		})
+	})
+
+	Context("Preparing a policy block for print", func() {
+		t := "MyTitle"
+		d := "MyDescription"
+		c := []string{"this", "that"}
+		expected := "[MyTitle Policy]: MyDescription\n- this\n- that\n"
+		It("Should return a string in an expected format", func() {
+			res := formattedPolicyBlock(t, c, d)
+			Expect(res).To(Equal(expected))
+		})
+	})
+
+	Context("Printing checks", func() {
+		It("should always contain the container policy", func() {
+			expected := formatList(engine.ContainerPolicy())
+			buf := strings.Builder{}
+			printChecks(&buf)
+
+			Expect(buf.String()).To(ContainSubstring(expected))
+		})
+
+		It("should always contain the operator policy", func() {
+			expected := formatList(engine.OperatorPolicy())
+			buf := strings.Builder{}
+			printChecks(&buf)
+
+			Expect(buf.String()).To(ContainSubstring(expected))
+		})
+
+		It("should always contain the root exception policy", func() {
+			expected := formatList(engine.RootExceptionContainerPolicy())
+			buf := strings.Builder{}
+			printChecks(&buf)
+
+			Expect(buf.String()).To(ContainSubstring(expected))
+		})
+
+		It("should always contain the scratch exception policy", func() {
+			expected := formatList(engine.ScratchContainerPolicy())
+			buf := strings.Builder{}
+			printChecks(&buf)
+
+			Expect(buf.String()).To(ContainSubstring(expected))
+		})
+	})
+
+	Context("When executing the cobra command", func() {
+		It("should contain output equivalent to printChecks", func() {
+			// get the expected result
+			buf := strings.Builder{}
+			printChecks(&buf)
+			expected := buf.String()
+
+			// Run the command. Because we bind this command to the
+			// root command in init, we must pass rootCmd to executeCommand.
+			out, err := executeCommand(rootCmd, "list-checks")
+			Expect(len(out) > 0).To(BeTrue())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring(expected))
+		})
+	})
+})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -11,6 +12,21 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// executeCommand is used for cobra command testing. It is effectively what's seen here:
+// https://github.com/spf13/cobra/blob/master/command_test.go#L34-L43. It should only
+// be used in tests. Typically, you should pass rootCmd as the param for root, and your
+// subcommand's invocation within args.
+func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	err = root.Execute()
+
+	return buf.String(), err
+}
 
 var _ = Describe("cmd package utility functions", func() {
 	DescribeTable("Determine filename to which to write test results",


### PR DESCRIPTION
Part of #620 
Fixes #696 

This PR adds a new `list-checks` subcommand that replaces the `--list-checks` flags. I initially marked the `--list-checks` flag as deprecated, but because it impedes testing of the **cmd** package, I just decided to remove it.

A majority of the code for this subcommand is formatting oriented, making sure things look okay when printed at the command line. This also adds the root and scratch exception check lists to the output, with an informative blurb on when a user might see the behavior of preflight change to using only these checks.

This new `list-checks` subcommand should have 100% test coverage with this PR.

The output looks like this:
```
12:58:37 ~/.go/src/github.com/redhat-openshift-ecosystem/openshift-preflight
$ ./preflight  -v
preflight version 0.0.0 <commit: 7ff91d29f7fdc96b2218e12f67bfe65a0d739998>

12:58:44 ~/.go/src/github.com/redhat-openshift-ecosystem/openshift-preflight
$ ./preflight list-checks
These are the available checks for each policy:
[Operator Policy]: invoked on operator bundles
- ScorecardBasicSpecCheck
- ScorecardOlmSuiteCheck
- DeployableByOLM
- ValidateOperatorBundle

[Container Policy]: invoked on container images
- HasLicense
- HasUniqueTag
- LayerCountAcceptable
- HasNoProhibitedPackages
- HasRequiredLabel
- RunAsNonRoot
- HasModifiedFiles
- BasedOnUbi

[Container Root Exception Policy]: automatically applied for container images if preflight determines a root exception flag has been added to your Red Hat Connect project
- HasLicense
- HasUniqueTag
- LayerCountAcceptable
- HasNoProhibitedPackages
- HasRequiredLabel
- HasModifiedFiles

[Container Scratch Exception Policy]: automatically applied for container checks if preflight determines a scratch exception flag has been added to your Red Hat Connect project
- HasLicense
- HasUniqueTag
- LayerCountAcceptable
- HasRequiredLabel
- RunAsNonRoot
```

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>