### PR TITLE
fix bug in derived runtime config where values were not populated from parameter

### DIFF
--- a/certification/runtime/config.go
+++ b/certification/runtime/config.go
@@ -50,7 +50,7 @@ func NewConfigFrom(vcfg viper.Viper) (*Config, error) {
 	cfg.LogFile = vcfg.GetString("logfile")
 	cfg.DockerConfig = vcfg.GetString("dockerConfig")
 	cfg.Artifacts = vcfg.GetString("artifacts")
-	cfg.WriteJUnit = viper.GetBool("junit")
+	cfg.WriteJUnit = vcfg.GetBool("junit")
 	cfg.storeContainerPolicyConfiguration(vcfg)
 	cfg.storeOperatorPolicyConfiguration(vcfg)
 	return &cfg, nil
@@ -75,10 +75,10 @@ func (c *Config) storeContainerPolicyConfiguration(vcfg viper.Viper) {
 // items in viper, normalizes them, and stores them in Config.
 func (c *Config) storeOperatorPolicyConfiguration(vcfg viper.Viper) {
 	c.Kubeconfig = os.Getenv("KUBECONFIG")
-	c.Namespace = viper.GetString("namespace")
-	c.ServiceAccount = viper.GetString("serviceaccount")
-	c.ScorecardImage = viper.GetString("scorecard_image")
-	c.ScorecardWaitTime = viper.GetString("scorecard_wait_time")
-	c.Channel = viper.GetString("channel")
-	c.IndexImage = viper.GetString("indeximage")
+	c.Namespace = vcfg.GetString("namespace")
+	c.ServiceAccount = vcfg.GetString("serviceaccount")
+	c.ScorecardImage = vcfg.GetString("scorecard_image")
+	c.ScorecardWaitTime = vcfg.GetString("scorecard_wait_time")
+	c.Channel = vcfg.GetString("channel")
+	c.IndexImage = vcfg.GetString("indeximage")
 }

--- a/certification/runtime/config_test.go
+++ b/certification/runtime/config_test.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
+)
+
+var _ = Describe("Viper to Runtime Config", func() {
+	var baseViperCfg *viper.Viper
+	var expectedRuntimeCfg *Config
+	BeforeEach(func() {
+		baseViperCfg = viper.New()
+		expectedRuntimeCfg = &Config{}
+
+		baseViperCfg.Set("logfile", "logfile")
+		expectedRuntimeCfg.LogFile = "logfile"
+		baseViperCfg.Set("dockerConfig", "dockerConfig")
+		expectedRuntimeCfg.DockerConfig = "dockerConfig"
+		baseViperCfg.Set("artifacts", "artifacts")
+		expectedRuntimeCfg.Artifacts = "artifacts"
+		baseViperCfg.Set("junit", true)
+		expectedRuntimeCfg.WriteJUnit = true
+
+		baseViperCfg.Set("pyxis_api_token", "apitoken")
+		expectedRuntimeCfg.PyxisAPIToken = "apitoken"
+		baseViperCfg.Set("submit", true)
+		expectedRuntimeCfg.Submit = true
+		baseViperCfg.Set("pyxis_env", "prod")
+		expectedRuntimeCfg.PyxisHost = "catalog.redhat.com/api/containers"
+		baseViperCfg.Set("certification_project_id", "000000000000")
+		expectedRuntimeCfg.CertificationProjectID = "000000000000"
+
+		baseViperCfg.Set("namespace", "myns")
+		expectedRuntimeCfg.Namespace = "myns"
+		baseViperCfg.Set("serviceaccount", "mysa")
+		expectedRuntimeCfg.ServiceAccount = "mysa"
+		baseViperCfg.Set("scorecard_image", "myscorecardimage")
+		expectedRuntimeCfg.ScorecardImage = "myscorecardimage"
+		baseViperCfg.Set("scorecard_wait_time", "100")
+		expectedRuntimeCfg.ScorecardWaitTime = "100"
+		baseViperCfg.Set("channel", "mychannel")
+		expectedRuntimeCfg.Channel = "mychannel"
+		baseViperCfg.Set("indeximage", "myindeximage")
+		expectedRuntimeCfg.IndexImage = "myindeximage"
+	})
+
+	Context("With values in a viper config", func() {
+		It("should populate a runtime.Config with container and operator policy values", func() {
+			cfg, err := NewConfigFrom(*baseViperCfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*cfg).To(BeEquivalentTo(*expectedRuntimeCfg))
+		})
+	})
+
+	Context("With proper values, but with an opsid- prefix on the certification project ID", func() {
+		It("should properly trim the ospid- prefix and succeed", func() {
+			baseViperCfg.Set("certification_project_id", "ospid-111111111111")
+			expectedRuntimeCfg.CertificationProjectID = "111111111111"
+			cfg, err := NewConfigFrom(*baseViperCfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*cfg).To(BeEquivalentTo(*expectedRuntimeCfg))
+		})
+	})
+
+	It("should only have 20 struct keys for tests to be valid", func() {
+		// If this test fails, it means a developer has added or removed
+		// keys from runtime.Config, and so these tests may no longer be
+		// accurate in confirming that the derived configuration from viper
+		// matches.
+		keys := reflect.TypeOf(Config{}).NumField()
+		Expect(keys).To(Equal(20))
+	})
+})


### PR DESCRIPTION
In writing tests, I discovered a bug in the runtime.Config derivation where the configuration values were not being populated from the passed in parameter, but rather from the upstream viper instance. 

It probably would have looked the same at execution time because we still fully leverage the upstream viper early on in the process, but the tests called just the derivation functions and caught it. 

Should add 100% coverage for this source file.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>