### PR TITLE
change dependabot to weekly checks to reduce the noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
- Changing the interval for dependabot to weekly to hopefully reduce the number of PR's, and the number of `/retest` that we have to run while waiting for infrastructure.