### PR TITLE
no longer send dockerconfigjson if container.HostedRegistry is true

### DIFF
--- a/certification/pyxis/types.go
+++ b/certification/pyxis/types.go
@@ -106,6 +106,7 @@ type CertProject struct {
 
 type Container struct {
 	DockerConfigJSON string `json:"docker_config_json,omitempty"`
+	HostedRegistry   bool   `json:"hosted_registry,omitempty"`
 	Type             string `json:"type,omitempty"`    // conditionally required
 	ISVPID           string `json:"isv_pid,omitempty"` // required
 	Registry         string `json:"registry,omitempty"`

--- a/internal/lib/fakes_test.go
+++ b/internal/lib/fakes_test.go
@@ -105,6 +105,18 @@ func gpFuncReturnError(ctx context.Context) (*pyxis.CertProject, error) {
 	return nil, errors.New("some error returned from the api")
 }
 
+// gpFuncReturnHostedRegistry implements gpFunc and returns hosted_registry=true.
+func gpFuncReturnHostedRegistry(ctx context.Context) (*pyxis.CertProject, error) {
+	return &pyxis.CertProject{
+		ID:                  "000000000000",
+		CertificationStatus: "false",
+		Name:                "some-project",
+		Container: pyxis.Container{
+			HostedRegistry: true,
+		},
+	}, nil
+}
+
 // gpFuncReturnScratchException implements gpFunc and returns a scratch exception.
 func gpFuncReturnScratchException(ctx context.Context) (*pyxis.CertProject, error) {
 	return &pyxis.CertProject{

--- a/internal/lib/lib_container_test.go
+++ b/internal/lib/lib_container_test.go
@@ -154,6 +154,17 @@ var _ = Describe("Lib Container Functions", func() {
 			})
 		})
 
+		Context("and certProject.Container.hosted_registry=true", func() {
+			BeforeEach(func() {
+				fakePC.setSRFuncSubmitSuccessfully("", "")
+				fakePC.getProjectsFunc = gpFuncReturnHostedRegistry
+			})
+			It("should not throw an error", func() {
+				err := sbmt.Submit(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
 		Context("and the cert image cannot be read from disk", func() {
 			It("should throw an error", func() {
 				err := os.Remove(path.Join(artifacts.Path(), certification.DefaultCertImageFilename))

--- a/internal/lib/types.go
+++ b/internal/lib/types.go
@@ -106,6 +106,12 @@ func (s *ContainerCertificationSubmitter) Submit(ctx context.Context) error {
 		certProject.Container.DockerConfigJSON = ""
 	}
 
+	// no longer set DockerConfigJSON for registries which Red Hat hosts, this prevents the user from sending an invalid
+	// docker file that systems like clair and registry-proxy cannot use to pull the image
+	if certProject.Container.HostedRegistry {
+		certProject.Container.DockerConfigJSON = ""
+	}
+
 	// prepare submission. We ignore the error because nil checks for the certProject
 	// are done earlier to prevent panics, and that's the only error case for this function.
 	submission, _ := pyxis.NewCertificationInput(certProject)


### PR DESCRIPTION
- Fixes: #817 
- Add in a check container to see if RH hosts the registry, and if so no longer send the dockerconfigjson to pyxis
  - This prevents uploading dockerfiles that clair/registry-proxy would be unable to use to pull the image
- Added unit tests to cover this logic
- Manually tested in UAT against projects `6334bcc6580d0bddc451107c` and `6334c74d387cd5060b70dce8`

Signed-off-by: Adam D. Cornett <adc@redhat.com>