### PR TITLE
[RFC] Add policy to check for scratch images running privileged

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -104,6 +104,13 @@ func initializeChecks(ctx context.Context, p policy.Policy, cfg certification.Co
 			&containerpol.HasRequiredLabelsCheck{},
 			&containerpol.RunAsNonRootCheck{},
 		}, nil
+	case policy.PolicyScratchRoot:
+		return []certification.Check{
+			&containerpol.HasLicenseCheck{},
+			containerpol.NewHasUniqueTagCheck(cfg.DockerConfig()),
+			&containerpol.MaxLayersCheck{},
+			&containerpol.HasRequiredLabelsCheck{},
+		}, nil
 	}
 
 	return nil, fmt.Errorf("provided policy %s is unknown", p)
@@ -142,6 +149,12 @@ func ContainerPolicy(ctx context.Context) []string {
 // container policy with scratch exception.
 func ScratchNonRootContainerPolicy(ctx context.Context) []string {
 	return checkNamesFor(ctx, policy.PolicyScratchNonRoot)
+}
+
+// ScratchRootContainerPolicy returns the names of checks in the
+// container policy with scratch and root exception.
+func ScratchRootContainerPolicy(ctx context.Context) []string {
+	return checkNamesFor(ctx, policy.PolicyScratchRoot)
 }
 
 // RootExceptionContainerPolicy returns the names of checks in the

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -96,7 +96,7 @@ func initializeChecks(ctx context.Context, p policy.Policy, cfg certification.Co
 				cfg.CertificationProjectID(),
 				&http.Client{Timeout: 60 * time.Second})),
 		}, nil
-	case policy.PolicyScratch:
+	case policy.PolicyScratchNonRoot:
 		return []certification.Check{
 			&containerpol.HasLicenseCheck{},
 			containerpol.NewHasUniqueTagCheck(cfg.DockerConfig()),
@@ -138,10 +138,10 @@ func ContainerPolicy(ctx context.Context) []string {
 	return checkNamesFor(ctx, policy.PolicyContainer)
 }
 
-// ScratchContainerPolicy returns the names of checks in the
+// ScratchNonRootContainerPolicy returns the names of checks in the
 // container policy with scratch exception.
-func ScratchContainerPolicy(ctx context.Context) []string {
-	return checkNamesFor(ctx, policy.PolicyScratch)
+func ScratchNonRootContainerPolicy(ctx context.Context) []string {
+	return checkNamesFor(ctx, policy.PolicyScratchNonRoot)
 }
 
 // RootExceptionContainerPolicy returns the names of checks in the

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -85,6 +85,29 @@ var _ = Describe("Engine Creation", func() {
 				})
 			})
 
