### PR TITLE
Add dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# dependabot config
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enables [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) to keep the go.mod dependencies up to date.  Opens PR with package updates.

Similar changes/files: 
- https://github.com/test-network-function/cnf-certification-test/blob/main/.github/dependabot.yml
- https://github.com/test-network-function/autodiscover/pull/2
- https://github.com/test-network-function/l2discovery/pull/9
- https://github.com/test-network-function/oct/pull/4