### PR TITLE
Fix some tests that would fail with existing env vars

### DIFF
--- a/certification/certification_suite_test.go
+++ b/certification/certification_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestBundle(t *testing.T) {
+func TestCertification(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Certification Suite")
 }

--- a/certification/runtime/config_test.go
+++ b/certification/runtime/config_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"os"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +16,10 @@ var _ = Describe("Viper to Runtime Config", func() {
 		baseViperCfg = viper.New()
 		expectedRuntimeCfg = &Config{}
 
+		if val, isSet := os.LookupEnv("KUBECONFIG"); isSet {
+			DeferCleanup(os.Setenv, "KUBECONFIG", val)
+			Expect(os.Unsetenv("KUBECONFIG")).To(Succeed())
+		}
 		baseViperCfg.Set("logfile", "logfile")
 		expectedRuntimeCfg.LogFile = "logfile"
 		baseViperCfg.Set("dockerConfig", "dockerConfig")

--- a/certification/runtime/runtime_suite_test.go
+++ b/certification/runtime/runtime_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestBundle(t *testing.T) {
+func TestRuntime(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Runtime Suite")
 }


### PR DESCRIPTION
Some of the unit tests would fail if KUBECONFIG or PFLT_INDEXIMAGE
were already present in the environment. This patch cleans those up
a bit by checking for the existence, clearing them when required, and
cleaning up appropriately after the test is run.

This also includes minor renaming of some of the test suites, as they
overlapped, and it was confusing where the error was actually coming
from.

Signed-off-by: Brad P. Crochet <brad@redhat.com>