### PR TITLE
Add function to get formatter by name and move default value out of the `cmd` package

### DIFF
--- a/certification/formatters/defaults.go
+++ b/certification/formatters/defaults.go
@@ -1,0 +1,5 @@
+package formatters
+
+const (
+	DefaultFormat = "json"
+)

--- a/certification/formatters/errors.go
+++ b/certification/formatters/errors.go
@@ -1,0 +1,5 @@
+package formatters
+
+import "errors"
+
+var ErrUnknownFormatter = errors.New("requested format is unknown")

--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -30,11 +30,17 @@ type FormatterFunc = func(context.Context, runtime.Results) (response []byte, fo
 // NewForConfig returns a new formatter based on the user-provided configuration. It relies
 // on config values which should align with known/supported/built-in formatters.
 func NewForConfig(cfg certification.Config) (ResponseFormatter, error) {
-	formatter, defined := availableFormatters[cfg.ResponseFormat()]
+	return NewByName(cfg.ResponseFormat())
+}
+
+// NewByName returns a predefined ResponseFormatter with the given name.
+// TODO: New* funcs in this package may benefit from renaming.
+func NewByName(name string) (ResponseFormatter, error) {
+	formatter, defined := availableFormatters[name]
 	if !defined {
-		return nil, fmt.Errorf(
-			"failed to create a new formatter from config: %s",
-			cfg.ResponseFormat(),
+		return nil, fmt.Errorf("%w: %s",
+			ErrUnknownFormatter,
+			name,
 		)
 	}
 

--- a/certification/formatters/formatters_test.go
+++ b/certification/formatters/formatters_test.go
@@ -10,6 +10,12 @@ import (
 )
 
 var _ = Describe("Formatters", func() {
+	Describe("When getting the formatter for the named default format", func() {
+		It("should never fail", func() {
+			_, err := NewByName(DefaultFormat)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 	Describe("When getting a new formatter for a configuration", func() {
 		Context("with a valid configuration", func() {
 			cfg := runtime.Config{

--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -64,7 +64,7 @@ func checkContainerRunE(cmd *cobra.Command, args []string) error {
 
 	// Set our runtime defaults.
 	cfg.Image = containerImage
-	cfg.ResponseFormat = DefaultOutputFormat
+	cfg.ResponseFormat = formatters.DefaultFormat
 
 	// Run the  container check.
 	cmd.SilenceUsage = true

--- a/cmd/check_operator.go
+++ b/cmd/check_operator.go
@@ -56,7 +56,7 @@ func checkOperatorRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg.Image = operatorImage
-	cfg.ResponseFormat = DefaultOutputFormat
+	cfg.ResponseFormat = formatters.DefaultFormat
 	cfg.Bundle = true
 	cfg.Scratch = true
 

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -1,7 +1,6 @@
 package cmd
 
 var (
-	DefaultOutputFormat      = "json"
 	DefaultLogFile           = "preflight.log"
 	DefaultLogLevel          = "info"
 	DefaultNamespace         = "default"


### PR DESCRIPTION
This PR adds a formatters.NewByName function and reconfigures existing functions to use it. This allows us to get a formatter without having to instantiate a configuration struct. 

In addition, this moves the default formatter definitions to the formatters package, and adds a test to make sure the value never fails to return a formatter. This is to help prevent dependency cycles in this test, and also makes somewhat more logical sense than storing it in the `cmd` package.

Related: #620

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>