### PR TITLE
add a few tests for the modified files check

### DIFF
--- a/certification/types.go
+++ b/certification/types.go
@@ -2,7 +2,7 @@ package certification
 
 import v1 "github.com/google/go-containerregistry/pkg/v1"
 
-// ImasgeReference holds all things image-related
+// ImageReference holds all things image-related
 type ImageReference struct {
 	ImageURI        string
 	ImageFSPath     string


### PR DESCRIPTION
This partitions a few more things in the hasModifiedFiles check logic to add some tests for them. There are other elements that need refactoring to be able to accurately test.

One notable change is the logic that drops the first layer if it's empty - this logic used to accept a `[]v1.Layer` interface from the go-containerregistry library. The problem with this is that it's not possible to pass in a slice of a concrete type that implements the interface because the compiler does not assert those two be the same (e.g. the implementation does not implement the interface). See the example below[1]. Kind of a unique behavior to go. Either way, we only needed that information for logging, so I moved the logging outside of the function and instead just report if we've shifted. I've added tests for this as well.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>

[1] https://go.dev/play/p/Tl6RVyz6uhq