### PR TITLE
updating scorecard knowledge base urls to point to new document location

### DIFF
--- a/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/internal/policy/operator/scorecard_basic_check_spec.go
@@ -57,8 +57,8 @@ func (p *ScorecardBasicSpecCheck) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Check to make sure that all CRs have a spec block.",
 		Level:            "best",
-		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#overview", // Placeholder
-		CheckURL:         "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#basic-test-suite",
+		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/testing-operators/scorecard/#overview",
+		CheckURL:         "https://sdk.operatorframework.io/docs/testing-operators/scorecard/#basic-test-suite",
 	}
 }
 

--- a/internal/policy/operator/scorecard_olm_suite.go
+++ b/internal/policy/operator/scorecard_olm_suite.go
@@ -57,8 +57,8 @@ func (p *ScorecardOlmSuiteCheck) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Operator-sdk scorecard OLM Test Suite Check",
 		Level:            "best",
-		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#overview", // Placeholder
-		CheckURL:         "https://sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#olm-test-suite",
+		KnowledgeBaseURL: "https://sdk.operatorframework.io/docs/testing-operators/scorecard/#overview",
+		CheckURL:         "https://sdk.operatorframework.io/docs/testing-operators/scorecard/#olm-test-suite",
 	}
 }
 


### PR DESCRIPTION
- The previous URL's have moved, updating each scorecard test to point to the appropriate anchor
- Fixes: #905 