### PR TITLE
remove extraneous defined error

### DIFF
--- a/certification/formatters/errors.go
+++ b/certification/formatters/errors.go
@@ -1,5 +1,0 @@
-package formatters
-
-import "errors"
-
-var ErrUnknownFormatter = errors.New("requested format is unknown")

--- a/certification/formatters/formatters.go
+++ b/certification/formatters/formatters.go
@@ -38,8 +38,8 @@ func NewForConfig(cfg certification.Config) (ResponseFormatter, error) {
 func NewByName(name string) (ResponseFormatter, error) {
 	formatter, defined := availableFormatters[name]
 	if !defined {
-		return nil, fmt.Errorf("%w: %s",
-			ErrUnknownFormatter,
+		return nil, fmt.Errorf("%s: %s",
+			"The requested formatter is unknown",
 			name,
 		)
 	}


### PR DESCRIPTION
I had originally added this error because I was leveraging a function that would evaluate if this error was encountered, and return the default formatter. That function never made it to the code base, so we don't need this function (in keeping in line with our new approach to standalone error definitions).

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>