### PR TITLE
Make CertificationInput a public type

### DIFF
--- a/certification/pyxis/builder.go
+++ b/certification/pyxis/builder.go
@@ -13,7 +13,7 @@ import (
 // certificationInputBuilder facilitates the building of CertificationInput for
 // submitting an asset to Pyxis.
 type certificationInputBuilder struct {
-	certificationInput
+	CertificationInput
 }
 
 // NewCertificationInput accepts required values for submitting to Pyxis, and returns a CertificationInputBuilder for
@@ -25,7 +25,7 @@ func NewCertificationInput(project *CertProject) (*certificationInputBuilder, er
 	}
 
 	b := certificationInputBuilder{
-		certificationInput: certificationInput{
+		CertificationInput: CertificationInput{
 			CertProject: project,
 		},
 	}
@@ -39,7 +39,7 @@ func NewCertificationInput(project *CertProject) (*certificationInputBuilder, er
 // unmodifiable CertificationInput.
 //
 // If any required values are not included, an error is thrown.
-func (b *certificationInputBuilder) Finalize() (*certificationInput, error) {
+func (b *certificationInputBuilder) Finalize() (*CertificationInput, error) {
 	// safeguards, make sure things aren't nil for any reason.
 	if b.CertImage == nil {
 		return nil, fmt.Errorf("a CertImage was not provided and is required")
@@ -61,7 +61,7 @@ func (b *certificationInputBuilder) Finalize() (*certificationInput, error) {
 	b.CertImage.ISVPID = b.CertProject.Container.ISVPID
 	b.CertImage.Certified = b.TestResults.Passed
 
-	return &b.certificationInput, nil
+	return &b.CertificationInput, nil
 }
 
 // WithCertImage adds a pyxis.CertImage from the passed io.Reader to the CertificationInput.

--- a/certification/pyxis/builder_test.go
+++ b/certification/pyxis/builder_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Pyxis Builder tests", func() {
 			})
 
 			It("should return a certification input builder with the project embedded", func() {
-				Expect(builder.certificationInput.CertProject.ID).To(Equal(p.ID))
+				Expect(builder.CertificationInput.CertProject.ID).To(Equal(p.ID))
 			})
 
 			It("should fail to finalize with no cert image", func() {

--- a/certification/pyxis/submit.go
+++ b/certification/pyxis/submit.go
@@ -12,7 +12,7 @@ var defaultRegistryAlias = "docker.io"
 
 // SubmitResults takes certInput and sends requests to Pyxis to create or update entries
 // based on certInput.
-func (p *pyxisClient) SubmitResults(ctx context.Context, certInput *certificationInput) (*CertificationResults, error) {
+func (p *pyxisClient) SubmitResults(ctx context.Context, certInput *CertificationInput) (*CertificationResults, error) {
 	var err error
 
 	certProject := certInput.CertProject

--- a/certification/pyxis/submit_test.go
+++ b/certification/pyxis/submit_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Pyxis Submit", func() {
 	ctx := context.Background()
 
 	var pyxisClient *pyxisClient
-	var certInput certificationInput
+	var certInput CertificationInput
 	mux := http.NewServeMux()
 
 	// These go from most explicit to least explicit. They will be check that way by the ServeMux.
@@ -29,7 +29,7 @@ var _ = Describe("Pyxis Submit", func() {
 			"my-awesome-project-id",
 			&http.Client{Transport: localRoundTripper{handler: mux}},
 		)
-		certInput = certificationInput{
+		certInput = CertificationInput{
 			CertProject: &CertProject{CertificationStatus: "Started"},
 			CertImage: &CertImage{
 				Repositories: []Repository{

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 )
 
-type certificationInput struct {
+type CertificationInput struct {
 	CertProject *CertProject
 	CertImage   *CertImage
 	TestResults *TestResults


### PR DESCRIPTION
In restructuring the `cmd` package to increase test coverage, and specifically writing out the Pyxis Submission abstraction, I found myself needing the CertificationInput to test various scenarios. Typical cases should use the builder, but testing shouldn't have to use the builder.

Related #620 

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>