### PR TITLE
allow results and log writing to overwrite existing content on re-run of preflight

### DIFF
--- a/artifacts/filesystem_writer.go
+++ b/artifacts/filesystem_writer.go
@@ -46,7 +46,7 @@ type FilesystemWriterOption = func(*FilesystemWriter)
 func (w *FilesystemWriter) WriteFile(filename string, contents io.Reader) (string, error) {
 	fullFilePath := filepath.Join(w.Path(), filename)
 
-	if err := afero.SafeWriteReader(w.fs, fullFilePath, contents); err != nil {
+	if err := afero.WriteReader(w.fs, fullFilePath, contents); err != nil {
 		return fullFilePath, fmt.Errorf("could not write file to artifacts directory: %v", err)
 	}
 	return fullFilePath, nil


### PR DESCRIPTION
Workaround for #827 

In [version 1.4.0](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/1.4.0/certification/artifacts/artifacts.go#L51), Preflight would overwrite existing results.json, etc. within the artifacts directory on re-execution. This behavior changed in version 1.4.1 with the introduction of Afero which is causing some friction for users.

This PR should return the original behavior back until we decide what we want to do re: artifacts writing in the future.

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>