### PR TITLE
Begin usage of operator-framework APIs

### DIFF
--- a/certification/internal/bundle/types.go
+++ b/certification/internal/bundle/types.go
@@ -1,0 +1,13 @@
+package bundle
+
+import "github.com/operator-framework/api/pkg/manifests"
+
+type AnnotationsFile struct {
+	Annotations Annotations `json:"annotations" yaml:"annotations"`
+}
+
+type Annotations struct {
+	manifests.Annotations
+
+	OpenshiftVersions string `json:"com.redhat.openshift.versions,omitempty" yaml:"com.redhat.openshift.versions,omitempty"`
+}

--- a/certification/internal/policy/operator/default.go
+++ b/certification/internal/policy/operator/default.go
@@ -52,10 +52,10 @@ var (
 		"registry.access.redhat.com":        {},
 	}
 
-	prioritizedInstallModes = []string{
-		string(operatorv1alpha1.InstallModeTypeOwnNamespace),
-		string(operatorv1alpha1.InstallModeTypeSingleNamespace),
-		string(operatorv1alpha1.InstallModeTypeMultiNamespace),
-		string(operatorv1alpha1.InstallModeTypeAllNamespaces),
+	prioritizedInstallModes = []operatorv1alpha1.InstallModeType{
+		operatorv1alpha1.InstallModeTypeOwnNamespace,
+		operatorv1alpha1.InstallModeTypeSingleNamespace,
+		operatorv1alpha1.InstallModeTypeMultiNamespace,
+		operatorv1alpha1.InstallModeTypeAllNamespaces,
 	}
 )

--- a/certification/internal/policy/operator/deployable_by_olm_test.go
+++ b/certification/internal/policy/operator/deployable_by_olm_test.go
@@ -40,6 +40,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 		annotations            = `annotations:
   operators.operatorframework.io.bundle.package.v1: testPackage
   operators.operatorframework.io.bundle.channel.default.v1: testChannel
+  operators.operatorframework.io.bundle.channels.v1: testChannel
 `
 		registryAuthToken = `{
 "auths": {
@@ -49,17 +50,18 @@ var _ = Describe("DeployableByOLMCheck", func() {
   }
 }`
 
