### PR TITLE
Refactor check_container to use preflightCheck, and enable tests

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -3,19 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path"
-	"path/filepath"
-	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/pyxis"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 	log "github.com/sirupsen/logrus"
@@ -29,28 +21,60 @@ var checkContainerCmd = &cobra.Command{
 	Use:   "container",
 	Short: "Run checks for a container",
 	Long:  `This command will run the Certification checks for a container image. `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("a container image positional argument is required")
-		}
-
-		if submit {
-			if !viper.IsSet("certification_project_id") {
-				cmd.MarkFlagRequired("certification-project-id")
-			}
-
-			if !viper.IsSet("pyxis_api_token") {
-				cmd.MarkFlagRequired("pyxis-api-token")
-			}
-		}
-
-		return nil
-	},
+	Args:  checkContainerPositionalArgs,
 	// this fmt.Sprintf is in place to keep spacing consistent with cobras two spaces that's used in: Usage, Flags, etc
 	Example: fmt.Sprintf("  %s", "preflight check container quay.io/repo-name/container-name:version"),
 	RunE:    checkContainerRunE,
 }
 
+// checkContainerRunner contains all of the components necessary to run checkContainer.
+type checkContainerRunner struct {
+	cfg       *runtime.Config
+	pc        pyxisClient
+	eng       engine.CheckEngine
+	formatter formatters.ResponseFormatter
+	rw        resultWriter
+	rs        resultSubmitter
+}
+
+func newCheckContainerRunner(ctx context.Context, cfg *runtime.Config) (*checkContainerRunner, error) {
+	cfg.Policy = policy.PolicyContainer
+	cfg.Submit = submit
+
+	pyxisClient := newPyxisClient(ctx, cfg.ReadOnly())
+	// If we have a pyxisClient, we can query for container policy exceptions.
+	if pyxisClient != nil {
+		policy, err := getContainerPolicyExceptions(ctx, pyxisClient)
+		if err != nil {
+			return nil, err
+		}
+
+		cfg.Policy = policy
+	}
+
+	engine, err := engine.NewForConfig(ctx, cfg.ReadOnly())
+	if err != nil {
+		return nil, err
+	}
+
+	fmttr, err := formatters.NewForConfig(cfg.ReadOnly())
+	if err != nil {
+		return nil, err
+	}
+
+	rs := resolveSubmitter(pyxisClient, cfg.ReadOnly())
+
+	return &checkContainerRunner{
+		cfg:       cfg,
+		pc:        pyxisClient,
+		eng:       engine,
+		formatter: fmttr,
+		rw:        &runtime.ResultWriterFile{},
+		rs:        rs,
+	}, nil
+}
+
+// checkContainerRunE executes checkContainer using the user args to inform the execution.
 func checkContainerRunE(cmd *cobra.Command, args []string) error {
 	log.Info("certification library version ", version.Version.String())
 	ctx := cmd.Context()
@@ -62,194 +86,77 @@ func checkContainerRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	// Set our runtime defaults.
 	cfg.Image = containerImage
-	cfg.ResponseFormat = formatters.DefaultFormat
+	checkContainer, err := newCheckContainerRunner(ctx, cfg)
+	if err != nil {
+		return err
+	}
 
 	// Run the  container check.
 	cmd.SilenceUsage = true
-	return checkContainer(ctx, cfg)
+	return preflightCheck(ctx,
+		checkContainer.cfg,
+		checkContainer.pc,
+		checkContainer.eng,
+		checkContainer.formatter,
+		checkContainer.rw,
+		checkContainer.rs,
+	)
 }
 
