### PR TITLE
Grab the image that matches the arch of the binary

### DIFF
--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	goruntime "runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -28,8 +29,10 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -76,6 +79,10 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 				authn.WithDockerConfig(c.Config.DockerConfig()),
 			),
 		),
+		crane.WithPlatform(&cranev1.Platform{
+			OS:           "linux",
+			Architecture: goruntime.GOARCH,
+		}),
 		retryOnceAfter(5 * time.Second),
 	}
 

--- a/certification/internal/policy/container/has_unique_tag.go
+++ b/certification/internal/policy/container/has_unique_tag.go
@@ -3,12 +3,14 @@ package container
 import (
 	"context"
 	"fmt"
+	goruntime "runtime"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/authn"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 var _ certification.Check = &hasUniqueTagCheck{}
@@ -57,6 +59,10 @@ func (p *hasUniqueTagCheck) getDataToValidate(ctx context.Context, image string)
 	options := []crane.Option{
 		crane.WithContext(ctx),
 		crane.WithAuthFromKeychain(authn.PreflightKeychain(authn.WithDockerConfig(p.dockercfg))),
+		crane.WithPlatform(&cranev1.Platform{
+			OS:           "linux",
+			Architecture: goruntime.GOARCH,
+		}),
 	}
 
 	return crane.ListTags(image, options...)

--- a/certification/runtime/assets.go
+++ b/certification/runtime/assets.go
@@ -3,11 +3,13 @@ package runtime
 import (
 	"context"
 	"fmt"
+	goruntime "runtime"
 	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/internal/authn"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -26,6 +28,10 @@ func imageList(ctx context.Context) []string {
 	options := []crane.Option{
 		crane.WithContext(ctx),
 		crane.WithAuthFromKeychain(authn.PreflightKeychain()),
+		crane.WithPlatform(&cranev1.Platform{
+			OS:           "linux",
+			Architecture: goruntime.GOARCH,
+		}),
 	}
 
 	imageList := make([]string, 0, len(images))


### PR DESCRIPTION
Crane defaults to "linux/amd64" as the platform, unless an option is passed with WithPlatform. This defaults to an OS of "linux", and an architecture of runtime.GOARCH, which is basically set at build time.

Additional work will be required to process all arches of an image in one go.

Related #807

Signed-off-by: Brad P. Crochet <brad@redhat.com>