### PR TITLE
Add fallback paths to credential resolution when using docker.io as your registry 

### DIFF
--- a/certification/internal/authn/keychain_test.go
+++ b/certification/internal/authn/keychain_test.go
@@ -123,6 +123,14 @@ func TestVariousPaths(t *testing.T) {
 			Password: "bar",
 		},
 	}, {
+		desc:    "valid config file as written by podman; default registry",
+		target:  defaultRegistry,
+		content: fmt.Sprintf(`{"auths": {"docker.io": {"auth": %q}}}`, encode("foo", "bar")),
+		cfg: &craneauthn.AuthConfig{
+			Username: "foo",
+			Password: "bar",
+		},
+	}, {
 		desc:   "valid config file; matches registry w/ v1",
 		target: testRegistry,
 		content: fmt.Sprintf(`{


### PR DESCRIPTION
Fixes #731 

This patch resolves an issue in credential resolution when attempting to work with images that reside in Docker hub. I'm not certain, but I believe this came to be after bumping go-containerregistry's version which is why this would have worked previously but not now. I added a test to cover the case with the new resolution logic.


# The problem

Internally, Crane (the library used by Preflight) rewrites image targets that have the `docker.io` hostname to `index.docker.io`. The Preflight Keychain would query a credential file (e.g. `auth.json`) for a normalized value, `https://index.docker.io/v1/`. 

If a user logs into Docker hub using `podman`, it seems whatever value the user passed in as the registry is what's written to the configuration file. Contrast that with `docker` cli or `crane`, which write the normalized value. So for example:

```
<container-tool> login docker.io --username example --password password
```

In my testing:

Podman (4.0.z) would produce...

```
{
	"auths": {
		"docker.io": {
			"auth": "encodedvalues"
		}
	}
}
```

DockerCLI (tested against fedora 36 I believe, but I didn't write it down) and Crane would produce:

```
{
	"auths": {
		"https://index.docker.io/v1/": {
			"auth": "encodedvalues"
		}
	}
}
```

The former would not be read by preflight, but the latter would.


# The solution 

This patch resolves this issue by adding `docker.io` as an additional target when searching for the right credentials.

So for an image `docker.io/example/test`, the following in your credential file _should_ work **from Preflight's perspective**.

- https://index.docker.io/v1/
- docker.io/example/test
- docker.io

We still recommend the credential file is built using podman or related tools for the moment, as there are upstream services (on submission) that I believe do not expect the first option, and should accept any of the others.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>