### PR TITLE
add offline flag and necessary code to tar artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ results-junit.xml
 *BasicSpecCheck.json
 *OlmSuiteCheck.json
 hashes.txt
+artifacts.tar
 
 # E2E customzied env log file.
 sgol.txt

--- a/artifacts/filesystem_writer.go
+++ b/artifacts/filesystem_writer.go
@@ -52,6 +52,20 @@ func (w *FilesystemWriter) WriteFile(filename string, contents io.Reader) (strin
 	return fullFilePath, nil
 }
 
+// Exists checks if a file exists with a filename
+func (w *FilesystemWriter) Exists(filename string) (bool, error) {
+	fullFilePath := filepath.Join(w.Path(), filename)
+
+	return afero.Exists(w.fs, fullFilePath)
+}
+
+// Remove removes contents from dir at filename.
+func (w *FilesystemWriter) Remove(filename string) error {
+	fullFilePath := filepath.Join(w.Path(), filename)
+
+	return w.fs.Remove(fullFilePath)
+}
+
 // Path is the full artifacts path.
 func (w *FilesystemWriter) Path() string {
 	return w.dir

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
@@ -24,7 +26,7 @@ var _ = Describe("Check Container Command", func() {
 	Context("when running the check container subcommand", func() {
 		Context("With all of the required parameters", func() {
 			It("should reach the core logic, but throw an error because of the placeholder values for the container image", func() {
-				_, err := executeCommand(checkContainerCmd(mockRunPreflight), "example.com/example/image:mytag")
+				_, err := executeCommand(checkContainerCmd(mockRunPreflightReturnNil), "example.com/example/image:mytag")
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -33,21 +35,21 @@ var _ = Describe("Check Container Command", func() {
 	Context("When validating check container arguments and flags", func() {
 		Context("and the user provided more than 1 positional arg", func() {
 			It("should fail to run", func() {
-				_, err := executeCommand(checkContainerCmd(mockRunPreflight), "foo", "bar")
+				_, err := executeCommand(checkContainerCmd(mockRunPreflightReturnNil), "foo", "bar")
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("and the user provided less than 1 positional arg", func() {
 			It("should fail to run", func() {
-				_, err := executeCommand(checkContainerCmd(mockRunPreflight))
+				_, err := executeCommand(checkContainerCmd(mockRunPreflightReturnNil))
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		DescribeTable("and the user has enabled the submit flag",
 			func(errString string, args []string) {
-				out, err := executeCommand(checkContainerCmd(mockRunPreflight), args...)
+				out, err := executeCommand(checkContainerCmd(mockRunPreflightReturnNil), args...)
 				Expect(err).To(HaveOccurred())
 				Expect(out).To(ContainSubstring(errString))
 			},
@@ -72,7 +74,7 @@ var _ = Describe("Check Container Command", func() {
 				It("should still execute with no error", func() {
 					submit = true
 
-					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflight), []string{"foo"})
+					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(viper.Instance().GetString("pyxis_api_token")).To(Equal("tokenid"))
 					Expect(viper.Instance().GetString("certification_project_id")).To(Equal("certid"))
@@ -94,7 +96,7 @@ certification_project_id: mycertid`
 					initConfig()
 					submit = true
 
-					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflight), []string{"foo"})
+					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(viper.Instance().GetString("pyxis_api_token")).To(Equal("mytoken"))
 					Expect(viper.Instance().GetString("certification_project_id")).To(Equal("mycertid"))
@@ -110,7 +112,7 @@ certification_project_id: mycertid`
 				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
 			})
 			It("should not change the flag value", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflight), []string{"foo"})
+				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(viper.Instance().GetString("certification_project_id")).To(Equal("123456789"))
 			})
@@ -121,7 +123,7 @@ certification_project_id: mycertid`
 				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
 			})
 			It("should strip ospid- from the flag value", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflight), []string{"foo"})
+				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(viper.Instance().GetString("certification_project_id")).To(Equal("123456789"))
 			})
@@ -132,7 +134,7 @@ certification_project_id: mycertid`
 				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
 			})
 			It("should throw an error", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflight), []string{"foo"})
+				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -142,7 +144,7 @@ certification_project_id: mycertid`
 				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
 			})
 			It("should throw an error", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflight), []string{"foo"})
+				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -151,14 +153,129 @@ certification_project_id: mycertid`
 	Context("when running the check container subcommand with a logger provided", func() {
 		Context("with all of the required parameters", func() {
 			It("should reach the core logic, and execute the mocked RunPreflight", func() {
-				_, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflight), logr.Discard(), "example.com/example/image:mytag")
+				_, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnNil), logr.Discard(), "example.com/example/image:mytag")
 				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("with all of the required parameters with error mocked", func() {
+			It("should reach the core logic, and execute the mocked RunPreflight and return error", func() {
+				_, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnErr), logr.Discard(), "example.com/example/image:mytag")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("when running the check container subcommand with a offline config provided", func() {
+		Context("with all of the required parameters", func() {
+			BeforeEach(func() {
+				tmpDir, err := os.MkdirTemp("", "preflight-submit-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(os.RemoveAll, tmpDir)
+
+				// creating test files on in the tmpDir so the tar function has files to tar
+				f1, err := os.Create(filepath.Join(tmpDir, "test-file-1.json"))
+				Expect(err).ToNot(HaveOccurred())
+				defer f1.Close()
+
+				f2, err := os.Create(filepath.Join(tmpDir, "test-file-1.json"))
+				Expect(err).ToNot(HaveOccurred())
+				defer f2.Close()
+
+				viper.Instance().Set("artifacts", tmpDir)
+				DeferCleanup(viper.Instance().Set, "artifacts", artifacts.DefaultArtifactsDir)
+
+				viper.Instance().Set("offline", true)
+				DeferCleanup(viper.Instance().Set, "offline", false)
+			})
+			It("should reach core logic, and the additional offline logic", func() {
+				out, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnNil), logr.Discard(), "example.com/example/image:mytag")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(BeNil())
+			})
+		})
+		Context("when an existing artifacts.tar already on disk", func() {
+			BeforeEach(func() {
+				tmpDir, err := os.MkdirTemp("", "preflight-submit-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(os.RemoveAll, tmpDir)
+
+				// creating test files on in the tmpDir so the tar function has files to tar
+				f1, err := os.Create(filepath.Join(tmpDir, "test-file-1.json"))
+				Expect(err).ToNot(HaveOccurred())
+				defer f1.Close()
+
+				f2, err := os.Create(filepath.Join(tmpDir, "test-file-1.json"))
+				Expect(err).ToNot(HaveOccurred())
+				defer f2.Close()
+
+				// creating a tar file to mimic a user re-running check container for a second time
+				f3, err := os.Create(filepath.Join(tmpDir, check.DefaultArtifactsTarFileName))
+				Expect(err).ToNot(HaveOccurred())
+				defer f3.Close()
+
+				viper.Instance().Set("artifacts", tmpDir)
+				DeferCleanup(viper.Instance().Set, "artifacts", artifacts.DefaultArtifactsDir)
+
+				viper.Instance().Set("offline", true)
+				DeferCleanup(viper.Instance().Set, "offline", false)
+			})
+			It("should reach the additional offline logic, and remove existing tar file", func() {
+				out, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnNil), logr.Discard(), "example.com/example/image:mytag")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("when artifactsTar is called directly", func() {
+		Context("and the src does not exist", func() {
+			It("should get an unable to tar files error", func() {
+				err := artifactsTar(context.Background(), "", nil)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("and a bad writer is passed", func() {
+			It("should get an error with trying to write the header", func() {
+				err := artifactsTar(context.Background(), ".", errWriter(0))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("and a src has no permissions", func() {
+			var tmpDir string
+			var err error
+			var buf bytes.Buffer
+			JustBeforeEach(func() {
+				tmpDir, err = os.MkdirTemp("", "preflight-submit-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				err = os.Chmod(tmpDir, 0o00)
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(os.RemoveAll, tmpDir)
+			})
+			It("should get an error with trying to read directory", func() {
+				err := artifactsTar(context.Background(), tmpDir, &buf)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("and src only contains another directory", func() {
+			var tmpDir string
+			var err error
+			var buf bytes.Buffer
+			JustBeforeEach(func() {
+				tmpDir, err = os.MkdirTemp("", "preflight-submit-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				err = os.Mkdir(filepath.Join(tmpDir, "test"), 0o755)
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(os.RemoveAll, tmpDir)
+			})
+			It("should continue and not tar any files", func() {
+				err := artifactsTar(context.Background(), tmpDir, &buf)
+				Expect(err).To(BeNil())
 			})
 		})
 	})
 })
 
-func mockRunPreflight(context.Context, func(ctx context.Context) (certification.Results, error), cli.CheckConfig, formatters.ResponseFormatter, lib.ResultWriter, lib.ResultSubmitter) error {
+func mockRunPreflightReturnNil(context.Context, func(ctx context.Context) (certification.Results, error), cli.CheckConfig, formatters.ResponseFormatter, lib.ResultWriter, lib.ResultSubmitter) error {
 	return nil
 }
 

--- a/cmd/preflight/cmd/check_operator_test.go
+++ b/cmd/preflight/cmd/check_operator_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Check Operator", func() {
 	Context("when running the check operator subcommand", func() {
 		Context("without the operator bundle image being provided", func() {
 			It("should return an error", func() {
-				_, err := executeCommand(checkOperatorCmd(mockRunPreflight))
+				_, err := executeCommand(checkOperatorCmd(mockRunPreflightReturnNil))
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -30,7 +30,7 @@ var _ = Describe("Check Operator", func() {
 				os.Unsetenv("KUBECONFIG")
 			})
 			It("should return an error", func() {
-				out, err := executeCommand(checkOperatorCmd(mockRunPreflight), "quay.io/example/image:mytag")
+				out, err := executeCommand(checkOperatorCmd(mockRunPreflightReturnNil), "quay.io/example/image:mytag")
 				Expect(err).To(HaveOccurred())
 				Expect(out).To(ContainSubstring("KUBECONFIG could not"))
 			})
@@ -50,7 +50,7 @@ var _ = Describe("Check Operator", func() {
 				os.Setenv("KUBECONFIG", "foo")
 			})
 			It("should return an error", func() {
-				out, err := executeCommand(checkOperatorCmd(mockRunPreflight), "quay.io/example/image:mytag")
+				out, err := executeCommand(checkOperatorCmd(mockRunPreflightReturnNil), "quay.io/example/image:mytag")
 				Expect(err).To(HaveOccurred())
 				Expect(out).To(ContainSubstring("PFLT_INDEXIMAGE could not"))
 			})
@@ -78,7 +78,7 @@ var _ = Describe("Check Operator", func() {
 				os.Setenv("KUBECONFIG", f1.Name())
 			})
 			It("should reach the core logic, and execute the mocked RunPreflight", func() {
-				out, err := executeCommandWithLogger(checkOperatorCmd(mockRunPreflight), logr.Discard(), "quay.io/example/image:mytag")
+				out, err := executeCommandWithLogger(checkOperatorCmd(mockRunPreflightReturnNil), logr.Discard(), "quay.io/example/image:mytag")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(BeNil())
 			})
@@ -102,7 +102,7 @@ var _ = Describe("Check Operator", func() {
 				os.Setenv("KUBECONFIG", "foo")
 			})
 			It("should return a no such file error", func() {
-				out, err := executeCommandWithLogger(checkOperatorCmd(mockRunPreflight), logr.Discard(), "quay.io/example/image:mytag")
+				out, err := executeCommandWithLogger(checkOperatorCmd(mockRunPreflightReturnNil), logr.Discard(), "quay.io/example/image:mytag")
 				Expect(err).To(HaveOccurred())
 				Expect(out).To(ContainSubstring(": open foo: no such file or directory"))
 			})
@@ -121,7 +121,7 @@ var _ = Describe("Check Operator", func() {
 				os.Setenv("KUBECONFIG", ".")
 			})
 			It("should return an is a directory error", func() {
-				out, err := executeCommandWithLogger(checkOperatorCmd(mockRunPreflight), logr.Discard(), "quay.io/example/image:mytag")
+				out, err := executeCommandWithLogger(checkOperatorCmd(mockRunPreflightReturnNil), logr.Discard(), "quay.io/example/image:mytag")
 				Expect(err).To(HaveOccurred())
 				Expect(out).To(ContainSubstring(": is a directory"))
 			})
@@ -185,7 +185,7 @@ var _ = Describe("Check Operator", func() {
 		})
 
 		It("should succeed when all positional arg constraints and environment constraints are correct", func() {
-			err := checkOperatorPositionalArgs(checkOperatorCmd(mockRunPreflight), posArgs)
+			err := checkOperatorPositionalArgs(checkOperatorCmd(mockRunPreflightReturnNil), posArgs)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/cmd/preflight/cmd/suite_test.go
+++ b/cmd/preflight/cmd/suite_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,4 +23,11 @@ var createAndCleanupDirForArtifactsAndLogs = func() {
 	DeferCleanup(os.RemoveAll, tmpDir)
 	DeferCleanup(os.Unsetenv, "PFLT_ARTIFACTS")
 	DeferCleanup(os.Unsetenv, "PFLT_LOGFILE")
+}
+
+// In order to test some negative paths, this io.Writer will just throw an error
+type errWriter int
+
+func (errWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("test error")
 }

--- a/internal/check/defaults.go
+++ b/internal/check/defaults.go
@@ -1,10 +1,11 @@
 package check
 
 var (
-	DefaultCertImageFilename   = "cert-image.json"
-	DefaultRPMManifestFilename = "rpm-manifest.json"
-	DefaultTestResultsFilename = "results.json"
-	DefaultPyxisHost           = "catalog.redhat.com/api/containers"
-	DefaultPyxisEnv            = "prod"
-	SystemdDir                 = "/etc/systemd/system"
+	DefaultCertImageFilename    = "cert-image.json"
+	DefaultRPMManifestFilename  = "rpm-manifest.json"
+	DefaultTestResultsFilename  = "results.json"
+	DefaultArtifactsTarFileName = "artifacts.tar"
+	DefaultPyxisHost            = "catalog.redhat.com/api/containers"
+	DefaultPyxisEnv             = "prod"
+	SystemdDir                  = "/etc/systemd/system"
 )

--- a/internal/policy/container/base_on_ubi.go
+++ b/internal/policy/container/base_on_ubi.go
@@ -50,7 +50,7 @@ func (p *BasedOnUBICheck) getImageLayers(image cranev1.Image) ([]cranev1.Hash, e
 func (p *BasedOnUBICheck) certifiedImagesFound(ctx context.Context, layerHashes []cranev1.Hash) (bool, error) {
 	certImages, err := p.LayerHashCheckEngine.CertifiedImagesContainingLayers(ctx, layerHashes)
 	if err != nil {
-		return false, fmt.Errorf("pyxis query for uncompressed top layers ids failed: %w", err)
+		return false, fmt.Errorf("pyxis query for uncompressed top layers ids %+q failed: %w", layerHashes, err)
 	}
 	if len(certImages) >= 1 {
 		return true, nil

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Submit                 bool
 	Platform               string
 	Insecure               bool
+	Offline                bool
 	// Operator-Specific Fields
 	Namespace         string
 	ServiceAccount    string
@@ -67,6 +68,7 @@ func (c *Config) storeContainerPolicyConfiguration(vcfg viper.Viper) {
 	c.CertificationProjectID = vcfg.GetString("certification_project_id")
 	c.Platform = vcfg.GetString("platform")
 	c.Insecure = vcfg.GetBool("insecure")
+	c.Offline = vcfg.GetBool("offline")
 }
 
 // storeOperatorPolicyConfiguration reads operator-policy-specific config

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -64,12 +64,12 @@ var _ = Describe("Viper to Runtime Config", func() {
 		})
 	})
 
-	It("should only have 20 struct keys for tests to be valid", func() {
+	It("should only have 23 struct keys for tests to be valid", func() {
 		// If this test fails, it means a developer has added or removed
 		// keys from runtime.Config, and so these tests may no longer be
 		// accurate in confirming that the derived configuration from viper
 		// matches.
 		keys := reflect.TypeOf(Config{}).NumField()
-		Expect(keys).To(Equal(22))
+		Expect(keys).To(Equal(23))
 	})
 })


### PR DESCRIPTION
This is the work for `--offline` flag to tar up the artifacts directory.

- Fixes: #781 
- Add new `--offline` flag for `check container` command
   - make this flag mutually exclusive with `--submit` flag's presence
- Add a method to `tar` the artifacts directory.

 