### PR TITLE
updating to latest version of go-rpmdb

### DIFF
--- a/certification/internal/policy/container/has_modified_files.go
+++ b/certification/internal/policy/container/has_modified_files.go
@@ -49,7 +49,7 @@ func (p *HasModifiedFilesCheck) getDataToValidate(ctx context.Context, imgRef ce
 	// installed packages.
 	packageFiles := make(map[string]struct{}, len(pkgList))
 	for _, pkg := range pkgList {
-		filenames, err := pkg.InstalledFiles()
+		filenames, err := pkg.InstalledFileNames()
 		if err != nil {
 			return nil, fmt.Errorf("could not list installed files: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -105,4 +105,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 
-replace github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1 => github.com/opdev/go-rpmdb v0.0.0-20220329221310-ca9c80a97804
+replace github.com/knqyf263/go-rpmdb v0.0.0-20201215100354-a9e3110d8ee1 => github.com/opdev/go-rpmdb v0.0.0-20220622214440-9ad97f393868

--- a/go.sum
+++ b/go.sum
@@ -685,8 +685,8 @@ github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
-github.com/opdev/go-rpmdb v0.0.0-20220329221310-ca9c80a97804 h1:SAMvnxdkgSBMB7Ak4sFdeKzzEBvg/eOHRM2h/l3QlJg=
-github.com/opdev/go-rpmdb v0.0.0-20220329221310-ca9c80a97804/go.mod h1:nrkAFnlGZhIkW8bAwWK1PE0rCnMe8uKCUzwrFHpfEsM=
+github.com/opdev/go-rpmdb v0.0.0-20220622214440-9ad97f393868 h1:XXxyt5fiiDKjF0rkzvkre52rznX6Vsib11xMqAvT8Q4=
+github.com/opdev/go-rpmdb v0.0.0-20220622214440-9ad97f393868/go.mod h1:ZQDkL8JLWXdoduwq/aZGDfI3Cn0FT5ta1yhDcb3yQAE=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 h1:+czc/J8SlhPKLOtVLMQc+xDCFBT73ZStMsRhSsUhsSg=


### PR DESCRIPTION
- Fixes: #694 
- Update to latest version of `go-rpmdb` in opdev fork from branch `preflight-next`
- Includes a fix for a change in upstream that renamed a method that we were using 
- Includes changes to support `mongo-cli` and other `rpm`s that have a `RPMTAG_SUMMARY` header tag as a value of `6` (STRING) instead of the expect value of `9` (I18NSTRING) 

Testing:
I tested the same image before and after this change and got the same list of files before/after. And the new method and old method look the same to me in the `go-rpmdb` codebase. But I would be interested in better/other ways to make sure this doesn't introduce unintended consequences, thoughts?

Signed-off-by: Adam D. Cornett <adc@redhat.com>