### PR TITLE
Remove the project type when submitting updates to pyxis

### DIFF
--- a/certification/pyxis/pyxis.go
+++ b/certification/pyxis/pyxis.go
@@ -299,7 +299,19 @@ func (p *pyxisClient) GetProject(ctx context.Context) (*CertProject, error) {
 }
 
 func (p *pyxisClient) updateProject(ctx context.Context, certProject *CertProject) (*CertProject, error) {
-	b, err := json.Marshal(certProject)
+	// We cannot send the project type to pyxis in a Patch.
+	// Copy the CertProject and strip the Type value to
+	// have omitempty skip the key in the JSON patch.
+	patchCertProject := &CertProject{
+		ID:                  certProject.ID,
+		CertificationStatus: certProject.CertificationStatus,
+		Container:           certProject.Container,
+		Name:                certProject.Name,
+		ProjectStatus:       certProject.ProjectStatus,
+		// Do not copy the Type.
+	}
+
+	b, err := json.Marshal(patchCertProject)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal certProject: %w", err)
 	}

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -99,9 +99,9 @@ type CertProject struct {
 	ID                  string    `json:"_id,omitempty"`
 	CertificationStatus string    `json:"certification_status" default:"In Progress"`
 	Container           Container `json:"container"`
-	Name                string    `json:"name"`                      // required
-	ProjectStatus       string    `json:"project_status"`            // required
-	Type                string    `json:"type" default:"Containers"` // required
+	Name                string    `json:"name"`           // required
+	ProjectStatus       string    `json:"project_status"` // required
+	Type                string    `json:"type,omitempty"` // required
 }
 
 type Container struct {


### PR DESCRIPTION
Fixes #766

The issue listed above results from our CertProject struct, which contains the project type. Certain values for the project's type cannot be set via the external API, but our submission included them, resulting in a rejection from the API.

This patch adjusts the CertProject.Type key such that it uses omitempty, and on update calls, we zero out the value of CertProject.Type before we submit.

We'll want to cut a beta release after this merges, which can then be tested by the blocked partner.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>