### PR TITLE
adding platform option to generateContainerCheckOptions

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -186,6 +186,7 @@ func generateContainerCheckOptions(cfg *runtime.Config) []container.Option {
 		container.WithDockerConfigJSONFromFile(cfg.DockerConfig),
 		// Always add PyxisHost, since the value is always set in viper config parsing.
 		container.WithPyxisHost(cfg.PyxisHost),
+		container.WithPlatform(cfg.Platform),
 	}
 
 	// set auth information if both are present in config.


### PR DESCRIPTION
When we refactored for `/lib` it seems `--platform` was missed as an option to be passed through to `check container`. This adds the `platoform` option to the check.

-Relates: #807 


## Test Data
### Input
```
check
container
quay.io/opdev/preflight:1.5.0
--submit
--pyxis-api-token=super-legit-token
--certification-project-id=62475e954a0f4241da0984f8
--platform=arm64
```

### Output `cert-image.json` file
```
{
    "certified": false,
    "deleted": false,
    "docker_image_digest": "sha256:d63ebb9a3a9ea6970a9a7a2968eeebbd1cdc80ca9ef5a2b747758f09f25b3f53",
    "docker_image_id": "sha256:da0991f2444cb9924df895d267ae4cbb359eca735c143255e8b0b3c2a656b5b2",
    "image_id": "sha256:d63ebb9a3a9ea6970a9a7a2968eeebbd1cdc80ca9ef5a2b747758f09f25b3f53",
    "parsed_data": {
        "architecture": "arm64",
        "command": "--help",
        "created": "2023-01-19 22:33:14.050783235 +0000 UTC",
        "image_id": "sha256:d63ebb9a3a9ea6970a9a7a2968eeebbd1cdc80ca9ef5a2b747758f09f25b3f53",
...
```        

Signed-off-by: Adam D. Cornett <adc@redhat.com>