### PR TITLE
updating gh actions to login to a given registry

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -33,6 +33,14 @@ jobs:
     name: create and push a multiarch manifest to the repo
     runs-on: ubuntu-latest
     steps:
+      # Authenticate to container image registry to push the image
+      - name: Podman Login
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ secrets.registry }}
+          username: ${{ secrets.user }}
+          password: ${{ secrets.password }}
+
       - name: Create and add to manifest
         run: |
           buildah manifest create ${{ inputs.name }}
@@ -41,14 +49,6 @@ jobs:
           buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-arm64
           buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-s390x
 
-      # Authenticate to container image registry to push the image
-      - name: Podman Login
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: ${{ secrets.registry }}
-          username: ${{ secrets.user }}
-          password: ${{ secrets.password }}
-          
       - name: Push manifest
         run: |
             podman manifest push ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}  --all

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,12 +70,13 @@ jobs:
   extract-assets:
     needs: build-release
     uses: ./.github/workflows/release-artifacts.yml
-
     with:
       name: ${{ needs.build-release.outputs.imageName }}
       tag: ${{ needs.build-release.outputs.imageVersion }}
     secrets:
       registry: ${{ secrets.IMAGE_REGISTRY }}
+      user: ${{ secrets.REGISTRY_USER }}
+      password: ${{ secrets.REGISTRY_PASSWORD }}
       token: ${{ secrets.GITHUB_TOKEN }}
 
   copy-to-rhisv:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -12,6 +12,10 @@ on:
     secrets:
       registry:
         required: true
+      user:
+        required: true
+      password:
+        required: true
       token:
         required: true
         
@@ -28,6 +32,13 @@ jobs:
           - ppc64le
           - s390x
     steps:
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.registry }}
+        username: ${{ secrets.user }}
+        password: ${{ secrets.password }}
+
     - name: Extract executable
       uses: shrink/actions-docker-extract@v1
       id: extract


### PR DESCRIPTION
## Motivation
There is sometimes a need to cut a hotfix for a partner and the easiest way to do this is to create a release from a fork, if we have changes in `main` that are not read to be released. In-order to accomplish this, the login steps need to be moved around/added in various steps to guard against failures.

## Testing
This was used in my fork in the `ghactions` [branch](https://github.com/acornett21/openshift-preflight/tree/ghactions) to cut release `1.2.1-rpm-hotfix` found [here](https://github.com/acornett21/openshift-preflight/releases/tag/1.2.1-rpm-hotfix)

Signed-off-by: Adam D. Cornett <adc@redhat.com>