### PR TITLE
Ensure the engine logs error strings

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -224,7 +224,7 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 		checkElapsedTime := time.Since(checkStartTime)
 
 		if err != nil {
-			logger.WithValues("result", "ERROR", "err", err).Info("check completed", "check", check.Name())
+			logger.WithValues("result", "ERROR", "err", err.Error()).Info("check completed", "check", check.Name())
 			c.results.Errors = appendUnlessOptional(c.results.Errors, certification.Result{Check: check, ElapsedTime: checkElapsedTime})
 			continue
 		}


### PR DESCRIPTION
The engine is logging errors slightly differently than other places that might call our log helper, using WithValues to inject context instead of using logger.Error(...). 

WithValues doesn't seem to stringify error structs, so currently we seem to be getting empty structures instead of strings. This should resolve that.