### PR TITLE
fix bug with undefined default formatter

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -87,6 +87,8 @@ func checkContainerRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg.Image = containerImage
+	cfg.ResponseFormat = formatters.DefaultFormat
+
 	checkContainer, err := newCheckContainerRunner(ctx, cfg)
 	if err != nil {
 		return err

--- a/cmd/check_container_test.go
+++ b/cmd/check_container_test.go
@@ -40,6 +40,15 @@ var _ = Describe("Check Container Command", func() {
 		artifacts.Reset()
 	})
 
+	Context("when running the check container subcommand", func() {
+		Context("With all of the required parameters", func() {
+			It("should reach the core logic, but throw an error because of the placeholder values for the container image", func() {
+				_, err := executeCommand(rootCmd, "check", "container", "example.com/example/image:mytag")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
 	Context("When determining container policy exceptions", func() {
 		var fakePC *fakePyxisClient
 		BeforeEach(func() {
@@ -426,6 +435,7 @@ var _ = Describe("Check Container Command", func() {
 
 				expectedEngine, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
 				Expect(runner.eng).To(BeEquivalentTo(expectedEngine))
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 		// NOTE(): There's no way to test policy exceptions here because


### PR DESCRIPTION
This fixes a bug where the formatter being used was undefined, and so `check container` would fail indicating that the value was empty. I forgot that this value isn't defined in viper's defaulting logic, or an environment variable.

I've added a test to see that we reach the "happy path" and then fail because of staged values when running check_container.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>