### PR TITLE
Refactor operatorsdk and add some unit tests

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os/exec"
 	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	internal "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/engine"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 	containerpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/container"
 	operatorpol "github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/policy/operator"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
@@ -50,10 +52,10 @@ func initializeChecks(ctx context.Context, p policy.Policy, cfg certification.Co
 	switch p {
 	case policy.PolicyOperator:
 		return []certification.Check{
-			operatorpol.NewScorecardBasicSpecCheck(internal.NewOperatorSdkEngine(cfg.ScorecardImage()), cfg.Namespace(), cfg.ServiceAccount(), cfg.Kubeconfig(), cfg.ScorecardWaitTime()),
-			operatorpol.NewScorecardOlmSuiteCheck(internal.NewOperatorSdkEngine(cfg.ScorecardImage()), cfg.Namespace(), cfg.ServiceAccount(), cfg.Kubeconfig(), cfg.ScorecardWaitTime()),
-			operatorpol.NewDeployableByOlmCheck(internal.NewOperatorSdkEngine(cfg.ScorecardImage()), cfg.IndexImage(), cfg.DockerConfig(), cfg.Channel()),
-			operatorpol.NewValidateOperatorBundleCheck(internal.NewOperatorSdkEngine(cfg.ScorecardImage())),
+			operatorpol.NewScorecardBasicSpecCheck(operatorsdk.New(cfg.ScorecardImage(), exec.Command), cfg.Namespace(), cfg.ServiceAccount(), cfg.Kubeconfig(), cfg.ScorecardWaitTime()),
+			operatorpol.NewScorecardOlmSuiteCheck(operatorsdk.New(cfg.ScorecardImage(), exec.Command), cfg.Namespace(), cfg.ServiceAccount(), cfg.Kubeconfig(), cfg.ScorecardWaitTime()),
+			operatorpol.NewDeployableByOlmCheck(operatorsdk.New(cfg.ScorecardImage(), exec.Command), cfg.IndexImage(), cfg.DockerConfig(), cfg.Channel()),
+			operatorpol.NewValidateOperatorBundleCheck(operatorsdk.New(cfg.ScorecardImage(), exec.Command)),
 		}, nil
 	case policy.PolicyContainer:
 		return []certification.Check{

--- a/certification/internal/bundle/bundle.go
+++ b/certification/internal/bundle/bundle.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/blang/semver"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
@@ -21,9 +21,13 @@ const ocpVerV1beta1Unsupported = "4.9"
 // versionsKey is the OpenShift versions in annotations.yaml that lists the versions allowed for an operator
 const versionsKey = "com.redhat.openshift.versions"
 
-func Validate(ctx context.Context, engine cli.OperatorSdkEngine, imagePath string) (*cli.OperatorSdkBundleValidateReport, error) {
+type operatorSdk interface {
+	BundleValidate(context.Context, string, operatorsdk.OperatorSdkBundleValidateOptions) (*operatorsdk.OperatorSdkBundleValidateReport, error)
+}
+
+func Validate(ctx context.Context, operatorSdk operatorSdk, imagePath string) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
 	selector := []string{"community", "operatorhub"}
-	opts := cli.OperatorSdkBundleValidateOptions{
+	opts := operatorsdk.OperatorSdkBundleValidateOptions{
 		Selector:        selector,
 		Verbose:         true,
 		ContainerEngine: "none",
@@ -52,7 +56,7 @@ func Validate(ctx context.Context, engine cli.OperatorSdkEngine, imagePath strin
 		}
 	}
 
-	return engine.BundleValidate(imagePath, opts)
+	return operatorSdk.BundleValidate(ctx, imagePath, opts)
 }
 
 func isTarget49OrGreater(ocpLabelIndex string) bool {

--- a/certification/internal/bundle/bundle_suite_test.go
+++ b/certification/internal/bundle/bundle_suite_test.go
@@ -1,12 +1,14 @@
 package bundle
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 )
 
 func TestBundle(t *testing.T) {
@@ -14,17 +16,13 @@ func TestBundle(t *testing.T) {
 	RunSpecs(t, "Bundle Utils Suite")
 }
 
-type FakeOperatorSdkEngine struct {
-	OperatorSdkReport   cli.OperatorSdkScorecardReport
-	OperatorSdkBVReport cli.OperatorSdkBundleValidateReport
+type FakeOperatorSdk struct {
+	OperatorSdkReport   operatorsdk.OperatorSdkScorecardReport
+	OperatorSdkBVReport operatorsdk.OperatorSdkBundleValidateReport
 }
 
-func (f FakeOperatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
+func (f FakeOperatorSdk) BundleValidate(ctx context.Context, image string, opts operatorsdk.OperatorSdkBundleValidateOptions) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
 	return &f.OperatorSdkBVReport, nil
-}
-
-func (f FakeOperatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
-	return &f.OperatorSdkReport, nil
 }
 
 // In order to test some negative paths, this io.Reader will just throw an error

--- a/certification/internal/bundle/bundle_test.go
+++ b/certification/internal/bundle/bundle_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 )
 
 var _ = Describe("BundleValidateCheck", func() {
@@ -43,7 +42,7 @@ var _ = Describe("BundleValidateCheck", func() {
 	Describe("Bundle validation", func() {
 		var (
 			imageRef   certification.ImageReference
-			fakeEngine cli.OperatorSdkEngine
+			fakeEngine operatorSdk
 		)
 
 		BeforeEach(func() {
@@ -61,7 +60,7 @@ var _ = Describe("BundleValidateCheck", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			imageRef.ImageFSPath = tmpDir
-			fakeEngine = FakeOperatorSdkEngine{}
+			fakeEngine = FakeOperatorSdk{}
 		})
 
 		AfterEach(func() {

--- a/certification/internal/cli/cli.go
+++ b/certification/internal/cli/cli.go
@@ -1,1 +1,0 @@
-package cli

--- a/certification/internal/operatorsdk/operatorsdk_suite_test.go
+++ b/certification/internal/operatorsdk/operatorsdk_suite_test.go
@@ -1,0 +1,20 @@
+package operatorsdk
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestOperatorSdk(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Suite")
+}
+
+func init() {
+	log.SetFormatter(&log.TextFormatter{})
+	log.SetLevel(log.TraceLevel)
+}

--- a/certification/internal/operatorsdk/operatorsdk_test.go
+++ b/certification/internal/operatorsdk/operatorsdk_test.go
@@ -1,0 +1,181 @@
+package operatorsdk
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
+)
+
+const (
+	testStdoutValue               = `{}`
+	testBundleValidateStdoutValue = `{"passed": true, "outputs": null}`
+)
+
+var _ = Describe("OperatorSdk", func() {
+	var tmpdir string
+	BeforeEach(func() {
+		var err error
+		tmpdir, err = os.MkdirTemp("", "operatorsdk-test-artifacts-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpdir)
+		artifacts.SetDir(tmpdir)
+	})
+	When("The Scorecard result is good", func() {
+		It("should succeed", func() {
+			operatorSdk := New("foo.image", fakeExecCommandSuccess)
+			_, err := operatorSdk.Scorecard(context.TODO(), "foo.image", OperatorSdkScorecardOptions{
+				ResultFile:     "success.txt",
+				OutputFormat:   "json",
+				Selector:       []string{"selector1", "selector2"},
+				Kubeconfig:     "/my/kubeconfig",
+				Namespace:      "awesome-namespace",
+				ServiceAccount: "this-service-account",
+				Verbose:        true,
+				WaitTime:       "120m",
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+	When("The Scorecard result is a failure", func() {
+		It("should fail", func() {
+			operatorSdk := New("foo.image", fakeExecCommandFailure)
+			_, err := operatorSdk.Scorecard(context.TODO(), "foo.image", OperatorSdkScorecardOptions{
+				ResultFile:   "failure.txt",
+				OutputFormat: "text",
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	When("The Bundle Validate result is good", func() {
+		It("should succeed", func() {
+			operatorSdk := New("foo.image", fakeExecValidateCommandSuccess)
+			_, err := operatorSdk.BundleValidate(context.TODO(), "foo.image", OperatorSdkBundleValidateOptions{
+				OutputFormat:    "json",
+				LogLevel:        "debug",
+				ContainerEngine: "podman",
+				Selector:        []string{"selector1", "selector2"},
+				OptionalValues:  map[string]string{"foo": "bar"},
+				Verbose:         true,
+				WaitTime:        "120m",
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+	When("The scorecard result has an error", func() {
+		It("should return result == failed", func() {
+			operatoSdk := New("foo.image", fakeExecValidateCommandError)
+			result, err := operatoSdk.BundleValidate(context.TODO(), "foo.image", OperatorSdkBundleValidateOptions{
+				OutputFormat: "text",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Passed).To(BeFalse())
+		})
+	})
+	When("The Bundle Validate result is bad", func() {
+		It("should fail", func() {
+			operatorSdk := New("foo.image", fakeExecValidateCommandFailure)
+			_, err := operatorSdk.BundleValidate(context.TODO(), "foo.image", OperatorSdkBundleValidateOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+// These will be called when the inception occurs.
+// If the GO_TEST_PROCESS envvar is not "1", which would
+// be the case on the full testing run, it just returns.
+// If it is set, then that means we are inside the
+// exec call, and can therefore print whatever we want
+// to stdout, stderr, and set the return value appropriately.
+// When it exits, it goes back to the original test exec.
+func TestShellProcessSuccess(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stdout, testStdoutValue)
+	os.Exit(0)
+}
+
+func TestShellProcessFail(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "FATA")
+	os.Exit(1)
+}
+
+func TestBundleValidateProcessSuccess(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stdout, testBundleValidateStdoutValue)
+	os.Exit(0)
+}
+
+func TestBundleValidateProcessError(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stdout, "FATA")
+	os.Exit(0)
+}
+
+func TestBundleValidateProcessFail(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "FATA")
+	os.Exit(1)
+}
+
+// What's happening here?
+//
+// These are the cmdContexts that are being subbed in instead of exec.Command
+// So, when the SUT calls cmdContext(...) it will use this instead.
+// It replaces the command that is passed in with the test args, plus the rest
+// of the original command. It then execs the test binary with these args.
+// The -test.run arg is will exec JUST that function from above.
+func fakeExecCommandSuccess(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellProcessSuccess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+func fakeExecCommandFailure(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellProcessFail", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+func fakeExecValidateCommandSuccess(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestBundleValidateProcessSuccess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+func fakeExecValidateCommandError(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestBundleValidateProcessError", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+func fakeExecValidateCommandFailure(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestBundleValidateProcessFail", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}

--- a/certification/internal/operatorsdk/types.go
+++ b/certification/internal/operatorsdk/types.go
@@ -1,4 +1,4 @@
-package cli
+package operatorsdk
 
 type OperatorSdkScorecardOptions struct {
 	OutputFormat   string
@@ -51,9 +51,4 @@ type OperatorSdkBundleValidateReport struct {
 type OperatorSdkBundleValidateOutput struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
-}
-
-type OperatorSdkEngine interface {
-	Scorecard(image string, opts OperatorSdkScorecardOptions) (*OperatorSdkScorecardReport, error)
-	BundleValidate(image string, opts OperatorSdkBundleValidateOptions) (*OperatorSdkBundleValidateReport, error)
 }

--- a/certification/internal/policy/operator/deployable_by_olm.go
+++ b/certification/internal/policy/operator/deployable_by_olm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/bundle"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/openshift"
 
 	log "github.com/sirupsen/logrus"
@@ -49,11 +48,11 @@ type DeployableByOlmCheck struct {
 	// channel is optional. If empty, we will introspect.
 	channel string
 
-	OperatorSdkEngine cli.OperatorSdkEngine
-	openshiftClient   openshift.Client
-	client            crclient.Client
-	csvReady          bool
-	validImages       bool
+	OperatorSdk     operatorSdk
+	openshiftClient openshift.Client
+	client          crclient.Client
+	csvReady        bool
+	validImages     bool
 }
 
 func (p *DeployableByOlmCheck) initClient() error {
@@ -92,23 +91,23 @@ func (p *DeployableByOlmCheck) initOpenShifeEngine() error {
 // in scope are public. An empty channel value implies that the check should
 // introspect the channel from the bundle. indexImage is required.
 func NewDeployableByOlmCheck(
-	operatorSdkEngine *cli.OperatorSdkEngine,
+	operatorSdk operatorSdk,
 	indexImage,
 	dockerConfig,
 	channel string,
 ) *DeployableByOlmCheck {
 	return &DeployableByOlmCheck{
-		OperatorSdkEngine: *operatorSdkEngine,
-		dockerConfig:      dockerConfig,
-		indexImage:        indexImage,
-		channel:           channel,
+		OperatorSdk:  operatorSdk,
+		dockerConfig: dockerConfig,
+		indexImage:   indexImage,
+		channel:      channel,
 	}
 }
 
 func (p *DeployableByOlmCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
 	p.initClient()
 	p.initOpenShifeEngine()
-	if report, err := bundle.Validate(ctx, p.OperatorSdkEngine, bundleRef.ImageFSPath); err != nil || !report.Passed {
+	if report, err := bundle.Validate(ctx, p.OperatorSdk, bundleRef.ImageFSPath); err != nil || !report.Passed {
 		return false, fmt.Errorf("%v", err)
 	}
 

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/openshift"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 )
 
 var _ = Describe("DeployableByOLMCheck", func() {
 	var (
 		deployableByOLMCheck DeployableByOlmCheck
-		fakeEngine           cli.OperatorSdkEngine
+		fakeEngine           operatorSdk
 		imageRef             certification.ImageReference
 		tmpDockerDir         string
 		client               crclient.Client
@@ -93,17 +94,17 @@ var _ = Describe("DeployableByOLMCheck", func() {
 		imageRef.ImageInfo = &fakeImage
 		imageRef.ImageFSPath = tmpDir
 
-		report := cli.OperatorSdkBundleValidateReport{
+		report := operatorsdk.OperatorSdkBundleValidateReport{
 			Passed:  true,
-			Outputs: []cli.OperatorSdkBundleValidateOutput{},
+			Outputs: []operatorsdk.OperatorSdkBundleValidateOutput{},
 		}
-		fakeEngine = FakeOperatorSdkEngine{
+		fakeEngine = FakeOperatorSdk{
 			OperatorSdkBVReport: report,
 		}
 
 		now := metav1.Now()
 		og.Status.LastUpdated = &now
-		deployableByOLMCheck = *NewDeployableByOlmCheck(&fakeEngine, "test_indeximage", "", "")
+		deployableByOLMCheck = *NewDeployableByOlmCheck(fakeEngine, "test_indeximage", "", "")
 		scheme := apiruntime.NewScheme()
 		Expect(openshift.AddSchemes(scheme)).To(Succeed())
 		client = fake.NewClientBuilder().

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 	imagestreamv1 "github.com/openshift/api/image/v1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,36 +26,36 @@ func init() {
 	log.SetLevel(log.TraceLevel)
 }
 
-type FakeOperatorSdkEngine struct {
-	OperatorSdkReport   cli.OperatorSdkScorecardReport
-	OperatorSdkBVReport cli.OperatorSdkBundleValidateReport
+type FakeOperatorSdk struct {
+	OperatorSdkReport   operatorsdk.OperatorSdkScorecardReport
+	OperatorSdkBVReport operatorsdk.OperatorSdkBundleValidateReport
 }
 
-func (f FakeOperatorSdkEngine) BundleValidate(image string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
+func (f FakeOperatorSdk) BundleValidate(ctx context.Context, image string, opts operatorsdk.OperatorSdkBundleValidateOptions) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
 	return &f.OperatorSdkBVReport, nil
 }
 
-func (f FakeOperatorSdkEngine) Scorecard(image string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
+func (f FakeOperatorSdk) Scorecard(ctx context.Context, image string, opts operatorsdk.OperatorSdkScorecardOptions) (*operatorsdk.OperatorSdkScorecardReport, error) {
 	return &f.OperatorSdkReport, nil
 }
 
-type BadOperatorSdkEngine struct{}
+type BadOperatorSdk struct{}
 
-func (bose BadOperatorSdkEngine) Scorecard(bundleImage string, opts cli.OperatorSdkScorecardOptions) (*cli.OperatorSdkScorecardReport, error) {
-	operatorSdkReport := cli.OperatorSdkScorecardReport{
+func (bose BadOperatorSdk) Scorecard(ctx context.Context, bundleImage string, opts operatorsdk.OperatorSdkScorecardOptions) (*operatorsdk.OperatorSdkScorecardReport, error) {
+	operatorSdkReport := operatorsdk.OperatorSdkScorecardReport{
 		Stdout: "Bad Stdout",
 		Stderr: "Bad Stderr",
-		Items:  []cli.OperatorSdkScorecardItem{},
+		Items:  []operatorsdk.OperatorSdkScorecardItem{},
 	}
 	return &operatorSdkReport, errors.New("the Operator Sdk Scorecard has failed")
 }
 
-func (bose BadOperatorSdkEngine) BundleValidate(bundleImage string, opts cli.OperatorSdkBundleValidateOptions) (*cli.OperatorSdkBundleValidateReport, error) {
-	operatorSdkReport := cli.OperatorSdkBundleValidateReport{
+func (bose BadOperatorSdk) BundleValidate(ctx context.Context, bundleImage string, opts operatorsdk.OperatorSdkBundleValidateOptions) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
+	operatorSdkReport := operatorsdk.OperatorSdkBundleValidateReport{
 		Stdout:  "Bad Stdout",
 		Stderr:  "Bad Stderr",
 		Passed:  false,
-		Outputs: []cli.OperatorSdkBundleValidateOutput{},
+		Outputs: []operatorsdk.OperatorSdkBundleValidateOutput{},
 	}
 	return &operatorSdkReport, errors.New("the Operator Sdk Bundle Validate has failed")
 }

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,14 +18,14 @@ type ScorecardBasicSpecCheck struct {
 
 const scorecardBasicCheckResult string = "operator_bundle_scorecard_BasicSpecCheck.json"
 
-func NewScorecardBasicSpecCheck(operatorSdkEngine *cli.OperatorSdkEngine, ns, sa, kubeconfig, waittime string) *ScorecardBasicSpecCheck {
+func NewScorecardBasicSpecCheck(operatorSdk operatorSdk, ns, sa, kubeconfig, waittime string) *ScorecardBasicSpecCheck {
 	return &ScorecardBasicSpecCheck{
 		scorecardCheck: scorecardCheck{
-			OperatorSdkEngine: *operatorSdkEngine,
-			namespace:         ns,
-			serviceAccount:    sa,
-			kubeconfig:        kubeconfig,
-			waitTime:          waittime,
+			OperatorSdk:    operatorSdk,
+			namespace:      ns,
+			serviceAccount: sa,
+			kubeconfig:     kubeconfig,
+			waitTime:       waittime,
 		},
 		fatalError: false,
 	}

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -6,13 +6,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 )
 
 var _ = Describe("ScorecardBasicCheck", func() {
 	var (
 		scorecardBasicCheck ScorecardBasicSpecCheck
-		fakeEngine          cli.OperatorSdkEngine
+		fakeEngine          operatorSdk
 	)
 
 	BeforeEach(func() {
@@ -48,10 +48,10 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		  }
 		  `
 		stderr := ""
-		items := []cli.OperatorSdkScorecardItem{
+		items := []operatorsdk.OperatorSdkScorecardItem{
 			{
-				Status: cli.OperatorSdkScorecardStatus{
-					Results: []cli.OperatorSdkScorecardResult{
+				Status: operatorsdk.OperatorSdkScorecardStatus{
+					Results: []operatorsdk.OperatorSdkScorecardResult{
 						{
 							Name:  "olm-bundle-validation",
 							Log:   "log",
@@ -61,15 +61,15 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				},
 			},
 		}
-		report := cli.OperatorSdkScorecardReport{
+		report := operatorsdk.OperatorSdkScorecardReport{
 			Stdout: stdout,
 			Stderr: stderr,
 			Items:  items,
 		}
-		fakeEngine = FakeOperatorSdkEngine{
+		fakeEngine = FakeOperatorSdk{
 			OperatorSdkReport: report,
 		}
-		scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine, "myns", "mysa", "", "20")
+		scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
 	})
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {
@@ -81,10 +81,10 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		})
 		Context("When Operator Bundle Scorecard Basic Check has a fail", func() {
 			BeforeEach(func() {
-				engine := fakeEngine.(FakeOperatorSdkEngine)
+				engine := fakeEngine.(FakeOperatorSdk)
 				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
 				fakeEngine = engine
-				scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine, "myns", "mysa", "", "20")
+				scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardBasicCheck.Validate(context.TODO(), certification.ImageReference{ImageURI: "dummy/image"})
@@ -93,10 +93,10 @@ var _ = Describe("ScorecardBasicCheck", func() {
 			})
 		})
 	})
-	Describe("Checking that OperatorSdkEngine errors are handled correctly", func() {
+	Describe("Checking that OperatorSdk errors are handled correctly", func() {
 		BeforeEach(func() {
-			fakeEngine = BadOperatorSdkEngine{}
-			scorecardBasicCheck = *NewScorecardBasicSpecCheck(&fakeEngine, "myns", "mysa", "", "20")
+			fakeEngine = BadOperatorSdk{}
+			scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {

--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 	log "github.com/sirupsen/logrus"
 )
 
 type scorecardCheck struct {
-	OperatorSdkEngine cli.OperatorSdkEngine
+	OperatorSdk operatorSdk
 
 	namespace      string
 	serviceAccount string
@@ -18,7 +18,7 @@ type scorecardCheck struct {
 	waitTime       string
 }
 
-func (p *scorecardCheck) validate(ctx context.Context, items []cli.OperatorSdkScorecardItem) (bool, error) {
+func (p *scorecardCheck) validate(ctx context.Context, items []operatorsdk.OperatorSdkScorecardItem) (bool, error) {
 	foundTestFailed := false
 	var err error
 
@@ -36,8 +36,8 @@ func (p *scorecardCheck) validate(ctx context.Context, items []cli.OperatorSdkSc
 	return !foundTestFailed, err
 }
 
-func (p *scorecardCheck) getDataToValidate(ctx context.Context, bundleImage string, selector []string, resultFile string) (*cli.OperatorSdkScorecardReport, error) {
-	opts := cli.OperatorSdkScorecardOptions{
+func (p *scorecardCheck) getDataToValidate(ctx context.Context, bundleImage string, selector []string, resultFile string) (*operatorsdk.OperatorSdkScorecardReport, error) {
+	opts := operatorsdk.OperatorSdkScorecardOptions{
 		OutputFormat:   "json",
 		Selector:       selector,
 		ResultFile:     resultFile,
@@ -47,7 +47,7 @@ func (p *scorecardCheck) getDataToValidate(ctx context.Context, bundleImage stri
 		Verbose:        true,
 		WaitTime:       fmt.Sprintf("%ss", p.waitTime),
 	}
-	result, err := p.OperatorSdkEngine.Scorecard(bundleImage, opts)
+	result, err := p.OperatorSdk.Scorecard(ctx, bundleImage, opts)
 	if err != nil {
 		return result, fmt.Errorf("%v", err)
 	}

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,14 +18,14 @@ type ScorecardOlmSuiteCheck struct {
 
 const scorecardOlmSuiteResult string = "operator_bundle_scorecard_OlmSuiteCheck.json"
 
-func NewScorecardOlmSuiteCheck(operatorSdkEngine *cli.OperatorSdkEngine, ns, sa, kubeconfig, waittime string) *ScorecardOlmSuiteCheck {
+func NewScorecardOlmSuiteCheck(operatorSdk operatorSdk, ns, sa, kubeconfig, waittime string) *ScorecardOlmSuiteCheck {
 	return &ScorecardOlmSuiteCheck{
 		scorecardCheck: scorecardCheck{
-			OperatorSdkEngine: *operatorSdkEngine,
-			namespace:         ns,
-			serviceAccount:    sa,
-			kubeconfig:        kubeconfig,
-			waitTime:          waittime,
+			OperatorSdk:    operatorSdk,
+			namespace:      ns,
+			serviceAccount: sa,
+			kubeconfig:     kubeconfig,
+			waitTime:       waittime,
 		},
 		fatalError: false,
 	}

--- a/certification/internal/policy/operator/types.go
+++ b/certification/internal/policy/operator/types.go
@@ -1,0 +1,12 @@
+package operator
+
+import (
+	"context"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
+)
+
+type operatorSdk interface {
+	BundleValidate(context.Context, string, operatorsdk.OperatorSdkBundleValidateOptions) (*operatorsdk.OperatorSdkBundleValidateReport, error)
+	Scorecard(context.Context, string, operatorsdk.OperatorSdkScorecardOptions) (*operatorsdk.OperatorSdkScorecardReport, error)
+}

--- a/certification/internal/policy/operator/validate_operator_bundle.go
+++ b/certification/internal/policy/operator/validate_operator_bundle.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/bundle"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 	log "github.com/sirupsen/logrus"
 )
 
 // ValidateOperatorBundleCheck evaluates the image and ensures that it passes bundle validation
 // as executed by `operator-sdk bundle validate`
 type ValidateOperatorBundleCheck struct {
-	OperatorSdkEngine cli.OperatorSdkEngine
+	OperatorSdk operatorSdk
 }
 
-func NewValidateOperatorBundleCheck(operatorSdkEngine *cli.OperatorSdkEngine) *ValidateOperatorBundleCheck {
+func NewValidateOperatorBundleCheck(operatorSdk operatorSdk) *ValidateOperatorBundleCheck {
 	return &ValidateOperatorBundleCheck{
-		OperatorSdkEngine: *operatorSdkEngine,
+		OperatorSdk: operatorSdk,
 	}
 }
 
@@ -33,11 +33,11 @@ func (p ValidateOperatorBundleCheck) Validate(ctx context.Context, bundleRef cer
 	return p.validate(ctx, report)
 }
 
-func (p ValidateOperatorBundleCheck) getDataToValidate(ctx context.Context, imagePath string) (*cli.OperatorSdkBundleValidateReport, error) {
-	return bundle.Validate(ctx, p.OperatorSdkEngine, imagePath)
+func (p ValidateOperatorBundleCheck) getDataToValidate(ctx context.Context, imagePath string) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
+	return bundle.Validate(ctx, p.OperatorSdk, imagePath)
 }
 
-func (p ValidateOperatorBundleCheck) validate(ctx context.Context, report *cli.OperatorSdkBundleValidateReport) (bool, error) {
+func (p ValidateOperatorBundleCheck) validate(ctx context.Context, report *operatorsdk.OperatorSdkBundleValidateReport) (bool, error) {
 	if !report.Passed || len(report.Outputs) > 0 {
 		for _, output := range report.Outputs {
 			var logFn func(...interface{})

--- a/cmd/check_operator_test.go
+++ b/cmd/check_operator_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/engine"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 	"github.com/spf13/viper"
 )
@@ -119,11 +120,14 @@ var _ = Describe("Check Operator", func() {
 
 		Context("with an invalid policy definition", func() {
 			It("should return the container policy engine anyway", func() {
+				cfg.Policy = "badpolicy"
+				beforeCfg := *cfg
 				runner, err := newCheckOperatorRunner(context.TODO(), cfg)
 				Expect(err).ToNot(HaveOccurred())
 
-				expectedEngine, err := engine.NewForConfig(context.TODO(), cfg.ReadOnly())
-				Expect(runner.eng).To(BeEquivalentTo(expectedEngine))
+				_, err = engine.NewForConfig(context.TODO(), cfg.ReadOnly())
+				Expect(runner.cfg.Policy).ToNot(Equal(beforeCfg.Policy))
+				Expect(runner.cfg.Policy).To(Equal(policy.PolicyOperator))
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
This was completely untested before. Now, the new operatorsdk
package has 90+% coverage. For the most part, this is a somewhat
transparent change.

The change also removes any reference to 'OperatorSdkEngine'. It
should never have been named that.

Signed-off-by: Brad P. Crochet <brad@redhat.com>