-// checkContainer runs the Container policy.
-func checkContainer(ctx context.Context, cfg *runtime.Config) error {
-	cfg.Policy = policy.PolicyContainer
-
-	// configure the artifacts directory if the user requested a different directory.
-	if cfg.Artifacts != "" {
-		artifacts.SetDir(cfg.Artifacts)
-	}
-
-	// Determine if we need to modify the policy that's executed.
-	if cfg.CertificationProjectID != "" {
-		pyxisClient := pyxis.NewPyxisClient(
-			cfg.PyxisHost,
-			cfg.PyxisAPIToken,
-			cfg.CertificationProjectID,
-			&http.Client{Timeout: 60 * time.Second},
-		)
-		certProject, err := pyxisClient.GetProject(ctx)
-		if err != nil {
-			return fmt.Errorf("could not retrieve project: %w", err)
-		}
-		log.Debugf("Certification project name is: %s", certProject.Name)
-		if certProject.Container.OsContentType == "scratch" {
-			cfg.Policy = policy.PolicyScratch
-			cfg.Scratch = true
-		}
-
-		// if a partner sets `Host Level Access` in connect to `Privileged`, enable RootExceptionContainerPolicy checks
-		if certProject.Container.Privileged {
-			cfg.Policy = policy.PolicyRoot
-		}
-	}
-	engine, err := engine.NewForConfig(ctx, cfg.ReadOnly())
-	if err != nil {
-		return err
-	}
-
-	formatter, err := formatters.NewForConfig(cfg.ReadOnly())
-	if err != nil {
-		return err
-	}
-
-	// create the results file early to catch cases where we are not
-	// able to write to the filesystem before we attempt to execute checks.
-	resultsFile, err := os.OpenFile(
-		filepath.Join(artifacts.Path(), resultsFilenameWithExtension(formatter.FileExtension())),
-		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
-		0o600,
-	)
-	if err != nil {
-		return err
-	}
-
-	// also write to stdout
-	resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
-
-	// execute the checks
-	if err := engine.ExecuteChecks(ctx); err != nil {
-		return err
-	}
-	results := engine.Results(ctx)
-
-	// return results to the user and then close output files
-	formattedResults, err := formatter.Format(ctx, results)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintln(resultsOutputTarget, string(formattedResults))
-	if err := resultsFile.Close(); err != nil {
-		return err
-	}
-
-	if cfg.WriteJUnit {
-		if err := writeJUnit(ctx, results); err != nil {
-			return err
+// resolveSubmitter will build out a resultSubmitter if the provided pyxisClient, pc, is not nil.
+// The pyxisClient is a required component of the submitter. If pc is nil, then a noop submitter
+// is returned instead, which does nothing.
+func resolveSubmitter(pc pyxisClient, cfg certification.Config) resultSubmitter {
+	if pc != nil {
+		return &containerCertificationSubmitter{
+			certificationProjectID: cfg.CertificationProjectID(),
+			pyxis:                  pc,
+			dockerConfig:           cfg.DockerConfig(),
+			preflightLogFile:       cfg.LogFile(),
 		}
 	}
 
-	// assemble artifacts and submit results to pyxis if user provided the submit flag.
+	return &noopSubmitter{emitLog: true}
+}
+
+// getContainerPolicyExceptions will query Pyxis to determine if
+// a given project has a certification excemptions, such as root or scratch.
+// This will then return the corresponding policy.
+//
+// If no policy exception flags are found on the project, the standard
+// container policy is returned.
+func getContainerPolicyExceptions(ctx context.Context, pc pyxisClient) (policy.Policy, error) {
+	certProject, err := pc.GetProject(ctx)
+	if err != nil {
+		return "", fmt.Errorf("could not retrieve project: %w", err)
+	}
+	log.Debugf("Certification project name is: %s", certProject.Name)
+	if certProject.Container.OsContentType == "scratch" {
+		return policy.PolicyScratch, nil
+	}
+
+	// if a partner sets `Host Level Access` in connect to `Privileged`, enable RootExceptionContainerPolicy checks
+	if certProject.Container.Privileged {
+		return policy.PolicyRoot, nil
+	}
+	return policy.PolicyContainer, nil
+}
+
+func checkContainerPositionalArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a container image positional argument is required")
+	}
+
 	if submit {
-		log.Info("preparing results that will be submitted to Red Hat")
-
-		// you must provide a project ID in order to submit.
-		if cfg.CertificationProjectID == "" {
-			return fmt.Errorf("project ID must be provided")
+		if !viper.IsSet("certification_project_id") {
+			cmd.MarkFlagRequired("certification-project-id")
 		}
 
-		// establish a pyxis client.
-		pyxisClient := pyxis.NewPyxisClient(
-			cfg.PyxisHost,
-			cfg.PyxisAPIToken,
-			cfg.CertificationProjectID,
-			&http.Client{Timeout: 60 * time.Second})
-
-		// get the project info from pyxis
-		certProject, err := pyxisClient.GetProject(ctx)
-		if err != nil {
-			return fmt.Errorf("could not retrieve project: %w", err)
+		if !viper.IsSet("pyxis_api_token") {
+			cmd.MarkFlagRequired("pyxis-api-token")
 		}
-		log.Tracef("CertProject: %+v", certProject)
-
-		// read the provided docker config
-		dockerConfigJsonBytes, err := os.ReadFile(cfg.DockerConfig)
-		if err != nil {
-			return err
-		}
-
-		certProject.Container.DockerConfigJSON = string(dockerConfigJsonBytes)
-
-		// prepare submission
-		submission, err := pyxis.NewCertificationInput(certProject)
-		if err != nil {
-			return fmt.Errorf("could not build submission with required assets: %w", err)
-		}
-
-		certImage, err := os.Open(path.Join(artifacts.Path(), certification.DefaultCertImageFilename))
-		defer certImage.Close()
-		if err != nil {
-			return fmt.Errorf("could not open file for submission: %s: %w",
-				certification.DefaultCertImageFilename,
-				err,
-			)
-		}
-		preflightResults, err := os.Open(path.Join(artifacts.Path(), certification.DefaultTestResultsFilename))
-		defer preflightResults.Close()
-		if err != nil {
-			return fmt.Errorf(
-				"could not open file for submission: %s: %w",
-				certification.DefaultTestResultsFilename,
-				err,
-			)
-		}
-		rpmManifest, err := os.Open(path.Join(artifacts.Path(), certification.DefaultRPMManifestFilename))
-		defer rpmManifest.Close()
-		if err != nil {
-			return fmt.Errorf(
-				"could not open file for submission: %s: %w",
-				certification.DefaultRPMManifestFilename,
-				err,
-			)
-		}
-		logfile, err := os.Open(cfg.LogFile)
-		defer logfile.Close()
-		if err != nil {
-			return fmt.Errorf(
-				"could not open file for submission: %s: %w",
-				cfg.LogFile,
-				err,
-			)
-		}
-		submission.
-			// The engine writes the certified image config to disk in a Pyxis-specific format.
-			WithCertImage(certImage).
-			// Include Preflight's test results in our submission. pyxis.TestResults embeds them.
-			WithPreflightResults(preflightResults).
-			// The certification engine writes the rpmManifest for images not based on scratch.
-			WithRPMManifest(rpmManifest).
-			// Include the preflight execution log file.
-			WithArtifact(logfile, filepath.Base(cfg.LogFile))
-
-		input, err := submission.Finalize()
-		if err != nil {
-			return fmt.Errorf("unable to finalize data that would be sent to pyxis: %w", err)
-		}
-
-		certResults, err := pyxisClient.SubmitResults(ctx, input)
-		if err != nil {
-			return fmt.Errorf("could not submit to pyxis: %w", err)
-		}
-
-		log.Info("Test results have been submitted to Red Hat.")
-		log.Info("These results will be reviewed by Red Hat for final certification.")
-		log.Infof("The container's image id is: %s.", certResults.CertImage.ID)
-		log.Infof("Please check %s to view scan results.", buildScanResultsURL(cfg.CertificationProjectID, certResults.CertImage.ID))
-		log.Infof("Please check %s to monitor the progress.", buildOverviewURL(cfg.CertificationProjectID))
 	}
-
-	log.Infof("Preflight result: %s", convertPassedOverall(results.PassedOverall))
 
 	return nil
 }

--- a/cmd/check_container_test.go
+++ b/cmd/check_container_test.go
@@ -1,0 +1,473 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/pyxis"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
+
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Check Container Command", func() {
+	var contextTempDir string
+	var artifactsDir string
+
+	BeforeEach(func() {
+		// instantiate err to make sure we can equal-assign in the following line.
+		var err error
+		contextTempDir, err = os.MkdirTemp(os.TempDir(), "check-container-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(contextTempDir)).ToNot(BeZero())
+		artifactsDir = path.Join(contextTempDir, "artifacts")
+		artifacts.SetDir(artifactsDir)
+	})
+
+	AfterEach(func() {
+		err := os.RemoveAll(contextTempDir)
+		Expect(err).ToNot(HaveOccurred())
+		artifacts.Reset()
+	})
+
+	Context("When determining container policy exceptions", func() {
+		var fakePC *fakePyxisClient
+		BeforeEach(func() {
+			// reset the fake pyxis client before each execution
+			// as a precaution.
+			fakePC = &fakePyxisClient{
+				findImagesByDigestFunc: fidbFuncNoop,
+				getProjectsFunc:        gpFuncNoop,
+				submitResultsFunc:      srFuncNoop,
+			}
+		})
+
+		It("should throw an error if unable to get the project from the API", func() {
+			fakePC.getProjectsFunc = gpFuncReturnError
+			_, err := getContainerPolicyExceptions(context.TODO(), fakePC)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return a scratch policy exception if the project has the flag in the API", func() {
+			fakePC.getProjectsFunc = gpFuncReturnScratchException
+			p, err := getContainerPolicyExceptions(context.TODO(), fakePC)
+			Expect(p).To(Equal(policy.PolicyScratch))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return a root policy exception if the project has the flag in the API", func() {
+			fakePC.getProjectsFunc = gpFuncReturnRootException
+			p, err := getContainerPolicyExceptions(context.TODO(), fakePC)
+			Expect(p).To(Equal(policy.PolicyRoot))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return a container policy exception if the project no exceptions in the API", func() {
+			fakePC.getProjectsFunc = gpFuncReturnNoException
+			p, err := getContainerPolicyExceptions(context.TODO(), fakePC)
+			Expect(p).To(Equal(policy.PolicyContainer))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("When using the containerCertificationSubmitter", func() {
+		var sbmt *containerCertificationSubmitter
+		var fakePC *fakePyxisClient
+		var dockerConfigPath string
+		var preflightLogPath string
+
+		preflightLogFilename := "preflight.log"
+		dockerconfigFilename := "dockerconfig.json"
+		BeforeEach(func() {
+			dockerConfigPath = path.Join(artifactsDir, dockerconfigFilename)
+			preflightLogPath = path.Join(artifactsDir, preflightLogFilename)
+			// Normalize a fakePyxisClient with noop functions.
+			fakePC = &fakePyxisClient{
+				findImagesByDigestFunc: fidbFuncNoop,
+				getProjectsFunc:        gpFuncNoop,
+				submitResultsFunc:      srFuncNoop,
+			}
+
+			// Most tests will need a passing getProjects func so set that to
+			// avoid having to perform multiple BeforeEaches
+			fakePC.setGPFuncReturnBaseProject("")
+
+			// configure the submitter
+			sbmt = &containerCertificationSubmitter{
+				certificationProjectID: fakePC.baseProject("").ID,
+				pyxis:                  fakePC,
+				dockerConfig:           dockerConfigPath,
+				preflightLogFile:       preflightLogPath,
+			}
+
+			certImageJSONBytes, err := json.Marshal(pyxis.CertImage{
+				ID: "111111111111",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			preflightTestResultsJSONBytes, err := json.Marshal(runtime.Results{
+				TestedImage:   "foo",
+				PassedOverall: true,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			rpmManifestJSONBytes, err := json.Marshal(pyxis.RPMManifest{
+				ID:      "foo",
+				ImageID: "foo",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create expected files.
+			artifacts.WriteFile(dockerconfigFilename, "dockerconfig")
+			artifacts.WriteFile(preflightLogFilename, "preflight log")
+			artifacts.WriteFile(certification.DefaultCertImageFilename, string(certImageJSONBytes))
+			artifacts.WriteFile(certification.DefaultTestResultsFilename, string(preflightTestResultsJSONBytes))
+			artifacts.WriteFile(certification.DefaultRPMManifestFilename, string(rpmManifestJSONBytes))
+		})
+
+		Context("and project cannot be obtained from the API", func() {
+			BeforeEach(func() {
+				fakePC.getProjectsFunc = gpFuncReturnError
+			})
+			It("should throw an error", func() {
+				err := sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("and the provided docker config cannot be read from disk", func() {
+			It("should throw an error", func() {
+				err := os.Remove(dockerConfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(dockerconfigFilename))
+			})
+		})
+
+		Context("and the cert image cannot be read from disk", func() {
+			It("should throw an error", func() {
+				err := os.Remove(path.Join(artifactsDir, certification.DefaultCertImageFilename))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(certification.DefaultCertImageFilename))
+			})
+		})
+
+		Context("and the preflight results cannot be read from disk", func() {
+			It("should throw an error", func() {
+				err := os.Remove(path.Join(artifactsDir, certification.DefaultTestResultsFilename))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(certification.DefaultTestResultsFilename))
+			})
+		})
+
+		Context("and the rpmManifest cannot be read from disk", func() {
+			It("should throw an error", func() {
+				err := os.Remove(path.Join(artifactsDir, certification.DefaultRPMManifestFilename))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(certification.DefaultRPMManifestFilename))
+			})
+		})
+
+		Context("and the preflight logfile cannot be read from disk", func() {
+			It("should throw an error", func() {
+				err := os.Remove(preflightLogPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(preflightLogFilename))
+			})
+		})
+
+		Context("and the submission fails", func() {
+			BeforeEach(func() {
+				fakePC.submitResultsFunc = srFuncReturnError
+			})
+
+			It("should throw an error", func() {
+				err := sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("and the certproject returned from pyxis is nil, but no error was returned", func() {
+			BeforeEach(func() {
+				fakePC.getProjectsFunc = gpFuncNoop
+			})
+
+			It("should throw an error", func() {
+				err := sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("and one of the submission artifacts is malformed", func() {
+			BeforeEach(func() {
+				artifacts.WriteFile(certification.DefaultRPMManifestFilename, "malformed")
+			})
+
+			It("should throw an error finalizing the submission", func() {
+				err := sbmt.Submit(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to finalize data"))
+			})
+		})
+
+		Context("and the submission succeeds", func() {
+			BeforeEach(func() {
+				fakePC.setSRFuncSubmitSuccessfully("", "")
+			})
+			It("should not throw an error", func() {
+				err := sbmt.Submit(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When using the noop submitter", func() {
+		var bf *bytes.Buffer
+		var noop *noopSubmitter
+
+		BeforeEach(func() {
+			bufferLogger := logrus.New()
+			bf = bytes.NewBuffer([]byte{})
+			bufferLogger.SetOutput(bf)
+
+			noop = &noopSubmitter{log: bufferLogger}
+		})
+
+		Context("and enabling log emitting", func() {
+			BeforeEach(func() {
+				noop.emitLog = true
+			})
+
+			It("should include the reason in the emitted log if specified", func() {
+				testReason := "test reason"
+				noop.reason = testReason
+				err := noop.Submit(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bf.String()).To(ContainSubstring(testReason))
+			})
+
+			It("should emit logs when calling submit", func() {
+				err := noop.Submit(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bf.String()).To(ContainSubstring("Results are not being sent for submission."))
+			})
+		})
+
+		Context("and disabling log emitting", func() {
+			It("should not emit logs when calling submit", func() {
+				noop.emitLog = false
+				err := noop.Submit(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bf.String()).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("When resolving the submitter", func() {
+		Context("with a valid pyxis client", func() {
+			cfg := runtime.Config{
+				CertificationProjectID: "projectid",
+				PyxisHost:              "host",
+				PyxisAPIToken:          "apitoken",
+				DockerConfig:           "dockercfg",
+				LogFile:                "logfile",
+			}
+
+			pc := newPyxisClient(context.TODO(), cfg.ReadOnly())
+			Expect(pc).ToNot(BeNil())
+
+			It("should return a containerCertificationSubmitter", func() {
+				submitter := resolveSubmitter(pc, cfg.ReadOnly())
+				typed, ok := submitter.(*containerCertificationSubmitter)
+				Expect(typed).ToNot(BeNil())
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		Context("With no pyxis client", func() {
+			cfg := runtime.Config{}
+			It("should return a no-op submitter", func() {
+				submitter := resolveSubmitter(nil, cfg.ReadOnly())
+				typed, ok := submitter.(*noopSubmitter)
+				Expect(typed).ToNot(BeNil())
+				Expect(ok).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When establishing a pyxis client.", func() {
+		Context("with none of the required values", func() {
+			cfgNoCertProjectID := runtime.Config{}
+
+			It("Should return a nil pyxis client", func() {
+				pc := newPyxisClient(context.TODO(), cfgNoCertProjectID.ReadOnly())
+				Expect(pc).To(BeNil())
+			})
+		})
+
+		Context("Missing any of the required values", func() {
+			cfgMissingCertProjectID := runtime.Config{
+				PyxisHost:     "foo",
+				PyxisAPIToken: "bar",
+			}
+
+			cfgMissingPyxisHost := runtime.Config{
+				CertificationProjectID: "foo",
+				PyxisAPIToken:          "bar",
+			}
+
+			cfgMissingPyxisAPIToken := runtime.Config{
+				CertificationProjectID: "foo",
+				PyxisHost:              "bar",
+			}
+
+			It("Should return a nil pyxis client", func() {
+				pc := newPyxisClient(context.TODO(), cfgMissingCertProjectID.ReadOnly())
+				Expect(pc).To(BeNil())
+
+				pc = newPyxisClient(context.TODO(), cfgMissingPyxisHost.ReadOnly())
+				Expect(pc).To(BeNil())
+
+				pc = newPyxisClient(context.TODO(), cfgMissingPyxisAPIToken.ReadOnly())
+				Expect(pc).To(BeNil())
+			})
+		})
+
+		Context("With all the required values", func() {
+			cfgValid := runtime.Config{
+				CertificationProjectID: "foo",
+				PyxisHost:              "bar",
+				PyxisAPIToken:          "baz",
+			}
+
+			It("should return a pyxis client", func() {
+				pc := newPyxisClient(context.TODO(), cfgValid.ReadOnly())
+				Expect(pc).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("When instantiating a checkContainerRunner", func() {
+		var cfg *runtime.Config
+
+		BeforeEach(func() {
+			cfg = &runtime.Config{
+				Image:          "quay.io/example/foo:latest",
+				ResponseFormat: formatters.DefaultFormat,
+			}
+		})
+
+		Context("and the user passed the submit flag, but no credentials", func() {
+			It("should return a noop submitter as credentials are required for submission", func() {
+				runner, err := newCheckContainerRunner(context.TODO(), cfg)
+				Expect(err).ToNot(HaveOccurred())
+				_, rsIsCorrectType := runner.rs.(*noopSubmitter)
+				Expect(rsIsCorrectType).To(BeTrue())
+			})
+		})
+
+		Context("and the user did not pass the submit flag", func() {
+			var origSubmitValue bool
+			BeforeEach(func() {
+				origSubmitValue = submit
+				submit = false
+			})
+
+			AfterEach(func() {
+				submit = origSubmitValue
+			})
+			It("should return a noopSubmitter resultSubmitter", func() {
+				runner, err := newCheckContainerRunner(context.TODO(), cfg)
+				Expect(err).ToNot(HaveOccurred())
+				_, rsIsCorrectType := runner.rs.(*noopSubmitter)
+				Expect(rsIsCorrectType).To(BeTrue())
+			})
+		})
+
+		Context("with a valid policy formatter", func() {
+			It("should return with no error, and the appropriate formatter", func() {
+				cfg.ResponseFormat = "xml"
+				runner, err := newCheckContainerRunner(context.TODO(), cfg)
+				Expect(err).ToNot(HaveOccurred())
+				expectedFormatter, err := formatters.NewByName(cfg.ResponseFormat)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runner.formatter.PrettyName()).To(Equal(expectedFormatter.PrettyName()))
+			})
+		})
+
+		Context("with an invalid policy definition", func() {
+			It("should return the container policy engine anyway", func() {
+				runner, err := newCheckContainerRunner(context.TODO(), cfg)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedEngine, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
+				Expect(runner.eng).To(BeEquivalentTo(expectedEngine))
+			})
+		})
+		// NOTE(): There's no way to test policy exceptions here because
+		// without valid credentials to pyxis.
+
+		Context("with an invalid formatter definition", func() {
+			It("should return an error", func() {
+				cfg.ResponseFormat = "foo"
+				_, err := newCheckContainerRunner(context.TODO(), cfg)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		It("should contain a ResultWriterFile resultWriter", func() {
+			runner, err := newCheckContainerRunner(context.TODO(), cfg)
+			Expect(err).ToNot(HaveOccurred())
+			_, rwIsExpectedType := runner.rw.(*runtime.ResultWriterFile)
+			Expect(rwIsExpectedType).To(BeTrue())
+		})
+	})
+
+	Context("When validating check container arguments and flags", func() {
+		Context("and the user provided more than 1 positional arg", func() {
+			It("should fail to run", func() {
+				_, err := executeCommand(rootCmd, "check", "container", "foo", "bar")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("and the user provided less than 1 positional arg", func() {
+			It("should fail to run", func() {
+				_, err := executeCommand(rootCmd, "check", "container")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("and the user has enabled the submit flag", func() {
+			It("should cause the certification-project-id and pyxis-api-token flag to be required", func() {
+				out, err := executeCommand(rootCmd, "check", "container", "--submit", "foo")
+				Expect(err).To(HaveOccurred())
+				Expect(out).To(ContainSubstring("required flag(s) \"%s\", \"%s\" not set", "certification-project-id", "pyxis-api-token"))
+			})
+		})
+	})
+})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -81,7 +81,7 @@ var _ = Describe("cmd package utility functions", func() {
 			}
 			cobra.OnInitialize(initConfig)
 		})
-		Context("confiuring a Cobra Command", func() {
+		Context("configuring a Cobra Command", func() {
 			var tmpDir string
 			BeforeEach(func() {
 				var err error


### PR DESCRIPTION
Related to #620 

This PR refactors check_container.go to use abstractions, allowing us to better test the workflow. 

Notes for the reviewer(s):

- The cobra command for check_container has had its major function definitions (E.g. `RunE`, `Args`, moved to functions be tested outside of the scope of the cobra command.
- There's a local only type that contains all of the runtime abstractions (E.g. submitter, resultWriter, etc) which allows us to derive it and test that we got expected results. 
- Previously, the RunE function was untested outside of E2E testing because it made external calls. That's still the case, however, it has been further compartmentalized to try and reduce how much is untested.
- There's a typo that's corrected in root_test.go. It's unrelated to the rest of this PR, but it's a single letter, so figured I'd just knock it out. 

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>