### PR TITLE
Bump operator-sdk to 1.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL OS=${OS}
 
 # Define versions for dependencies
 ARG OPENSHIFT_CLIENT_VERSION=4.7.19
-ARG OPERATOR_SDK_VERSION=1.14.0
+ARG OPERATOR_SDK_VERSION=1.22.2
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.14.0         |
+| OperatorSDK      | `operator-sdk`    | v1.22.2         |
 | OpenShift Client | `oc`              | v4.7.19         |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.14.0
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.22.2
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:| ---------------:|
-| OperatorSDK      | `operator-sdk`    | v1.14.0         |
+| OperatorSDK      | `operator-sdk`    | v1.22.2         |
 | OpenShift Client | `oc`              | v4.7.19         |
 | Podman           | `podman`          | v3.0            |
 


### PR DESCRIPTION
In order to support the latest deprecated API checks, operator-sdk
needs to be bumped.

Signed-off-by: Brad P. Crochet <brad@redhat.com>