### PR TITLE
removing oc as a binary dependency since we now use the library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ LABEL ARCH=${ARCH}
 LABEL OS=${OS}
 
 # Define versions for dependencies
-ARG OPENSHIFT_CLIENT_VERSION=4.7.19
 ARG OPERATOR_SDK_VERSION=1.26.0
 
 # Add preflight binary
@@ -56,9 +55,6 @@ RUN dnf install -y \
       findutils \
       podman \
     && dnf clean all
-
-# Install OpenShift client binary
-RUN curl --fail -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_CLIENT_VERSION}/openshift-client-linux-${OPENSHIFT_CLIENT_VERSION}.tar.gz | tar -xzv -C /usr/local/bin oc
 
 # Install Operator SDK binray
 RUN curl --fail -Lo /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_${ARCH} \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ functional, and in your path.
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
 | OperatorSDK      | `operator-sdk`    |         v1.26.0 |
-| OpenShift Client | `oc`              |         v4.7.19 |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
 development environment. Some checks may also require access to an OpenShift


### PR DESCRIPTION
We now use oc via a library and not a binary dependency, so it makes sense to remove this from our container.

# Motivations:
- Relates: openshift/release#36183

Had a comment that we should keep the version in preflight and in our E2E automation the pinned to the same version. Since we don't really need this anymore I feel it makes more sense to remove it from our container. And then in the E2E tests.

# What doesn't change:
It makes sense to keep `oc` in our vagrant file and in our Dev docs, since it's a nice to have to help with developer testing on while developing.

# Testing

### `check operator`
```
 podman run \
  -it \
  --rm \
  --security-opt=label=disable \
  --privileged \
  --env KUBECONFIG=/kubeconfig \
  --env PFLT_LOGLEVEL=trace \
  --env PFLT_INDEXIMAGE=quay.io/opdev/simple-demo-operator-catalog:v0.0.6 \
  --env PFLT_ARTIFACTS=/artifacts \
  --env PFLT_CHANNEL=stable \
  --env PFLT_LOGFILE=/artifacts/preflight.log \
  -v ./artifacts:/artifacts \
  -v ${KUBECONFIG}:/kubeconfig \
  quay.io/acornett/preflight:remove-oc check operator quay.io/opdev/simple-demo-operator-bundle:v0.0.6
.
.
.
{
    "image": "quay.io/opdev/simple-demo-operator-bundle:v0.0.6",
    "passed": true,
    "certification_hash": "d41d8cd98f00b204e9800998ecf8427e",
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "0.0.0",
        "commit": "e9a3abc0917d0623ce698a4e911723d2f8c9caca"
    },
    "results": {
        "passed": [
            {
                "name": "ScorecardBasicSpecCheck",
                "elapsed_time": 9738,
                "description": "Check to make sure that all CRs have a spec block."
            },
            {
                "name": "ScorecardOlmSuiteCheck",
                "elapsed_time": 2577,
                "description": "Operator-sdk scorecard OLM Test Suite Check"
            },
            {
                "name": "DeployableByOLM",
                "elapsed_time": 48677,
                "description": "Checking if the operator could be deployed by OLM"
            },
            {
                "name": "ValidateOperatorBundle",
                "elapsed_time": 48,
                "description": "Validating Bundle image that checks if it can validate the content and format of the operator bundle"
            }
        ],
        "failed": [],
        "errors": []
    }
}
```

### `check container`
```
 podman run \
  -it \
  --rm \
  --security-opt=label=disable \
  --privileged \
  --env PFLT_LOGLEVEL=trace \
  --env PFLT_ARTIFACTS=/artifacts \
  --env PFLT_LOGFILE=/artifacts/preflight.log \
  -v ./artifacts:/artifacts \
  quay.io/acornett/preflight:remove-oc check container quay.io/acornett/container-passes:dnfupdate
.
.
.
{
    "image": "quay.io/acornett/container-passes:dnfupdate",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "0.0.0",
        "commit": "e9a3abc0917d0623ce698a4e911723d2f8c9caca"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 135,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 1,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 4209,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1721,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
```

### shows `oc` isn't in container
```
[vagrant@fedora36 preflight]$ podman run -it --entrypoint=/bin/bash  quay.io/acornett/preflight:remove-oc
[root@989a4c9d75d9 /]# oc
bash: oc: command not found
```

Signed-off-by: Adam D. Cornett <adc@redhat.com>