### PR TITLE
updating ospid logic to exit if legacy project id is provided

### DIFF
--- a/certification/runtime/config.go
+++ b/certification/runtime/config.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"os"
-	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/policy"
 	"github.com/spf13/viper"
@@ -62,13 +61,7 @@ func (c *Config) storeContainerPolicyConfiguration(vcfg viper.Viper) {
 	c.PyxisAPIToken = vcfg.GetString("pyxis_api_token")
 	c.Submit = vcfg.GetBool("submit")
 	c.PyxisHost = pyxisHostLookup(vcfg.GetString("pyxis_env"), vcfg.GetString("pyxis_host"))
-
-	// Strip the ospid- prefix from the project ID if provided.
-	certificationProjectID := vcfg.GetString("certification_project_id")
-	if strings.HasPrefix(certificationProjectID, "ospid-") {
-		certificationProjectID = strings.Split(certificationProjectID, "-")[1]
-	}
-	c.CertificationProjectID = certificationProjectID
+	c.CertificationProjectID = vcfg.GetString("certification_project_id")
 }
 
 // storeOperatorPolicyConfiguration reads operator-policy-specific config

--- a/certification/runtime/config_test.go
+++ b/certification/runtime/config_test.go
@@ -60,16 +60,6 @@ var _ = Describe("Viper to Runtime Config", func() {
 		})
 	})
 
-	Context("With proper values, but with an opsid- prefix on the certification project ID", func() {
-		It("should properly trim the ospid- prefix and succeed", func() {
-			baseViperCfg.Set("certification_project_id", "ospid-111111111111")
-			expectedRuntimeCfg.CertificationProjectID = "111111111111"
-			cfg, err := NewConfigFrom(*baseViperCfg)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(*cfg).To(BeEquivalentTo(*expectedRuntimeCfg))
-		})
-	})
-
 	It("should only have 20 struct keys for tests to be valid", func() {
 		// If this test fails, it means a developer has added or removed
 		// keys from runtime.Config, and so these tests may no longer be

--- a/cmd/check_container_test.go
+++ b/cmd/check_container_test.go
@@ -527,4 +527,45 @@ certification_project_id: mycertid`
 			})
 		})
 	})
+
+	Context("When validating the certification-project-id flag", func() {
+		Context("and the flag is set properly", func() {
+			BeforeEach(func() {
+				viper.Set("certification_project_id", "123456789")
+			})
+			It("should not change the flag value", func() {
+				err := validateCertificationProjectId(checkContainerCmd(), []string{"foo"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(viper.GetString("certification_project_id")).To(Equal("123456789"))
+			})
+		})
+		Context("and a valid ospid format is provided", func() {
+			BeforeEach(func() {
+				viper.Set("certification_project_id", "ospid-123456789")
+			})
+			It("should strip ospid- from the flag value", func() {
+				err := validateCertificationProjectId(checkContainerCmd(), []string{"foo"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(viper.GetString("certification_project_id")).To(Equal("123456789"))
+			})
+		})
+		Context("and a legacy format with ospid is provided", func() {
+			BeforeEach(func() {
+				viper.Set("certification_project_id", "ospid-62423-f26c346-6cc1dc7fae92")
+			})
+			It("should throw an error", func() {
+				err := validateCertificationProjectId(checkContainerCmd(), []string{"foo"})
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("and a legacy format without ospid is provided", func() {
+			BeforeEach(func() {
+				viper.Set("certification_project_id", "62423-f26c346-6cc1dc7fae92")
+			})
+			It("should throw an error", func() {
+				err := validateCertificationProjectId(checkContainerCmd(), []string{"foo"})
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
- Fixes: #758 
- Added a `PreRunE` to validate the project id, and throw an error if it's in an improper format is used.

Output from test
```
Examples:
  preflight check container quay.io/repo-name/container-name:version

Flags:
      --certification-project-id string   Certification Project ID from connect.redhat.com/projects/{certification-project-id}/overview
                                          URL paramater. This value may differ from the PID on the overview page. (env: PFLT_CERTIFICATION_PROJECT_ID)
  -h, --help                              help for container
      --pyxis-api-token string            API token for Pyxis authentication (env: PFLT_PYXIS_API_TOKEN)
      --pyxis-env string                  Env to use for Pyxis submissions. (default "prod")
      --pyxis-host string                 Host to use for Pyxis submissions. This will override Pyxis Env. Only set this if you know what you are doing.
                                          If you do set it, it should include just the host, and the URI path. (env: PFLT_PYXIS_HOST)
  -s, --submit                            submit check container results to red hat

Global Flags:
      --artifacts string       Where check-specific artifacts will be written. (env: PFLT_ARTIFACTS)
  -d, --docker-config string   Path to docker config.json file. This value is optional for publicly accessible images.
                               However, it is strongly encouraged for public Docker Hub images,
                               due to the rate limit imposed for unauthenticated requests. (env: PFLT_DOCKERCONFIG)
      --logfile string         Where the execution logfile will be written. (env: PFLT_LOGFILE)
      --loglevel string        The verbosity of the preflight tool itself. Ex. warn, debug, trace, info, error. (env: PFLT_LOGLEVEL)

2022/08/24 16:11:12 certification project id: ospid-62423-f26c346-6cc1dc7fae92 is improperly formatted see help command for instructions on obtaining proper value

```

Signed-off-by: Adam D. Cornett <adc@redhat.com>