### PR TITLE
refactoring check container rune to use a closure

### DIFF
--- a/cmd/preflight/cmd/check.go
+++ b/cmd/preflight/cmd/check.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -21,7 +23,7 @@ func checkCmd() *cobra.Command {
 	_ = viper.BindPFlag("artifacts", checkCmd.PersistentFlags().Lookup("artifacts"))
 
 	checkCmd.AddCommand(checkOperatorCmd())
-	checkCmd.AddCommand(checkContainerCmd())
+	checkCmd.AddCommand(checkContainerCmd(cli.RunPreflight))
 
 	return checkCmd
 }

--- a/cmd/preflight/cmd/root_test.go
+++ b/cmd/preflight/cmd/root_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
@@ -24,6 +25,22 @@ func executeCommand(root *cobra.Command, args ...string) (output string, err err
 	root.SetOut(buf)
 	root.SetErr(buf)
 	root.SetArgs(args)
+
+	err = root.Execute()
+
+	return buf.String(), err
+}
+
+// executeCommandWithLogger is like executeCommand, but with an additional argument of a logger. This logger is added
+// to the context, which allows for testing of core functionality within a subcommand that relies on a logger's presence.
+func executeCommandWithLogger(root *cobra.Command, l logr.Logger, args ...string) (output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	ctx := logr.NewContext(context.Background(), l)
+	root.SetContext(ctx)
 
 	err = root.Execute()
 


### PR DESCRIPTION
## Motivation
None of the `check_container` code had test coverage, and existing tests only cover the error scenario where the logger exits early. This isn't ideal, but not terrible with how we currently return `cli.RunPreflight` as the last step in this execution flow and the CLI is heavily tested. However, in the future there will be additional code after `cli.RunPreflight` so being able to test various pass/fail scenarios will be helpful.

## Additions
- executeCommandWithLogger func gives the ability to pass in a logger that is then added to a context, this enables getting to the core functionality.
- runPreflight func gives the ability to mock `cli.RunPreflight`