### PR TITLE
Use constructor-style for NoopSubmitter

### DIFF
--- a/cmd/check_container_test.go
+++ b/cmd/check_container_test.go
@@ -158,7 +158,7 @@ certification_project_id: mycertid`
 			AfterEach(func() {
 				submit = origSubmitValue
 			})
-			It("should return a noopSubmitter ResultSubmitter", func() {
+			It("should return a NoopSubmitter ResultSubmitter", func() {
 				runner, err := lib.NewCheckContainerRunner(context.TODO(), cfg, false)
 				Expect(err).ToNot(HaveOccurred())
 				_, rsIsCorrectType := runner.Rs.(*lib.NoopSubmitter)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -109,7 +109,7 @@ func ResolveSubmitter(pc PyxisClient, cfg certification.Config) ResultSubmitter 
 			PreflightLogFile:       cfg.LogFile(),
 		}
 	}
-	return NewNoopSubmitter(true, "", nil)
+	return NewNoopSubmitter(true, nil)
 }
 
 // GetContainerPolicyExceptions will query Pyxis to determine if

--- a/internal/lib/lib_container_test.go
+++ b/internal/lib/lib_container_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Lib Container Functions", func() {
 			bf = bytes.NewBuffer([]byte{})
 			bufferLogger.SetOutput(bf)
 
-			noop = NewNoopSubmitter(false, "", bufferLogger)
+			noop = NewNoopSubmitter(false, bufferLogger)
 		})
 
 		Context("and enabling log emitting", func() {

--- a/internal/lib/preflight_check_test.go
+++ b/internal/lib/preflight_check_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Preflight Check Func", func() {
 
 			fmttr, _ = formatters.NewByName(formatters.DefaultFormat)
 			rw = &runtime.ResultWriterFile{}
-			rs = NewNoopSubmitter(false, "", nil)
+			rs = NewNoopSubmitter(false, nil)
 
 			DeferCleanup(os.RemoveAll, localTempDir)
 			DeferCleanup(os.RemoveAll, localArtifactsDir)

--- a/internal/lib/types.go
+++ b/internal/lib/types.go
@@ -186,10 +186,9 @@ type NoopSubmitter struct {
 	log     *log.Logger
 }
 
-func NewNoopSubmitter(emitLog bool, reason string, log *log.Logger) *NoopSubmitter {
+func NewNoopSubmitter(emitLog bool, log *log.Logger) *NoopSubmitter {
 	return &NoopSubmitter{
 		emitLog: emitLog,
-		reason:  reason,
 		log:     log,
 	}
 }


### PR DESCRIPTION
Inspired by #809 

This change can be separated from the rest of the `lib` work, but using a constructor-style to creating the `noopSubmitter` objects.