### PR TITLE
check container type for scratch exceptions instead of os_content_type

### DIFF
--- a/cmd/check_container.go
+++ b/cmd/check_container.go
@@ -157,7 +157,7 @@ func getContainerPolicyExceptions(ctx context.Context, pc pyxisClient) (policy.P
 		return "", fmt.Errorf("could not retrieve project: %w", err)
 	}
 	log.Debugf("Certification project name is: %s", certProject.Name)
-	if certProject.Container.OsContentType == "scratch" {
+	if certProject.Container.Type == "scratch" {
 		return policy.PolicyScratch, nil
 	}
 

--- a/cmd/fakes_test.go
+++ b/cmd/fakes_test.go
@@ -101,7 +101,7 @@ func gpFuncReturnError(ctx context.Context) (*pyxis.CertProject, error) {
 func gpFuncReturnScratchException(ctx context.Context) (*pyxis.CertProject, error) {
 	return &pyxis.CertProject{
 		Container: pyxis.Container{
-			OsContentType: "scratch",
+			Type: "scratch",
 		},
 	}, nil
 }


### PR DESCRIPTION
According to a recent review of data, we may be checking the wrong field to determine if a scratch exception is required. This corrects that.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>