### PR TITLE
add support for kubeconfig being pulled in from an io.Reader and stored as a []byte

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -33,6 +33,7 @@ type CheckEngine interface {
 func New(ctx context.Context,
 	image string,
 	checks []certification.Check,
+	kubeconfig []byte,
 	dockerconfig string,
 	isBundle,
 	isScratch bool,
@@ -40,6 +41,7 @@ func New(ctx context.Context,
 	platform string,
 ) (CheckEngine, error) {
 	return &internal.CraneEngine{
+		Kubeconfig:   kubeconfig,
 		DockerConfig: dockerconfig,
 		Image:        image,
 		Checks:       checks,
@@ -52,7 +54,8 @@ func New(ctx context.Context,
 // OperatorCheckConfig contains configuration relevant to an individual check's execution.
 type OperatorCheckConfig struct {
 	ScorecardImage, ScorecardWaitTime, ScorecardNamespace, ScorecardServiceAccount string
-	IndexImage, DockerConfig, Channel, Kubeconfig                                  string
+	IndexImage, DockerConfig, Channel                                              string
+	Kubeconfig                                                                     []byte
 }
 
 // InitializeOperatorChecks returns opeartor checks for policy p give cfg.

--- a/certification/engine/engine_test.go
+++ b/certification/engine/engine_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("CheckInitialization", func() {
 	When("initializing the engine", func() {
 		It("should not return an error", func() {
-			_, err := New(context.TODO(), "example.com/some/image:latest", []certification.Check{}, "", false, false, false, goruntime.GOARCH)
+			_, err := New(context.TODO(), "example.com/some/image:latest", []certification.Check{}, nil, "", false, false, false, goruntime.GOARCH)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/certification/internal/engine/engine.go
+++ b/certification/internal/engine/engine.go
@@ -38,6 +38,8 @@ import (
 // CraneEngine implements a certification.CheckEngine, and leverage crane to interact with
 // the container registry and target image.
 type CraneEngine struct {
+	// Kubeconfig is a byte slice containing a valid Kubeconfig to be used by checks.
+	Kubeconfig []byte
 	// DockerConfig is the credential required to pull the image.
 	DockerConfig string
 	// Image is what is being tested, and should contain the
@@ -175,7 +177,7 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 
 	if c.IsBundle {
 		// Record test cluster version
-		c.results.TestedOn, err = openshift.GetOpenshiftClusterVersion()
+		c.results.TestedOn, err = openshift.GetOpenshiftClusterVersion(c.Kubeconfig)
 		if err != nil {
 			log.Errorf("could not determine test cluster version: %v", err)
 		}

--- a/certification/internal/openshift/openshift_version.go
+++ b/certification/internal/openshift/openshift_version.go
@@ -3,25 +3,26 @@ package openshift
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 
 	configv1Client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
-func GetOpenshiftClusterVersion() (runtime.OpenshiftClusterVersion, error) {
-	if _, ok := os.LookupEnv("KUBECONFIG"); !ok {
-		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("KUBECONFIG not specified")
+func GetOpenshiftClusterVersion(kubeconfig []byte) (runtime.OpenshiftClusterVersion, error) {
+	if len(kubeconfig) == 0 {
+		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("kubeconfig was not provided")
 	}
-	kubeConfig, err := ctrl.GetConfig() // TODO(): Identify how to get the config/rest client using an io.Reader or similar instead of this.
+
+	restconfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 	if err != nil {
 		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("unable to load the config, check if KUBECONFIG is set correctly: %v", err)
 	}
-	configV1Client, err := configv1Client.NewForConfig(kubeConfig)
+
+	configV1Client, err := configv1Client.NewForConfig(restconfig)
 	if err != nil {
 		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("unable to create a client with the provided kubeconfig: %v", err)
 	}
@@ -30,7 +31,7 @@ func GetOpenshiftClusterVersion() (runtime.OpenshiftClusterVersion, error) {
 		return runtime.UnknownOpenshiftClusterVersion(), fmt.Errorf("unable to get openshift-apiserver cluster operator: %v", err)
 	}
 
-	log.Debug(fmt.Sprintf("fetching operator version and openshift-apiserver version %s from %s", openshiftAPIServer.Status.Versions, kubeConfig.Host))
+	log.Debug(fmt.Sprintf("fetching operator version and openshift-apiserver version %s from %s", openshiftAPIServer.Status.Versions, restconfig.Host))
 	return runtime.OpenshiftClusterVersion{
 		Name:    "OpenShift",
 		Version: openshiftAPIServer.Status.Versions[1].Version,

--- a/certification/internal/openshift/openshift_version_test.go
+++ b/certification/internal/openshift/openshift_version_test.go
@@ -1,8 +1,6 @@
 package openshift
 
 import (
-	"os"
-
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification/runtime"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -12,19 +10,15 @@ import (
 var _ = Describe("OpenShift Version", func() {
 	When("no KUBECONFIG is provided", func() {
 		It("should return UnknownVersion and an error", func() {
-			version, err := GetOpenshiftClusterVersion()
+			version, err := GetOpenshiftClusterVersion([]byte{})
 			Expect(version).To(BeEquivalentTo(runtime.UnknownOpenshiftClusterVersion()))
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("an invalid KUBECONFIG is passed", func() {
-		BeforeEach(func() {
-			os.Setenv("KUBECONFIG", "/bad/kubeconfig")
-			DeferCleanup(os.Unsetenv, "KUBECONFIG")
-		})
 		It("should return UnkownVersion and an error", func() {
-			version, err := GetOpenshiftClusterVersion()
+			version, err := GetOpenshiftClusterVersion([]byte("foo"))
 			Expect(version).To(BeEquivalentTo(runtime.UnknownOpenshiftClusterVersion()))
 			Expect(err).To(HaveOccurred())
 		})

--- a/certification/internal/operatorsdk/operatorsdk.go
+++ b/certification/internal/operatorsdk/operatorsdk.go
@@ -41,9 +41,21 @@ func (o operatorSdk) Scorecard(ctx context.Context, image string, opts OperatorS
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--selector=%s", selector))
 		}
 	}
-	if opts.Kubeconfig != "" {
-		cmdArgs = append(cmdArgs, "--kubeconfig", opts.Kubeconfig)
+
+	if opts.Kubeconfig != nil {
+		kcf, err := os.CreateTemp("", "")
+		if err != nil {
+			return nil, fmt.Errorf("unable to create a temporary kubeconfig file for use with scorecard: %s", err)
+		}
+		log.Trace("created temporary kubeconfig for use with scorecard at path: ", kcf.Name())
+		defer os.Remove(kcf.Name())
+		_, err = kcf.Write(opts.Kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("unable to write a temporary kubeconfig for use with scorecard: %s", err)
+		}
+		cmdArgs = append(cmdArgs, "--kubeconfig", kcf.Name())
 	}
+
 	if opts.WaitTime != "" {
 		cmdArgs = append(cmdArgs, "--wait-time", opts.WaitTime)
 	}

--- a/certification/internal/operatorsdk/operatorsdk_test.go
+++ b/certification/internal/operatorsdk/operatorsdk_test.go
@@ -38,7 +38,7 @@ var _ = Describe("OperatorSdk", func() {
 				ResultFile:     "success.txt",
 				OutputFormat:   "json",
 				Selector:       []string{"selector1", "selector2"},
-				Kubeconfig:     "/my/kubeconfig",
+				Kubeconfig:     []byte("fake kubeconfig contents"),
 				Namespace:      "awesome-namespace",
 				ServiceAccount: "this-service-account",
 				Verbose:        true,

--- a/certification/internal/operatorsdk/types.go
+++ b/certification/internal/operatorsdk/types.go
@@ -4,7 +4,7 @@ type OperatorSdkScorecardOptions struct {
 	OutputFormat   string
 	Selector       []string
 	ResultFile     string
-	Kubeconfig     string
+	Kubeconfig     []byte
 	Namespace      string
 	ServiceAccount string
 	Verbose        bool

--- a/certification/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec.go
@@ -20,7 +20,7 @@ type ScorecardBasicSpecCheck struct {
 
 const scorecardBasicCheckResult string = "operator_bundle_scorecard_BasicSpecCheck.json"
 
-func NewScorecardBasicSpecCheck(operatorSdk operatorSdk, ns, sa, kubeconfig, waittime string) *ScorecardBasicSpecCheck {
+func NewScorecardBasicSpecCheck(operatorSdk operatorSdk, ns, sa string, kubeconfig []byte, waittime string) *ScorecardBasicSpecCheck {
 	return &ScorecardBasicSpecCheck{
 		scorecardCheck: scorecardCheck{
 			OperatorSdk:    operatorSdk,

--- a/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/certification/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -73,7 +73,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		fakeEngine = FakeOperatorSdk{
 			OperatorSdkReport: report,
 		}
-		scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
+		scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
 
 		tmpDir, err := os.MkdirTemp("", "artifacts-*")
 		Expect(err).ToNot(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				engine := fakeEngine.(FakeOperatorSdk)
 				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
 				fakeEngine = engine
-				scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
+				scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardBasicCheck.Validate(testcontext, certification.ImageReference{ImageURI: "dummy/image"})
@@ -112,7 +112,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Checking that OperatorSdk errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdk{}
-			scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", "", "20")
+			scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {

--- a/certification/internal/policy/operator/scorecard_check.go
+++ b/certification/internal/policy/operator/scorecard_check.go
@@ -15,7 +15,7 @@ type scorecardCheck struct {
 
 	namespace      string
 	serviceAccount string
-	kubeconfig     string
+	kubeconfig     []byte
 	waitTime       string
 }
 

--- a/certification/internal/policy/operator/scorecard_olm_suite.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite.go
@@ -20,7 +20,7 @@ type ScorecardOlmSuiteCheck struct {
 
 const scorecardOlmSuiteResult string = "operator_bundle_scorecard_OlmSuiteCheck.json"
 
-func NewScorecardOlmSuiteCheck(operatorSdk operatorSdk, ns, sa, kubeconfig, waittime string) *ScorecardOlmSuiteCheck {
+func NewScorecardOlmSuiteCheck(operatorSdk operatorSdk, ns, sa string, kubeconfig []byte, waittime string) *ScorecardOlmSuiteCheck {
 	return &ScorecardOlmSuiteCheck{
 		scorecardCheck: scorecardCheck{
 			OperatorSdk:    operatorSdk,

--- a/certification/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/certification/internal/policy/operator/scorecard_olm_suite_test.go
@@ -73,7 +73,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		fakeEngine = FakeOperatorSdk{
 			OperatorSdkReport: report,
 		}
-		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", "", "20")
+		scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
 
 		tmpDir, err := os.MkdirTemp("", "artifacts-*")
 		Expect(err).ToNot(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 				engine := fakeEngine.(FakeOperatorSdk)
 				engine.OperatorSdkReport.Items[0].Status.Results[0].State = "fail"
 				fakeEngine = engine
-				scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", "", "20")
+				scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
 			})
 			It("Should not pass Validate", func() {
 				ok, err := scorecardOlmSuiteCheck.Validate(testcontext, certification.ImageReference{ImageURI: "dummy/image"})
@@ -112,7 +112,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	Describe("Checking that OperatorSdk errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdk{}
-			scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", "", "20")
+			scorecardOlmSuiteCheck = *NewScorecardOlmSuiteCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
 		})
 		Context("When OperatorSdk throws an error", func() {
 			It("should fail Validate and return an error", func() {

--- a/container/check_container.go
+++ b/container/check_container.go
@@ -75,7 +75,7 @@ func (c *containerCheck) Run(ctx context.Context) (runtime.Results, error) {
 		return runtime.Results{}, fmt.Errorf("%w: %s", preflighterr.ErrCannotInitializeChecks, err)
 	}
 
-	eng, err := engine.New(ctx, c.image, checks, c.dockerconfigjson, false, pol == policy.PolicyScratch, c.insecure, c.platform)
+	eng, err := engine.New(ctx, c.image, checks, nil, c.dockerconfigjson, false, pol == policy.PolicyScratch, c.insecure, c.platform)
 	if err != nil {
 		return runtime.Results{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	gotest.tools/v3 v3.4.0
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
+	k8s.io/client-go v0.25.0
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -118,7 +119,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/apiserver v0.25.0 // indirect
-	k8s.io/client-go v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/operator/check_operator_test.go
+++ b/operator/check_operator_test.go
@@ -13,7 +13,8 @@ var _ = Describe("Operator Check initialization", func() {
 	When("Using options to initialize a check", func() {
 		It("Should properly store the options with their correct values", func() {
 			image := "placeholder"
-			kubeconfig := "/some/path/to/kubeconfig"
+			kubeconfigContents := "kubeconfig contents"
+			kubeconfig := []byte(kubeconfigContents)
 			indeximage := "indeximage:latest"
 			scorecardImage := "scorecardimage:latest"
 			scorecardNamespace := "scorecardnamespace"
@@ -22,7 +23,7 @@ var _ = Describe("Operator Check initialization", func() {
 			operatorChannel := "operatorchannel"
 			dockerConfigFilePath := "dockerconfigfilepath"
 			insecure := true
-			c := NewCheck(image, kubeconfig, indeximage,
+			c := NewCheck(image, indeximage, kubeconfig,
 				WithScorecardImage(scorecardImage),
 				WithScorecardNamespace(scorecardNamespace),
 				WithScorecardServiceAccount(scorecardServiceAccount),
@@ -33,6 +34,7 @@ var _ = Describe("Operator Check initialization", func() {
 			)
 			Expect(c.image).To(Equal(image))
 			Expect(c.kubeconfig).To(Equal(kubeconfig))
+			Expect(c.kubeconfig).To(Equal([]byte(kubeconfigContents)))
 			Expect(c.indeximage).To(Equal(indeximage))
 			Expect(c.scorecardImage).To(Equal(scorecardImage))
 			Expect(c.scorecardNamespace).To(Equal(scorecardNamespace))
@@ -50,19 +52,19 @@ var _ = Describe("Operator Check Execution", func() {
 
 	When("Calling the check", func() {
 		It("should fail if you passed an empty image", func() {
-			chk := NewCheck("", "kubeconfig", "indeximage")
+			chk := NewCheck("", "indeximage", []byte{})
 			_, err := chk.Run(context.TODO())
 			Expect(err).To(MatchError(preflighterr.ErrImageEmpty))
 		})
 
 		It("should fail if you passed an empty kubeconfig", func() {
-			chk := NewCheck("image", "", "indeximage")
+			chk := NewCheck("image", "indeximage", nil)
 			_, err := chk.Run(context.TODO())
 			Expect(err).To(MatchError(preflighterr.ErrKubeconfigEmpty))
 		})
 
 		It("should fail if you passed an empty index image", func() {
-			chk := NewCheck("image", "kubeconfig", "")
+			chk := NewCheck("image", "", []byte{})
 			_, err := chk.Run(context.TODO())
 			Expect(err).To(MatchError(preflighterr.ErrIndexImageEmpty))
 		})


### PR DESCRIPTION
This PR converts all logic that relies on the existence of the `KUBECONFIG` environment variable to instead rely on either the raw data (as `[]byte` or an `io.Reader` depending on the case.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>