### PR TITLE
inform the user of tag and digest binding semantics for container certification

### DIFF
--- a/certification/internal/engine/engine_test.go
+++ b/certification/internal/engine/engine_test.go
@@ -139,3 +139,20 @@ var _ = Describe("Source RPM name function", func() {
 		})
 	})
 })
+
+var _ = Describe("Tag and digest binding information function", func() {
+	Context("with a digest as the user-provided identifier", func() {
+		It("should return a message indicating that no tag will be associated", func() {
+			m, _ := tagDigestBindingInfo("sha256:5031aedc52578c68277ef127ef0f2a941e12d280722f1c19ee83932b6efd2f3b", "sha256:5031aedc52578c68277ef127ef0f2a941e12d280722f1c19ee83932b6efd2f3b")
+			Expect(m).To(ContainSubstring("You've provided an image by digest"))
+		})
+		Context("with a tag as the user-proivded identifier", func() {
+			It("should return a message indicating the tag and digest are bound", func() {
+				t := "mytag"
+				d := "sha256:5031aedc52578c68277ef127ef0f2a941e12d280722f1c19ee83932b6efd2f3b"
+				m, _ := tagDigestBindingInfo(t, d)
+				Expect(m).To(ContainSubstring(fmt.Sprintf("This image's tag %s will be paired with digest %s", t, d)))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Fixes #741

This PR adds some logging in the internal engine that informs the user that preflight checks with images provided via digest will likely need to be re-executed with a tag when certifying/submitting.

```
...
time="2022-07-26T12:12:53-05:00" level=info msg="check completed: RunAsNonRoot" result=PASSED
time="2022-07-26T12:12:54-05:00" level=info msg="check completed: HasModifiedFiles" result=PASSED
time="2022-07-26T12:12:54-05:00" level=info msg="check completed: BasedOnUbi" result=PASSED
time="2022-07-26T12:12:54-05:00" level=warning msg="You've provided an image by digest. When submitting this image to Red Hat for certification, no tag will be associated with this image. If you would like to associate a tag with this image, please rerun this tool replacing your image reference with a tag."
{
    "image": "quay.io/opdev/simple-demo-operator@sha256:072aedb6fdeb14fedd859ed9ff6704a5ae3d3453463d9b618308c4a261d997b4",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "unknown",
        "commit": "unknown"
...
```

If the user provides a tag, this emits a log line indicating that the tag and digest will be bound from the certification perspective, and supplemental tags can be manipulated by the user sees fit.

```
...
time="2022-07-26T12:28:04-05:00" level=info msg="check completed: HasModifiedFiles" result=PASSED
time="2022-07-26T12:28:04-05:00" level=info msg="check completed: BasedOnUbi" result=PASSED
time="2022-07-26T12:28:04-05:00" level=info msg="This image's tag 0.0.6 will be paired with digest sha256:072aedb6fdeb14fedd859ed9ff6704a5ae3d3453463d9b618308c4a261d997b4once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "quay.io/opdev/simple-demo-operator:0.0.6",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "unknown",
...
```

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>