### PR TITLE
updating git ignore to ignore files outputted by check operator cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,14 @@ results.json
 cert-image.json
 rpm-manifest.json
 results-junit.xml
+*CatalogSource.json
+*Namespace.json
+*OperatorGroup.json
+*Subscription.json
+*BasicSpecCheck.json
+*OlmSuiteCheck.json
+hashes.txt
+
 # E2E customzied env log file.
 sgol.txt
 


### PR DESCRIPTION
- Updating the gitignore so we do not accidentally check in output files.

Signed-off-by: Adam D. Cornett <adc@redhat.com>