### PR TITLE
Add a minimum required RHEL version to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ subject to change, and some features are not fully implemented.
 
 ## Requirements
 
-The preflight binary currently requires that you have the following tools installed,
+For running the Preflight binary, the host or VM must have at least RHEL 8.5, CentOS 8.5 or Fedora 35 installed.
+
+The Preflight binary currently requires that you have the following tools installed,
 functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |


### PR DESCRIPTION
Update Readme to mention a minimum required RHEL version due to glibc and other libs.
Fixes #777 