### PR TITLE
chore: fix typo in log message

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -282,7 +282,7 @@ func tagDigestBindingInfo(providedIdentifier string, resolvedDigest string) (msg
 	}
 
 	return fmt.Sprintf(
-		`This image's tag %s will be paired with digest %s`+
+		`This image's tag %s will be paired with digest %s `+
 			`once this image has been published in accordance `+
 			`with Red Hat Certification policy. `+
 			`You may then add or remove any supplemental tags `+


### PR DESCRIPTION
Currently the message `once this image` was tied to the container image sha256 digest, this put just an space for easy reading and parsing.

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>