### PR TITLE
Re-adds basedOnUBI check to root policy exception

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -86,6 +86,11 @@ func initializeChecks(ctx context.Context, p policy.Policy, cfg certification.Co
 			&containerpol.HasNoProhibitedPackagesCheck{},
 			&containerpol.HasRequiredLabelsCheck{},
 			&containerpol.HasModifiedFilesCheck{},
+			containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisClient(
+				certification.DefaultPyxisHost,
+				cfg.PyxisAPIToken(),
+				cfg.CertificationProjectID(),
+				&http.Client{Timeout: 60 * time.Second})),
 		}, nil
 	case policy.PolicyScratch:
 		return []certification.Check{


### PR DESCRIPTION
In https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/680 I left out the BasedOnUBI check for the container root policy exception check list. This PR re-adds this check.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>