### PR TITLE
Extract the metadata tests to a separate function

### DIFF
--- a/certification/internal/policy/container/base_on_ubi_test.go
+++ b/certification/internal/policy/container/base_on_ubi_test.go
@@ -93,24 +93,6 @@ var _ = Describe("BaseOnUBI", func() {
 			})
 		})
 
-		Context("When checking metadata", func() {
-			Context("The check name should not be empty", func() {
-				Expect(basedOnUbiCheck.Name()).ToNot(BeEmpty())
-			})
-
-			Context("The metadata keys should not be empty", func() {
-				meta := basedOnUbiCheck.Metadata()
-				Expect(meta.CheckURL).ToNot(BeEmpty())
-				Expect(meta.Description).ToNot(BeEmpty())
-				Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-				// Level is optional.
-			})
-
-			Context("The help text should not be empty", func() {
-				help := basedOnUbiCheck.Help()
-				Expect(help.Message).ToNot(BeEmpty())
-				Expect(help.Suggestion).ToNot(BeEmpty())
-			})
-		})
+		AssertMetaData(&basedOnUbiCheck)
 	})
 })

--- a/certification/internal/policy/container/container_suite_test.go
+++ b/certification/internal/policy/container/container_suite_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -45,4 +46,26 @@ func (fl FakeLayer) Size() (int64, error) {
 
 func (fl FakeLayer) MediaType() (types.MediaType, error) {
 	return "mediatype", nil
+}
+
+var AssertMetaData = func(check certification.Check) {
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(check.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := check.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := check.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
 }

--- a/certification/internal/policy/container/has_license_test.go
+++ b/certification/internal/policy/container/has_license_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 var _ = Describe("HasLicense", func() {
-	var HasLicense HasLicenseCheck
+	var hasLicense HasLicenseCheck
 
 	Describe("Checking if licenses can be found", func() {
 		var imgRef certification.ImageReference
@@ -35,7 +35,7 @@ var _ = Describe("HasLicense", func() {
 		})
 		Context("When license(s) are found", func() {
 			It("Should pass Validate", func() {
-				ok, err := HasLicense.Validate(context.TODO(), imgRef)
+				ok, err := hasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -45,7 +45,7 @@ var _ = Describe("HasLicense", func() {
 				imgRef.ImageFSPath = "/invalid"
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate(context.TODO(), imgRef)
+				ok, err := hasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -56,7 +56,7 @@ var _ = Describe("HasLicense", func() {
 				os.Remove(filepath.Join(imgRef.ImageFSPath, licenses, emptyLicense))
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate(context.TODO(), imgRef)
+				ok, err := hasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -66,7 +66,7 @@ var _ = Describe("HasLicense", func() {
 				os.Remove(filepath.Join(imgRef.ImageFSPath, licenses, validLicense))
 			})
 			It("Should not pass Validate", func() {
-				ok, err := HasLicense.Validate(context.TODO(), imgRef)
+				ok, err := hasLicense.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -76,24 +76,6 @@ var _ = Describe("HasLicense", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Context("When checking metadata", func() {
-			Context("The check name should not be empty", func() {
-				Expect(HasLicense.Name()).ToNot(BeEmpty())
-			})
-
-			Context("The metadata keys should not be empty", func() {
-				meta := HasLicense.Metadata()
-				Expect(meta.CheckURL).ToNot(BeEmpty())
-				Expect(meta.Description).ToNot(BeEmpty())
-				Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-				// Level is optional.
-			})
-
-			Context("The help text should not be empty", func() {
-				help := HasLicense.Help()
-				Expect(help.Message).ToNot(BeEmpty())
-				Expect(help.Suggestion).ToNot(BeEmpty())
-			})
-		})
+		AssertMetaData(&hasLicense)
 	})
 })

--- a/certification/internal/policy/container/has_modifed_files_test.go
+++ b/certification/internal/policy/container/has_modifed_files_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("HasModifiedFiles", func() {
 	var (
-		HasModifiedFiles HasModifiedFilesCheck
+		hasModifiedFiles HasModifiedFilesCheck
 		pkgList          packageFilesRef
 	)
 
@@ -41,30 +41,10 @@ var _ = Describe("HasModifiedFiles", func() {
 		}
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(HasModifiedFiles.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := HasModifiedFiles.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := HasModifiedFiles.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
-
 	Describe("Checking if it has any modified RPM files", func() {
 		Context("When there are no modified RPM files found", func() {
 			It("should pass validate", func() {
-				ok, err := HasModifiedFiles.validate(&pkgList)
+				ok, err := hasModifiedFiles.validate(&pkgList)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -76,7 +56,7 @@ var _ = Describe("HasModifiedFiles", func() {
 				pkgs.LayerFiles[1] = append(pkgs.LayerFiles[1], "this")
 			})
 			It("should not pass Validate", func() {
-				ok, err := HasModifiedFiles.validate(&pkgs)
+				ok, err := hasModifiedFiles.validate(&pkgs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -110,7 +90,7 @@ var _ = Describe("HasModifiedFiles", func() {
 			}
 		})
 		It("should contain all files installed by the package according to its metadata", func() {
-			files, err := HasModifiedFiles.getInstalledFilesFor(goodPkgList)
+			files, err := hasModifiedFiles.getInstalledFilesFor(goodPkgList)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, ok := files[path.Join(dirname, basename)]
@@ -118,7 +98,7 @@ var _ = Describe("HasModifiedFiles", func() {
 		})
 
 		It("should fail if the rpm is invalid", func() {
-			_, err := HasModifiedFiles.getInstalledFilesFor(badPkgList)
+			_, err := hasModifiedFiles.getInstalledFilesFor(badPkgList)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -133,13 +113,13 @@ var _ = Describe("HasModifiedFiles", func() {
 		})
 		It("should shift over to the next layer if the first layer is empty", func() {
 			files[0] = []string{}
-			shiftedFiles, shifted := HasModifiedFiles.dropFirstLayerIfEmpty(files)
+			shiftedFiles, shifted := hasModifiedFiles.dropFirstLayerIfEmpty(files)
 			Expect(shiftedFiles).To(BeEquivalentTo(files[1:]))
 			Expect(shifted).To(BeTrue())
 		})
 
 		It("should start at the first layer if it's not empty", func() {
-			unshiftedFiles, shifted := HasModifiedFiles.dropFirstLayerIfEmpty(files)
+			unshiftedFiles, shifted := hasModifiedFiles.dropFirstLayerIfEmpty(files)
 			Expect(unshiftedFiles).To(BeEquivalentTo(files))
 			Expect(shifted).To(BeFalse())
 		})
@@ -147,9 +127,11 @@ var _ = Describe("HasModifiedFiles", func() {
 
 	Context("When calling the top level Validate", func() {
 		It("should fail with an invalid ImageReference", func() {
-			passed, err := HasModifiedFiles.Validate(context.TODO(), certification.ImageReference{})
+			passed, err := hasModifiedFiles.Validate(context.TODO(), certification.ImageReference{})
 			Expect(err).To(HaveOccurred())
 			Expect(passed).To(BeFalse())
 		})
 	})
+
+	AssertMetaData(&hasModifiedFiles)
 })

--- a/certification/internal/policy/container/has_prohibited_packages_test.go
+++ b/certification/internal/policy/container/has_prohibited_packages_test.go
@@ -9,7 +9,7 @@ import (
 
 var _ = Describe("HasNoProhibitedPackages", func() {
 	var (
-		HasNoProhibitedPackages HasNoProhibitedPackagesCheck
+		hasNoProhibitedPackages HasNoProhibitedPackagesCheck
 		pkgList                 []string
 	)
 
@@ -22,30 +22,12 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 		}
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(HasNoProhibitedPackages.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := HasNoProhibitedPackages.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := HasNoProhibitedPackages.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
+	AssertMetaData(&hasNoProhibitedPackages)
 
 	Describe("Checking if it has an prohibited packages", func() {
 		Context("When there are no prohibited packages found", func() {
 			It("should pass validate", func() {
-				ok, err := HasNoProhibitedPackages.validate(context.TODO(), pkgList)
+				ok, err := hasNoProhibitedPackages.validate(context.TODO(), pkgList)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -56,7 +38,7 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 				pkgs = append(pkgList, "grub")
 			})
 			It("should not pass Validate", func() {
-				ok, err := HasNoProhibitedPackages.validate(context.TODO(), pkgs)
+				ok, err := hasNoProhibitedPackages.validate(context.TODO(), pkgs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -67,7 +49,7 @@ var _ = Describe("HasNoProhibitedPackages", func() {
 				pkgs = append(pkgList, "kpatch2121")
 			})
 			It("should not pass Validate", func() {
-				ok, err := HasNoProhibitedPackages.validate(context.TODO(), pkgs)
+				ok, err := hasNoProhibitedPackages.validate(context.TODO(), pkgs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})

--- a/certification/internal/policy/container/has_required_labels_test.go
+++ b/certification/internal/policy/container/has_required_labels_test.go
@@ -56,26 +56,6 @@ var _ = Describe("HasRequiredLabels", func() {
 		imageRef.ImageInfo = &fakeImage
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(hasRequiredLabelsCheck.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := hasRequiredLabelsCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := hasRequiredLabelsCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
-
 	Describe("Checking for required labels", func() {
 		Context("When it has required labels", func() {
 			It("should pass Validate", func() {
@@ -98,4 +78,6 @@ var _ = Describe("HasRequiredLabels", func() {
 			})
 		})
 	})
+
+	AssertMetaData(&hasRequiredLabelsCheck)
 })

--- a/certification/internal/policy/container/has_unique_tag_test.go
+++ b/certification/internal/policy/container/has_unique_tag_test.go
@@ -46,26 +46,6 @@ var _ = Describe("UniqueTag", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(hasUniqueTagCheck.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := hasUniqueTagCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := hasUniqueTagCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
-
 	Describe("Checking for unique tags", func() {
 		Context("When it has tags other than latest", func() {
 			It("should pass Validate", func() {
@@ -82,6 +62,8 @@ var _ = Describe("UniqueTag", func() {
 			})
 		})
 	})
+
+	AssertMetaData(&hasUniqueTagCheck)
 })
 
 func validImageTags() []string {

--- a/certification/internal/policy/container/max_layers_test.go
+++ b/certification/internal/policy/container/max_layers_test.go
@@ -39,26 +39,6 @@ var _ = Describe("LessThanMaxLayers", func() {
 		imgRef.ImageInfo = &fakeImage
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(maxLayersCheck.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := maxLayersCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := maxLayersCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
-
 	Describe("Checking for less than max layers", func() {
 		Context("When it has fewer layers than max", func() {
 			It("should pass Validate", func() {
@@ -81,4 +61,6 @@ var _ = Describe("LessThanMaxLayers", func() {
 			})
 		})
 	})
+
+	AssertMetaData(&maxLayersCheck)
 })

--- a/certification/internal/policy/container/runs_as_nonroot_test.go
+++ b/certification/internal/policy/container/runs_as_nonroot_test.go
@@ -47,26 +47,6 @@ var _ = Describe("RunAsNonRoot", func() {
 		imageRef.ImageInfo = &fakeImage
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(runAsNonRoot.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := runAsNonRoot.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := runAsNonRoot.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
-
 	Describe("Checking manifest user is not root", func() {
 		Context("When manifest user is not root", func() {
 			It("should pass Validate", func() {
@@ -117,4 +97,6 @@ var _ = Describe("RunAsNonRoot", func() {
 			})
 		})
 	})
+
+	AssertMetaData(&runAsNonRoot)
 })

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -120,26 +120,6 @@ var _ = Describe("DeployableByOLMCheck", func() {
 		artifacts.Reset()
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(deployableByOLMCheck.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := deployableByOLMCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := deployableByOLMCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
-
 	Describe("When deploying an operator using OLM", func() {
 		Context("When CSV has been created successfully", func() {
 			It("Should pass Validate", func() {
@@ -202,6 +182,9 @@ var _ = Describe("DeployableByOLMCheck", func() {
 			})
 		})
 	})
+
+	AssertMetaData(&deployableByOLMCheck)
+
 	DescribeTable("Image Registry validation",
 		func(bundleImages []string, expected bool) {
 			ok := checkImageSource(bundleImages)

--- a/certification/internal/policy/operator/operator_suite_test.go
+++ b/certification/internal/policy/operator/operator_suite_test.go
@@ -10,6 +10,7 @@ import (
 	imagestreamv1 "github.com/openshift/api/image/v1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/operatorsdk"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -192,4 +193,26 @@ var isList = imagestreamv1.ImageStreamList{
 			},
 		},
 	},
+}
+
+var AssertMetaData = func(check certification.Check) {
+	Context("When checking metadata", func() {
+		Context("The check name should not be empty", func() {
+			Expect(check.Name()).ToNot(BeEmpty())
+		})
+
+		Context("The metadata keys should not be empty", func() {
+			meta := check.Metadata()
+			Expect(meta.CheckURL).ToNot(BeEmpty())
+			Expect(meta.Description).ToNot(BeEmpty())
+			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
+			// Level is optional.
+		})
+
+		Context("The help text should not be empty", func() {
+			help := check.Help()
+			Expect(help.Message).ToNot(BeEmpty())
+			Expect(help.Suggestion).ToNot(BeEmpty())
+		})
+	})
 }

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -72,25 +72,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(scorecardBasicCheck.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := scorecardBasicCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := scorecardBasicCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
+	AssertMetaData(&scorecardBasicCheck)
 
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -72,25 +72,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", "", "20")
 	})
 
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(scorecardOlmSuiteCheck.Name()).ToNot(BeEmpty())
-		})
-
-		Context("The metadata keys should not be empty", func() {
-			meta := scorecardOlmSuiteCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := scorecardOlmSuiteCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
+	AssertMetaData(&scorecardOlmSuiteCheck)
 
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {

--- a/certification/internal/policy/operator/validate_operator_bundle_test.go
+++ b/certification/internal/policy/operator/validate_operator_bundle_test.go
@@ -58,25 +58,8 @@ var _ = Describe("BundleValidateCheck", func() {
 
 		bundleValidateCheck = *NewValidateOperatorBundleCheck(fakeEngine)
 	})
-	Context("When checking metadata", func() {
-		Context("The check name should not be empty", func() {
-			Expect(bundleValidateCheck.Name()).ToNot(BeEmpty())
-		})
 
-		Context("The metadata keys should not be empty", func() {
-			meta := bundleValidateCheck.Metadata()
-			Expect(meta.CheckURL).ToNot(BeEmpty())
-			Expect(meta.Description).ToNot(BeEmpty())
-			Expect(meta.KnowledgeBaseURL).ToNot(BeEmpty())
-			// Level is optional.
-		})
-
-		Context("The help text should not be empty", func() {
-			help := bundleValidateCheck.Help()
-			Expect(help.Message).ToNot(BeEmpty())
-			Expect(help.Suggestion).ToNot(BeEmpty())
-		})
-	})
+	AssertMetaData(&bundleValidateCheck)
 
 	Describe("Operator Bundle Validate", func() {
 		Context("When Operator Bundle Validate passes", func() {


### PR DESCRIPTION
This DRYs up the handling of this test a bit. There are 2 copies, instead
of one in every test. I consciously did not want to have a test function
cross package boundaries.

Signed-off-by: Brad P. Crochet <brad@redhat.com>