### PR TITLE
Fix bugs in new checks

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -63,6 +63,7 @@ func initializeChecks(ctx context.Context, p policy.Policy, cfg certification.Co
 				&http.Client{Timeout: 60 * time.Second}),
 			),
 			operatorpol.NewSecurityContextConstraintsCheck(),
+			&operatorpol.RelatedImagesCheck{},
 		}, nil
 	case policy.PolicyContainer:
 		return []certification.Check{


### PR DESCRIPTION
This PR contains two fixes.

1. Adding the RelatedImages check to the operator policy.
2. Fix the logic in the Certified Images check, so that if an image is not found in Pyxis, it's marked as uncertified.