### PR TITLE
Only add results that are not marked as "optional"

### DIFF
--- a/certification/internal/engine/engine_test.go
+++ b/certification/internal/engine/engine_test.go
@@ -73,6 +73,24 @@ var _ = Describe("Execute Checks tests", func() {
 			certification.HelpText{},
 		)
 
+		optionalCheckPassing := certification.NewGenericCheck(
+			"optionalCheckPassing",
+			func(context.Context, certification.ImageReference) (bool, error) {
+				return true, nil
+			},
+			certification.Metadata{Level: "optional"},
+			certification.HelpText{},
+		)
+
+		optionalCheckFailing := certification.NewGenericCheck(
+			"optionalCheckFailing",
+			func(context.Context, certification.ImageReference) (bool, error) {
+				return false, fmt.Errorf("optionalError")
+			},
+			certification.Metadata{Level: "optional"},
+			certification.HelpText{},
+		)
+
 		emptyConfig := runtime.Config{}
 		engine = CraneEngine{
 			Config: emptyConfig.ReadOnly(), // must pass a config to avoid nil pointer errors
@@ -81,6 +99,8 @@ var _ = Describe("Execute Checks tests", func() {
 				goodCheck,
 				errorCheck,
 				failedCheck,
+				optionalCheckPassing,
+				optionalCheckFailing,
 			},
 			IsBundle:  false,
 			IsScratch: false,

--- a/certification/internal/policy/operator/certified_images.go
+++ b/certification/internal/policy/operator/certified_images.go
@@ -89,7 +89,7 @@ func (p *certifiedImagesCheck) Name() string {
 
 func (p *certifiedImagesCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Checking that all images referenced in the CSV are certified",
+		Description:      "Checking that all images referenced in the CSV are certified. Currently, this check is not enforced.",
 		Level:            "optional",
 		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-products-managed-by-an-operator_openshift-sw-cert-policy-container-images#con-operand-requirements_openshift-sw-cert-policy-products-managed",
 		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-products-managed-by-an-operator_openshift-sw-cert-policy-container-images#con-operand-requirements_openshift-sw-cert-policy-products-managed",

--- a/certification/internal/policy/operator/related_images.go
+++ b/certification/internal/policy/operator/related_images.go
@@ -74,7 +74,7 @@ func (p *RelatedImagesCheck) Name() string {
 
 func (p *RelatedImagesCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
-		Description:      "Check that all images in the CSV are listed in RelatedImages section",
+		Description:      "Check that all images in the CSV are listed in RelatedImages section. Currently, this check is not enforced.",
 		Level:            "optional",
 		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-products-managed-by-an-operator_openshift-sw-cert-policy-container-images#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-products-managed-by-an-operator_openshift-sw-cert-policy-container-images#con-operator-requirements_openshift-sw-cert-policy-products-managed",


### PR DESCRIPTION
The "optional" level will treat the check as normal, but will not
add it's outcome to the actual results. A user will still see the
log message with the status, but it will not cause a failure, nor
will it be reported in the output.

Signed-off-by: Brad P. Crochet <brad@redhat.com>