### PR TITLE
incorporating runPreflight func call into check_operator cmd

### DIFF
--- a/cmd/preflight/cmd/check.go
+++ b/cmd/preflight/cmd/check.go
@@ -22,7 +22,7 @@ func checkCmd() *cobra.Command {
 	checkCmd.PersistentFlags().String("artifacts", "", "Where check-specific artifacts will be written. (env: PFLT_ARTIFACTS)")
 	_ = viper.BindPFlag("artifacts", checkCmd.PersistentFlags().Lookup("artifacts"))
 
-	checkCmd.AddCommand(checkOperatorCmd())
+	checkCmd.AddCommand(checkOperatorCmd(cli.RunPreflight))
 	checkCmd.AddCommand(checkContainerCmd(cli.RunPreflight))
 
 	return checkCmd

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -159,4 +160,8 @@ certification_project_id: mycertid`
 
 func mockRunPreflight(context.Context, func(ctx context.Context) (certification.Results, error), cli.CheckConfig, formatters.ResponseFormatter, lib.ResultWriter, lib.ResultSubmitter) error {
 	return nil
+}
+
+func mockRunPreflightReturnErr(context.Context, func(ctx context.Context) (certification.Results, error), cli.CheckConfig, formatters.ResponseFormatter, lib.ResultWriter, lib.ResultSubmitter) error {
+	return errors.New("random error")
 }


### PR DESCRIPTION
## Motivation
The `cmd` at this level had basically zero code coverage since we were always exiting early for not having a `logr` in the context. This PR builds upon the same format that was added for `check_container`. These tests should now cover all of the core logic that I think is possible. But if there is another `err` case that we can mock I'm happy to add it here, just let me know.

**Note: This PR has mockRunPreflightReturnErr method that is in another PR as well, whichever PR is merged first I'll rebase accordingly**