### PR TITLE
Update GolangCI-lint to v1.49.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 	$(shell if [ -f "$(BINARY)-$(GOOS)-$(GOARCH)" ]; then rm -f $(BINARY)-$(GOOS)-$(GOARCH); fi)))
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.48.0
+GOLANGCI_LINT_VERSION ?= v1.49.0
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.49.0

No other changes needed as it seems to pass with the new version.