-		csvStr = `
-    spec:
-      installModes:
-        - supported: false
-          type: OwnNamespace
-        - supported: false
-          type: SingleNamespace
-        - supported: false
-          type: MultiNamespace
-        - supported: true
-          type: AllNamespaces
+		csvStr = `apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+spec:
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
 `
 	)
 	BeforeEach(func() {

--- a/certification/internal/policy/operator/scc_info.go
+++ b/certification/internal/policy/operator/scc_info.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/bundle"
 	log "github.com/sirupsen/logrus"
@@ -35,17 +34,7 @@ func (p *securityContextConstraintsInCSV) Validate(ctx context.Context, bundleRe
 }
 
 func (p *securityContextConstraintsInCSV) dataToValidate(ctx context.Context, imagePath string) ([]string, error) {
-	csvFilepath, err := bundle.GetCsvFilePathFromBundle(imagePath)
-	if err != nil {
-		return nil, err
-	}
-
-	csvFileReader, err := os.Open(csvFilepath)
-	if err != nil {
-		return nil, err
-	}
-
-	requestedSccList, err := bundle.GetSecurityContextConstraints(ctx, csvFileReader)
+	requestedSccList, err := bundle.GetSecurityContextConstraints(ctx, imagePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to extract security context constraints from ClusterServiceVersion: %w", err)
 	}

--- a/certification/internal/policy/operator/validate_operator_bundle.go
+++ b/certification/internal/policy/operator/validate_operator_bundle.go
@@ -26,7 +26,7 @@ func NewValidateOperatorBundleCheck(operatorSdk operatorSdk) *ValidateOperatorBu
 
 const ocpVerV1beta1Unsupported = "4.9"
 
-func (p ValidateOperatorBundleCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
+func (p *ValidateOperatorBundleCheck) Validate(ctx context.Context, bundleRef certification.ImageReference) (bool, error) {
 	report, err := p.getDataToValidate(ctx, bundleRef.ImageFSPath)
 	if err != nil {
 		return false, fmt.Errorf("error while executing operator-sdk bundle validate: %v", err)
@@ -35,11 +35,11 @@ func (p ValidateOperatorBundleCheck) Validate(ctx context.Context, bundleRef cer
 	return p.validate(ctx, report)
 }
 
-func (p ValidateOperatorBundleCheck) getDataToValidate(ctx context.Context, imagePath string) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
+func (p *ValidateOperatorBundleCheck) getDataToValidate(ctx context.Context, imagePath string) (*operatorsdk.OperatorSdkBundleValidateReport, error) {
 	return bundle.Validate(ctx, p.OperatorSdk, imagePath)
 }
 
-func (p ValidateOperatorBundleCheck) validate(ctx context.Context, report *operatorsdk.OperatorSdkBundleValidateReport) (bool, error) {
+func (p *ValidateOperatorBundleCheck) validate(ctx context.Context, report *operatorsdk.OperatorSdkBundleValidateReport) (bool, error) {
 	if !report.Passed || len(report.Outputs) > 0 {
 		for _, output := range report.Outputs {
 			var logFn func(...interface{})
@@ -57,11 +57,11 @@ func (p ValidateOperatorBundleCheck) validate(ctx context.Context, report *opera
 	return report.Passed, nil
 }
 
-func (p ValidateOperatorBundleCheck) Name() string {
+func (p *ValidateOperatorBundleCheck) Name() string {
 	return "ValidateOperatorBundle"
 }
 
-func (p ValidateOperatorBundleCheck) Metadata() certification.Metadata {
+func (p *ValidateOperatorBundleCheck) Metadata() certification.Metadata {
 	return certification.Metadata{
 		Description:      "Validating Bundle image that checks if it can validate the content and format of the operator bundle",
 		Level:            "best",
@@ -70,7 +70,7 @@ func (p ValidateOperatorBundleCheck) Metadata() certification.Metadata {
 	}
 }
 
-func (p ValidateOperatorBundleCheck) Help() certification.HelpText {
+func (p *ValidateOperatorBundleCheck) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "Check ValidateOperatorBundle encountered an error. Please review the preflight.log file for more information.",
 		Suggestion: "Valid bundles are defined by bundle spec, so make sure that this bundle conforms to that spec. More Information: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md",

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.20.0
 	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/operator-framework/api v0.15.0
+	github.com/operator-framework/api v0.16.0
 	github.com/operator-framework/operator-manifest-tools v0.2.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/sirupsen/logrus v1.8.1
@@ -105,3 +105,5 @@ require (
 )
 
 replace github.com/knqyf263/go-rpmdb => github.com/opdev/go-rpmdb v0.0.0-20220719131451-751902254f35
+
+replace github.com/operator-framework/api v0.16.0 => github.com/operator-framework/api v0.16.1-0.20220823134246-5f99430d4ec4

--- a/go.sum
+++ b/go.sum
@@ -665,8 +665,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mo
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1p9LsJt4HQ+akDrys4PrYnXzOWI5LK03I=
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/operator-framework/api v0.15.0 h1:4f9i0drtqHj7ykLoHxv92GR43S7MmQHhmFQkfm5YaGI=
-github.com/operator-framework/api v0.15.0/go.mod h1:scnY9xqSeCsOdtJtNoHIXd7OtHZ14gj1hkDA4+DlgLY=
+github.com/operator-framework/api v0.16.1-0.20220823134246-5f99430d4ec4 h1:juST/k+hHmKD/BlZ4GCzeDdxvNsxB4wHlDyfAPYmSrU=
+github.com/operator-framework/api v0.16.1-0.20220823134246-5f99430d4ec4/go.mod h1:kk8xJahHJR3bKqrA+A+1VIrhOTmyV76k+ARv+iV+u1Q=
 github.com/operator-framework/operator-manifest-tools v0.2.1 h1:hD3iyOm2mBItzYhpFFWqU1StkolS4XGvXxRvFO4v3Oo=
 github.com/operator-framework/operator-manifest-tools v0.2.1/go.mod h1:C4AmRDIJiM8WVyGyqoUuK3KlloZr7XqaabKMMKKhHtA=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=


### PR DESCRIPTION
The operator-framework API[1] has lots of bundle manipulation tools
that we can leverage to make our own code simpler. This begins the
journey of leveraging those APIs. This removes a good bit of code
that we get from the library.

[1] https://github.com/operator-framework/api

Signed-off-by: Brad P. Crochet <brad@redhat.com>