### PR TITLE
Increase coverage of the engine package

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -104,31 +104,31 @@ func makeCheckList(checks []certification.Check) []string {
 }
 
 // checkNamesFor produces a slice of names for checks in the requested policy.
-func checkNamesFor(p policy.Policy) []string {
+func checkNamesFor(ctx context.Context, p policy.Policy) []string {
 	// stub the config. We don't technically need the policy here, but why not.
 	c := &runtime.Config{Policy: p}
-	checks, _ := initializeChecks(context.TODO(), p, c.ReadOnly())
+	checks, _ := initializeChecks(ctx, p, c.ReadOnly())
 	return makeCheckList(checks)
 }
 
 // OperatorPolicy returns the names of checks in the operator policy.
-func OperatorPolicy() []string {
-	return checkNamesFor(policy.PolicyOperator)
+func OperatorPolicy(ctx context.Context) []string {
+	return checkNamesFor(ctx, policy.PolicyOperator)
 }
 
 // ContainerPolicy returns the names of checks in the container policy.
-func ContainerPolicy() []string {
-	return checkNamesFor(policy.PolicyContainer)
+func ContainerPolicy(ctx context.Context) []string {
+	return checkNamesFor(ctx, policy.PolicyContainer)
 }
 
 // ScratchContainerPolicy returns the names of checks in the
 // container policy with scratch exception.
-func ScratchContainerPolicy() []string {
-	return checkNamesFor(policy.PolicyScratch)
+func ScratchContainerPolicy(ctx context.Context) []string {
+	return checkNamesFor(ctx, policy.PolicyScratch)
 }
 
 // RootExceptionContainerPolicy returns the names of checks in the
 // container policy with root exception.
-func RootExceptionContainerPolicy() []string {
-	return checkNamesFor(policy.PolicyRoot)
+func RootExceptionContainerPolicy(ctx context.Context) []string {
+	return checkNamesFor(ctx, policy.PolicyRoot)
 }

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("Engine Creation", func() {
-	Describe("When getting a new engine for a configuration", func() {
+	When("getting a new engine for a configuration", func() {
 		Context("with a valid configurations", func() {
 			Context("for the container policy", func() {
 				cfg := runtime.Config{
@@ -24,6 +24,19 @@ var _ = Describe("Engine Creation", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(engine).ToNot(BeNil())
 				})
+				It("should return the correct names", func() {
+					names := ContainerPolicy(context.TODO())
+					Expect(names).To(ContainElements([]string{
+						"HasLicense",
+						"HasUniqueTag",
+						"LayerCountAcceptable",
+						"HasNoProhibitedPackages",
+						"HasRequiredLabel",
+						"RunAsNonRoot",
+						"HasModifiedFiles",
+						"BasedOnUbi",
+					}))
+				})
 			})
 			Context("for the operator policy", func() {
 				cfg := runtime.Config{
@@ -35,6 +48,15 @@ var _ = Describe("Engine Creation", func() {
 					engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(engine).ToNot(BeNil())
+				})
+				It("should return the correct names", func() {
+					names := OperatorPolicy(context.TODO())
+					Expect(names).To(ContainElements([]string{
+						"ScorecardBasicSpecCheck",
+						"ScorecardOlmSuiteCheck",
+						"DeployableByOLM",
+						"ValidateOperatorBundle",
+					}))
 				})
 			})
 
@@ -50,6 +72,16 @@ var _ = Describe("Engine Creation", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(engine).ToNot(BeNil())
 				})
+				It("should return the correct names", func() {
+					names := ScratchContainerPolicy(context.TODO())
+					Expect(names).To(ContainElements([]string{
+						"HasLicense",
+						"HasUniqueTag",
+						"LayerCountAcceptable",
+						"HasRequiredLabel",
+						"RunAsNonRoot",
+					}))
+				})
 			})
 
 			Context("for the Root policy", func() {
@@ -64,6 +96,31 @@ var _ = Describe("Engine Creation", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(engine).ToNot(BeNil())
 				})
+				It("should return the correct names", func() {
+					names := RootExceptionContainerPolicy(context.TODO())
+					Expect(names).To(ContainElements([]string{
+						"HasLicense",
+						"HasUniqueTag",
+						"LayerCountAcceptable",
+						"HasNoProhibitedPackages",
+						"HasRequiredLabel",
+						"HasModifiedFiles",
+					}))
+				})
+			})
+		})
+
+		Context("with an invalid policy", func() {
+			cfg := runtime.Config{
+				Image:          "dummy/image",
+				Policy:         "invalid",
+				ResponseFormat: "json",
+			}
+
+			It("should return an error and no engine", func() {
+				engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
+				Expect(err).To(HaveOccurred())
+				Expect(engine).To(BeNil())
 			})
 		})
 	})

--- a/cmd/list_checks.go
+++ b/cmd/list_checks.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -25,11 +26,11 @@ func listChecksRunFunc(cmd *cobra.Command, args []string) {
 // printChecks writes the formatted check list output to w.
 func printChecks(w io.Writer) {
 	fmt.Fprintln(w, "These are the available checks for each policy:")
-	fmt.Fprintln(w, formattedPolicyBlock("Operator", engine.OperatorPolicy(), "invoked on operator bundles"))
-	fmt.Fprintln(w, formattedPolicyBlock("Container", engine.ContainerPolicy(), "invoked on container images"))
-	fmt.Fprintln(w, formattedPolicyBlock("Container Root Exception", engine.RootExceptionContainerPolicy(),
+	fmt.Fprintln(w, formattedPolicyBlock("Operator", engine.OperatorPolicy(context.TODO()), "invoked on operator bundles"))
+	fmt.Fprintln(w, formattedPolicyBlock("Container", engine.ContainerPolicy(context.TODO()), "invoked on container images"))
+	fmt.Fprintln(w, formattedPolicyBlock("Container Root Exception", engine.RootExceptionContainerPolicy(context.TODO()),
 		"automatically applied for container images if preflight determines a root exception flag has been added to your Red Hat Connect project"))
-	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch Exception", engine.ScratchContainerPolicy(),
+	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch Exception", engine.ScratchContainerPolicy(context.TODO()),
 		"automatically applied for container checks if preflight determines a scratch exception flag has been added to your Red Hat Connect project"))
 }
 

--- a/cmd/list_checks_test.go
+++ b/cmd/list_checks_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -39,7 +40,7 @@ var _ = Describe("list checks subcommand", func() {
 
 	Context("Printing checks", func() {
 		It("should always contain the container policy", func() {
-			expected := formatList(engine.ContainerPolicy())
+			expected := formatList(engine.ContainerPolicy(context.TODO()))
 			buf := strings.Builder{}
 			printChecks(&buf)
 
@@ -47,7 +48,7 @@ var _ = Describe("list checks subcommand", func() {
 		})
 
 		It("should always contain the operator policy", func() {
-			expected := formatList(engine.OperatorPolicy())
+			expected := formatList(engine.OperatorPolicy(context.TODO()))
 			buf := strings.Builder{}
 			printChecks(&buf)
 
@@ -55,7 +56,7 @@ var _ = Describe("list checks subcommand", func() {
 		})
 
 		It("should always contain the root exception policy", func() {
-			expected := formatList(engine.RootExceptionContainerPolicy())
+			expected := formatList(engine.RootExceptionContainerPolicy(context.TODO()))
 			buf := strings.Builder{}
 			printChecks(&buf)
 
@@ -63,7 +64,7 @@ var _ = Describe("list checks subcommand", func() {
 		})
 
 		It("should always contain the scratch exception policy", func() {
-			expected := formatList(engine.ScratchContainerPolicy())
+			expected := formatList(engine.ScratchContainerPolicy(context.TODO()))
 			buf := strings.Builder{}
 			printChecks(&buf)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,7 +36,7 @@ var _ = Describe("policy validation", func() {
 			results := e.Results(ctx)
 
 			It("should pass all checks", func() {
-				Expect(len(results.Passed)).To(Equal(len(engine.OperatorPolicy())))
+				Expect(len(results.Passed)).To(Equal(len(engine.OperatorPolicy(context.TODO()))))
 			})
 		})
 
@@ -82,7 +82,7 @@ var _ = Describe("policy validation", func() {
 			results := e.Results(ctx)
 
 			It("should pass all checks", func() {
-				Expect(len(results.Passed)).To(Equal(len(engine.ContainerPolicy())))
+				Expect(len(results.Passed)).To(Equal(len(engine.ContainerPolicy(context.TODO()))))
 				Expect(len(results.Errors)).To(BeZero())
 				Expect(len(results.Failed)).To(BeZero())
 			})


### PR DESCRIPTION
This gets the engine package to 100%.

Also added the context param to all functions, as these could be
called by other places of the code in the future, and the context
should come from the top-most levels.

Signed-off-by: Brad P. Crochet <brad@redhat.com>