### PR TITLE
updating to the latest version of operator-sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL OS=${OS}
 
 # Define versions for dependencies
 ARG OPENSHIFT_CLIENT_VERSION=4.7.19
-ARG OPERATOR_SDK_VERSION=1.14.0
+ARG OPERATOR_SDK_VERSION=1.22.2
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The preflight binary currently requires that you have the following tools instal
 functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
-|----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.14.0         |
-| OpenShift Client | `oc`              | v4.7.19         |
+|----------------- |:-----------------:|----------------:|
+| OperatorSDK      | `operator-sdk`    |         v1.22.2 |
+| OpenShift Client | `oc`              |         v4.7.19 |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
 development environment. Some checks may also require access to an OpenShift

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.14.0
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.22.2
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -16,7 +16,7 @@ import (
 // to be used outside of this package.
 var images = map[string]string{
 	// operator policy, operator-sdk scorecard
-	"scorecard": "quay.io/operator-framework/scorecard-test:v1.14.0",
+	"scorecard": "quay.io/operator-framework/scorecard-test:v1.22.2",
 }
 
 // imageList takes the images mapping and represents them using just

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -14,10 +14,10 @@ Development and testing preflight requires that you have the following tools ins
 functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
-|----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.14.0         |
-| OpenShift Client | `oc`              | v4.7.19         |
-| Podman           | `podman`          | v3.0            |
+|----------------- |:-----------------:|----------------:|
+| OperatorSDK      | `operator-sdk`    |         v1.22.2 |
+| OpenShift Client | `oc`              |         v4.7.19 |
+| Podman           | `podman`          |            v3.0 |
 
 ## Checks
 


### PR DESCRIPTION
- updating to use the latest version of operator-sdk
- tested this against fork of `operator-certifcation-operator`

More testing by others (and other operators) might be needed since we are making such a large jump in versions.

Signed-off-by: Adam D. Cornett <adc@redhat.com>