### PR TITLE
Add runtime assets tests

### DIFF
--- a/cmd/runtime_assets_test.go
+++ b/cmd/runtime_assets_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+)
+
+var _ = Describe("runtime-assets test", func() {
+	Context("When formatting JSON data", func() {
+		It("should be formatted in a standard format", func() {
+			in := map[string]interface{}{
+				"foo":  "bar",
+				"this": []string{"that", "theother"},
+			}
+			expected := "{\n    \"foo\": \"bar\",\n    \"this\": [\n        \"that\",\n        \"theother\"\n    ]\n}"
+			res, err := prettyPrintJSON(in)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(expected))
+		})
+
+		Context("With invalid data", func() {
+			It("should throw an error", func() {
+				// channels are not supported in json.
+				_, err := prettyPrintJSON(make(chan int))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When printing the runtime assets", func() {
+		It("should print successfully and match the actual data", func() {
+			buf := bytes.NewBuffer([]byte{})
+			err := printAssets(context.TODO(), buf)
+			Expect(err).ToNot(HaveOccurred())
+
+			var printed runtime.AssetData
+			json.Unmarshal(buf.Bytes(), &printed)
+
+			actual := runtime.Assets(context.TODO())
+
+			Expect(printed).To(BeEquivalentTo(actual))
+		})
+	})
+
+	Context("When calling the runtime-assets cobra command", func() {
+		It("should print successfully and match the actual data", func() {
+			out, err := executeCommand(rootCmd, "runtime-assets")
+			Expect(err).ToNot(HaveOccurred())
+
+			var printed runtime.AssetData
+			json.Unmarshal([]byte(out), &printed)
+
+			actual := runtime.Assets(context.TODO())
+
+			Expect(printed).To(BeEquivalentTo(actual))
+		})
+	})
+})


### PR DESCRIPTION
Part of #620 

NOTE: This builds on #697 so I'll put do-not-merge on this until I can rebase. That said, it's ready for review. The only files that changed are **cmd/runtime_assets.go** and **cmd/runtime_assets_test.go**. 

This PR adds runtime-assets testing by:
- Extracting write operations to an io.Writer
- Extracting formatting to its own function
- Passing through the cmd output to the io.Writer

Doesn't quite reach 100% because of two error paths that I'm not hitting. Seemed like too much fragmenting of the code just to hit the two error paths, but we hit the same error path in at least one test.

I'm seeing 85.7% on this file now. Okay for the moment.