### PR TITLE
Truncate container type on pyxis update calls

### DIFF
--- a/certification/pyxis/pyxis.go
+++ b/certification/pyxis/pyxis.go
@@ -299,9 +299,9 @@ func (p *pyxisClient) GetProject(ctx context.Context) (*CertProject, error) {
 }
 
 func (p *pyxisClient) updateProject(ctx context.Context, certProject *CertProject) (*CertProject, error) {
-	// We cannot send the project type to pyxis in a Patch.
-	// Copy the CertProject and strip the Type value to
-	// have omitempty skip the key in the JSON patch.
+	// We cannot send the project type or container type
+	// to pyxis in a Patch. Copy the CertProject and strip type
+	// values to have omitempty skip the key in the JSON patch.
 	patchCertProject := &CertProject{
 		ID:                  certProject.ID,
 		CertificationStatus: certProject.CertificationStatus,
@@ -310,6 +310,7 @@ func (p *pyxisClient) updateProject(ctx context.Context, certProject *CertProjec
 		ProjectStatus:       certProject.ProjectStatus,
 		// Do not copy the Type.
 	}
+	patchCertProject.Container.Type = "" // Truncate this value, too.
 
 	b, err := json.Marshal(patchCertProject)
 	if err != nil {

--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -106,8 +106,8 @@ type CertProject struct {
 
 type Container struct {
 	DockerConfigJSON string `json:"docker_config_json,omitempty"`
-	Type             string `json:"type" default:"Containers"` // conditionally required
-	ISVPID           string `json:"isv_pid,omitempty"`         // required
+	Type             string `json:"type,omitempty"`    // conditionally required
+	ISVPID           string `json:"isv_pid,omitempty"` // required
 	Registry         string `json:"registry,omitempty"`
 	Repository       string `json:"repository,omitempty"`
 	OsContentType    string `json:"os_content_type,omitempty"`


### PR DESCRIPTION
In #768 we truncated the `CertificationProject.Type` value on update requests because Pyxis was rejecting requests that included that value for projects with exceptions (being that external users cannot update that field).

It seems like we actually need to strip the value from the `CertificationProject.Container.Type` field. This PR removes that field. I did not replace the `CertificationProject.Type` value because in my mind, neither of those should change anyway. I'd imagine we should be fine removing both.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>