+			Context("for the scratch and root policy", func() {
+				cfg := runtime.Config{
+					Image:          "dummy/image",
+					Policy:         policy.PolicyScratchRoot,
+					ResponseFormat: "json",
+				}
+
+				It("should return an engine and no error", func() {
+					engine, err := NewForConfig(context.TODO(), cfg.ReadOnly())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(engine).ToNot(BeNil())
+				})
+				It("should return the correct names", func() {
+					names := ScratchRootContainerPolicy(context.TODO())
+					Expect(names).To(ContainElements([]string{
+						"HasLicense",
+						"HasUniqueTag",
+						"LayerCountAcceptable",
+						"HasRequiredLabel",
+					}))
+				})
+			})
+
 			Context("for the Root policy", func() {
 				cfg := runtime.Config{
 					Image:          "dummy/image",

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Engine Creation", func() {
 			Context("for the scratch policy", func() {
 				cfg := runtime.Config{
 					Image:          "dummy/image",
-					Policy:         policy.PolicyScratch,
+					Policy:         policy.PolicyScratchNonRoot,
 					ResponseFormat: "json",
 				}
 
@@ -74,7 +74,7 @@ var _ = Describe("Engine Creation", func() {
 					Expect(engine).ToNot(BeNil())
 				})
 				It("should return the correct names", func() {
-					names := ScratchContainerPolicy(context.TODO())
+					names := ScratchNonRootContainerPolicy(context.TODO())
 					Expect(names).To(ContainElements([]string{
 						"HasLicense",
 						"HasUniqueTag",

--- a/certification/policy/policy.go
+++ b/certification/policy/policy.go
@@ -6,5 +6,6 @@ const (
 	PolicyOperator       Policy = "operator"
 	PolicyContainer      Policy = "container"
 	PolicyScratchNonRoot Policy = "scratch-nonroot"
+	PolicyScratchRoot    Policy = "scratch-root"
 	PolicyRoot           Policy = "root"
 )

--- a/certification/policy/policy.go
+++ b/certification/policy/policy.go
@@ -3,8 +3,8 @@ package policy
 type Policy = string
 
 const (
-	PolicyOperator  Policy = "operator"
-	PolicyContainer Policy = "container"
-	PolicyScratch   Policy = "scratch"
-	PolicyRoot      Policy = "root"
+	PolicyOperator       Policy = "operator"
+	PolicyContainer      Policy = "container"
+	PolicyScratchNonRoot Policy = "scratch-nonroot"
+	PolicyRoot           Policy = "root"
 )

--- a/cmd/preflight/cmd/list_checks.go
+++ b/cmd/preflight/cmd/list_checks.go
@@ -36,6 +36,8 @@ func printChecks(w io.Writer) {
 		"automatically applied for container images if preflight determines a root exception flag has been added to your Red Hat Connect project"))
 	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch (NonRoot) Exception", engine.ScratchNonRootContainerPolicy(context.TODO()),
 		"automatically applied for container checks if preflight determines a scratch exception flag has been added to your Red Hat Connect project"))
+	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch (Root) Exception", engine.ScratchRootContainerPolicy(context.TODO()),
+		"automatically applied for container checks if preflight determines a scratch and root exception flags have been added to your Red Hat Connect project"))
 }
 
 // formattedPolicyBlock accepts information about the checklist

--- a/cmd/preflight/cmd/list_checks.go
+++ b/cmd/preflight/cmd/list_checks.go
@@ -34,7 +34,7 @@ func printChecks(w io.Writer) {
 	fmt.Fprintln(w, formattedPolicyBlock("Container", engine.ContainerPolicy(context.TODO()), "invoked on container images"))
 	fmt.Fprintln(w, formattedPolicyBlock("Container Root Exception", engine.RootExceptionContainerPolicy(context.TODO()),
 		"automatically applied for container images if preflight determines a root exception flag has been added to your Red Hat Connect project"))
-	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch Exception", engine.ScratchContainerPolicy(context.TODO()),
+	fmt.Fprintln(w, formattedPolicyBlock("Container Scratch (NonRoot) Exception", engine.ScratchNonRootContainerPolicy(context.TODO()),
 		"automatically applied for container checks if preflight determines a scratch exception flag has been added to your Red Hat Connect project"))
 }
 

--- a/cmd/preflight/cmd/list_checks_test.go
+++ b/cmd/preflight/cmd/list_checks_test.go
@@ -65,7 +65,7 @@ var _ = Describe("list checks subcommand", func() {
 		})
 
 		It("should always contain the scratch exception policy", func() {
-			expected := formatList(engine.ScratchContainerPolicy(context.TODO()))
+			expected := formatList(engine.ScratchNonRootContainerPolicy(context.TODO()))
 			buf := strings.Builder{}
 			printChecks(&buf)
 

--- a/cmd/preflight/cmd/list_checks_test.go
+++ b/cmd/preflight/cmd/list_checks_test.go
@@ -71,6 +71,14 @@ var _ = Describe("list checks subcommand", func() {
 
 			Expect(buf.String()).To(ContainSubstring(expected))
 		})
+
+		It("should always contain the scratch and root exception policy", func() {
+			expected := formatList(engine.ScratchRootContainerPolicy(context.TODO()))
+			buf := strings.Builder{}
+			printChecks(&buf)
+
+			Expect(buf.String()).To(ContainSubstring(expected))
+		})
 	})
 
 	Context("When executing the cobra command", func() {

--- a/internal/lib/fakes_test.go
+++ b/internal/lib/fakes_test.go
@@ -117,8 +117,8 @@ func gpFuncReturnHostedRegistry(ctx context.Context) (*pyxis.CertProject, error)
 	}, nil
 }
 
-// gpFuncReturnScratchException implements gpFunc and returns a scratch exception.
-func gpFuncReturnScratchException(ctx context.Context) (*pyxis.CertProject, error) {
+// gpFuncReturnScratchNonRootException implements gpFunc and returns a scratch exception.
+func gpFuncReturnScratchNonRootException(ctx context.Context) (*pyxis.CertProject, error) {
 	return &pyxis.CertProject{
 		Container: pyxis.Container{
 			Type: "scratch",

--- a/internal/lib/fakes_test.go
+++ b/internal/lib/fakes_test.go
@@ -126,6 +126,17 @@ func gpFuncReturnScratchNonRootException(ctx context.Context) (*pyxis.CertProjec
 	}, nil
 }
 
+// gpFuncReturnScratchRootException implements gpFunc and returns a scratch
+// and root exception.
+func gpFuncReturnScratchRootException(ctx context.Context) (*pyxis.CertProject, error) {
+	return &pyxis.CertProject{
+		Container: pyxis.Container{
+			Type:       "scratch",
+			Privileged: true,
+		},
+	}, nil
+}
+
 // gpFuncReturnRootException implements gpFunc and returns a root exception.
 func gpFuncReturnRootException(ctx context.Context) (*pyxis.CertProject, error) {
 	return &pyxis.CertProject{

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -125,6 +125,9 @@ func GetContainerPolicyExceptions(ctx context.Context, pc PyxisClient) (policy.P
 	}
 	// log.Debugf("Certification project name is: %s", certProject.Name)
 	if certProject.Container.Type == "scratch" {
+		if certProject.Container.Privileged {
+			return policy.PolicyScratchRoot, nil
+		}
 		return policy.PolicyScratchNonRoot, nil
 	}
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -125,7 +125,7 @@ func GetContainerPolicyExceptions(ctx context.Context, pc PyxisClient) (policy.P
 	}
 	// log.Debugf("Certification project name is: %s", certProject.Name)
 	if certProject.Container.Type == "scratch" {
-		return policy.PolicyScratch, nil
+		return policy.PolicyScratchNonRoot, nil
 	}
 
 	// if a partner sets `Host Level Access` in connect to `Privileged`, enable RootExceptionContainerPolicy checks

--- a/internal/lib/lib_container_test.go
+++ b/internal/lib/lib_container_test.go
@@ -45,9 +45,9 @@ var _ = Describe("Lib Container Functions", func() {
 		})
 
 		It("should return a scratch policy exception if the project has the flag in the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnScratchException
+			fakePC.getProjectsFunc = gpFuncReturnScratchNonRootException
 			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
-			Expect(p).To(Equal(policy.PolicyScratch))
+			Expect(p).To(Equal(policy.PolicyScratchNonRoot))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/internal/lib/lib_container_test.go
+++ b/internal/lib/lib_container_test.go
@@ -51,6 +51,13 @@ var _ = Describe("Lib Container Functions", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should return a scratch and root policy exception if the project has the flag in the API", func() {
+			fakePC.getProjectsFunc = gpFuncReturnScratchRootException
+			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+			Expect(p).To(Equal(policy.PolicyScratchRoot))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should return a root policy exception if the project has the flag in the API", func() {
 			fakePC.getProjectsFunc = gpFuncReturnRootException
 			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)


### PR DESCRIPTION
The policy for scratch container images includes the check for `RunAsNonRoot` and does not consider the privileged setting in the container project. This PR is about to introduce a scratch container image policy to consider running privileged containers.

This PR arises from discussions on the RH support case 03250672 which triggered issue #766.

Testing the latest `preflight` (main branch) with issue #766 corrected, solved the parsing problem but introduced the `RunAsNonRoot` check again as part of the scratch policy. In preflight v1.4.0, the check has been skipped based on the project setting. This behavior might have been introduced by PR #776 which correctly detects scratch images.

Signed-off-by: Hendrik Brueckner <brueckner@linux.ibm.com>