### PR TITLE
Add tests confirming check metadata is never empty

### DIFF
--- a/certification/internal/policy/container/base_on_ubi_test.go
+++ b/certification/internal/policy/container/base_on_ubi_test.go
@@ -92,5 +92,25 @@ var _ = Describe("BaseOnUBI", func() {
 				Expect(ok).To(BeFalse())
 			})
 		})
+
+		Context("When checking metadata", func() {
+			Context("The check name should not be empty", func() {
+				Expect(basedOnUbiCheck.Name()).ToNot(BeEmpty())
+			})
+
+			Context("The metadata keys should not be empty", func() {
+				meta := basedOnUbiCheck.Metadata()
+				Expect(meta.CheckURL).ToNot(BeEmpty())
+				Expect(meta.Description).ToNot(BeEmpty())
+				Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+				// Level is optional.
+			})
+
+			Context("The help text should not be empty", func() {
+				help := basedOnUbiCheck.Help()
+				Expect(help.Message).ToNot(BeEmpty())
+				Expect(help.Suggestion).ToNot(BeEmpty())
+			})
+		})
 	})
 })

--- a/certification/internal/policy/container/has_license_test.go
+++ b/certification/internal/policy/container/has_license_test.go
@@ -75,5 +75,25 @@ var _ = Describe("HasLicense", func() {
 			err := os.RemoveAll(imgRef.ImageFSPath)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		Context("When checking metadata", func() {
+			Context("The check name should not be empty", func() {
+				Expect(HasLicense.Name()).ToNot(BeEmpty())
+			})
+
+			Context("The metadata keys should not be empty", func() {
+				meta := HasLicense.Metadata()
+				Expect(meta.CheckURL).ToNot(BeEmpty())
+				Expect(meta.Description).ToNot(BeEmpty())
+				Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+				// Level is optional.
+			})
+
+			Context("The help text should not be empty", func() {
+				help := HasLicense.Help()
+				Expect(help.Message).ToNot(BeEmpty())
+				Expect(help.Suggestion).ToNot(BeEmpty())
+			})
+		})
 	})
 })

--- a/certification/internal/policy/container/has_modifed_files_test.go
+++ b/certification/internal/policy/container/has_modifed_files_test.go
@@ -35,6 +35,27 @@ var _ = Describe("HasModifiedFiles", func() {
 			},
 		}
 	})
+
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(HasModifiedFiles.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := HasModifiedFiles.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := HasModifiedFiles.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Checking if it has any modified RPM files", func() {
 		Context("When there are no modified RPM files found", func() {
 			It("should pass validate", func() {

--- a/certification/internal/policy/container/has_prohibited_packages_test.go
+++ b/certification/internal/policy/container/has_prohibited_packages_test.go
@@ -21,6 +21,27 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 			"prohibitted",
 		}
 	})
+
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(HasNoProhibitedPackages.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := HasNoProhibitedPackages.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := HasNoProhibitedPackages.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Checking if it has an prohibited packages", func() {
 		Context("When there are no prohibited packages found", func() {
 			It("should pass validate", func() {

--- a/certification/internal/policy/container/has_required_labels_test.go
+++ b/certification/internal/policy/container/has_required_labels_test.go
@@ -56,6 +56,26 @@ var _ = Describe("HasRequiredLabels", func() {
 		imageRef.ImageInfo = &fakeImage
 	})
 
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(hasRequiredLabelsCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := hasRequiredLabelsCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := hasRequiredLabelsCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Checking for required labels", func() {
 		Context("When it has required labels", func() {
 			It("should pass Validate", func() {

--- a/certification/internal/policy/container/has_unique_tag_test.go
+++ b/certification/internal/policy/container/has_unique_tag_test.go
@@ -45,6 +45,27 @@ var _ = Describe("UniqueTag", func() {
 		err = crane.Tag(dst, "unique-tag")
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(hasUniqueTagCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := hasUniqueTagCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := hasUniqueTagCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Checking for unique tags", func() {
 		Context("When it has tags other than latest", func() {
 			It("should pass Validate", func() {

--- a/certification/internal/policy/container/max_layers_test.go
+++ b/certification/internal/policy/container/max_layers_test.go
@@ -39,6 +39,26 @@ var _ = Describe("LessThanMaxLayers", func() {
 		imgRef.ImageInfo = &fakeImage
 	})
 
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(maxLayersCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := maxLayersCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := maxLayersCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Checking for less than max layers", func() {
 		Context("When it has fewer layers than max", func() {
 			It("should pass Validate", func() {

--- a/certification/internal/policy/container/runs_as_nonroot_test.go
+++ b/certification/internal/policy/container/runs_as_nonroot_test.go
@@ -47,6 +47,26 @@ var _ = Describe("RunAsNonRoot", func() {
 		imageRef.ImageInfo = &fakeImage
 	})
 
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(runAsNonRoot.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := runAsNonRoot.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := runAsNonRoot.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Checking manifest user is not root", func() {
 		Context("When manifest user is not root", func() {
 			It("should pass Validate", func() {

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -119,6 +119,27 @@ var _ = Describe("DeployableByOLMCheck", func() {
 	AfterEach(func() {
 		artifacts.Reset()
 	})
+
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(deployableByOLMCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := deployableByOLMCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := deployableByOLMCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("When deploying an operator using OLM", func() {
 		Context("When CSV has been created successfully", func() {
 			It("Should pass Validate", func() {

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -71,6 +71,27 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		}
 		scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
 	})
+
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(scorecardBasicCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := scorecardBasicCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := scorecardBasicCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {
 			It("Should pass Validate", func() {

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -71,6 +71,27 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		}
 		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", "", "20")
 	})
+
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(scorecardOlmSuiteCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := scorecardOlmSuiteCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := scorecardOlmSuiteCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {
 			It("Should pass Validate", func() {

--- a/certification/internal/policy/operator/validate_operator_bundle_test.go
+++ b/certification/internal/policy/operator/validate_operator_bundle_test.go
@@ -58,6 +58,26 @@ var _ = Describe("BundleValidateCheck", func() {
 
 		bundleValidateCheck = *NewValidateOperatorBundleCheck(fakeEngine)
 	})
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(bundleValidateCheck.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := bundleValidateCheck.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := bundleValidateCheck.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Operator Bundle Validate", func() {
 		Context("When Operator Bundle Validate passes", func() {
 			It("Should pass Validate", func() {


### PR DESCRIPTION
These functions are red in test coverage, and generally that's because they don't really have any logic to them... but we should at least confirm that they're not empty, so these tests confirm that the values returned are never empty.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>