### PR TITLE
Sign release images with keyless cosign

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -99,6 +99,7 @@ jobs:
     with:
       name: ${{ needs.build-main.outputs.imageName }}
       tag: ${{ needs.build-main.outputs.imageVersion }}
+      sign: false # do not sign images built on main
     secrets:
       registry: ${{ secrets.IMAGE_REGISTRY }}
       user: ${{ secrets.REGISTRY_USER }}

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -19,6 +19,10 @@ on:
       tag:
         required: true
         type: string
+      sign:
+        type: boolean
+        default: false
+        required: false
     secrets:
       registry:
         required: true
@@ -26,13 +30,29 @@ on:
         required: true
       password:
         required: true
+      token:
+        required: false
+        description: "The token used for cosign. Typically GITHUB_TOKEN within GitHub Actions."
+        
         
 
 jobs:
   create-and-push-multiarch-manifest:
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
     name: create and push a multiarch manifest to the repo
     runs-on: ubuntu-latest
     steps:
+      - name: Install cosign
+        if: ${{ inputs.sign == true && github.event.release.published }}
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v2.0.0'
+
       # Authenticate to container image registry to push the image
       - name: Podman Login
         uses: redhat-actions/podman-login@v1
@@ -50,5 +70,22 @@ jobs:
           buildah manifest add ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}-linux-s390x
 
       - name: Push manifest
+        id: push-manifest
         run: |
-            podman manifest push ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}  --all
+            podman manifest push --digestfile imagedigest ${{ inputs.name }} ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}  --all
+            echo "digest=$(cat imagedigest)" | tee -a $GITHUB_OUTPUT
+
+      - name: Sign the published manifest
+        # only sign if release is published, not for ghactions branch push
+        # which is used for testing and development.
+        if: ${{ inputs.sign == true && github.event.release.published }}
+        run: |
+          cosign sign --yes --recursive ${{ secrets.registry }}/${{ inputs.name }}@${{ steps.push-manifest.outputs.digest }}
+
+      - name: Verify the image signature
+        if: ${{ inputs.sign == true && github.event.release.published }}
+        run: |
+          cosign verify \
+            --certificate-identity https://github.com/redhat-openshift-ecosystem/openshift-preflight/.github/workflows/build-multiarch.yml@refs/tags/${{ inputs.tag }} \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -57,15 +57,23 @@ jobs:
       imageVersion: ${{ env.RELEASE_TAG }}
 
   build-multiarch:
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
     needs: build-release
     uses: ./.github/workflows/build-multiarch.yml
     with:
       name: ${{ needs.build-release.outputs.imageName }}
       tag: ${{ needs.build-release.outputs.imageVersion }}
+      sign: true
     secrets:
       registry: ${{ secrets.IMAGE_REGISTRY }}
       user: ${{ secrets.REGISTRY_USER }}
       password: ${{ secrets.REGISTRY_PASSWORD }}
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   extract-assets:
     needs: build-release

--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ make test-e2e
 
 Check out the [contributor documentation][contribution_docs].
 
+## Signed Images
+
+This repository uses the [Cosign](https://github.com/sigstore/cosign) project to
+sign release images stored in `quay.io/opdev/preflight` using [Keyless
+Signatures](https://docs.sigstore.dev/cosign/keyless/). The verification
+workflow is documented in the `verify-image` Make target for those that want to
+confirm the images locally
+
+```shell
+RELEASE_TAG=1.5.4 make verify-image
+```
+
 ## License
 
 Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file


### PR DESCRIPTION
This PR adds a [Cosign](https://github.com/sigstore/cosign) integration to our GitHub actions so that our releases will be signed using Cosign's Keyless Signatures.

This is intended to be a starting point. I'm not fully certain where I want us to go with this as a next step (e.g. binary signing, result signing, etc). With that said, it's a fairly simply addition, and ends up allowing consumers of our container images to optionally verify that the image was built by the workflows in this repo.

The Cosign project has recently hit v2.0.0 - which stabilizes keyless signing for images. Th docs (linked above) are still pending update, so they reference the previous version (which is evident because they constantly include references to the `COSIGN EXPERIMENTAL=1` env var). This stability is particular why I think it's wise to hold off (for now) on doing blob signing. I don't think it'll be long before it stabilizes.

## Change Summary

- Extend our build-release.yml GitHub action to sign the ManifestList that's produced. Explicitly ensure that we're only signing RELEASE images.

- Add docs to README.md and Makefile targets to install Cosign and verify the build.

## The Gist of Cosign

- Cosign provides a simplified tooling to sign that an asset was produced using a known flow, or more specifically, by a known identity/actor. In our case, our "known identity/actor" is our GitHub action.

- When you produce an artifact, you produce a keypair that is then sent to a root trust to produces a signature, which includes a certificate containing identifier metadata.

- For images, the signature is stored in a container repository. It can be the same repository as the image, or some other repository - in this case, I'm just storing it in the same repo (opdev/preflight).

- That certificate, along with your metadata, is then appended to an append-only public transparency log. This allows an external user to request your signature and check it against the transparency log to verify that the asset they pulled matches the metadata the produce embedded in it.

At its core, this should feel a lot like traditional TLS certificate management to folks familiar with that workflow. The key idea is:

- CREATE: You produce an asset.
- SIGN: You identify yourself as being <someone or something directly correlated with the project> (this is typically done using some OIDC).
- VERIFY: Users can then verify that <someone or something directly correlated with the project> indeed produced an asset running in their infrastructure.

## Tangible Example - What's happening under the cover

Maintainers: Reach out to me if you have questions. Happy to clarify anything at all. With that said, you can see this running successfully over in my fork.

https://github.com/komish/openshift-preflight/actions/runs/4536819338/jobs/7994363493

The "Sign the Published Manifest" step is where the magic happens. Once we build the manifest list (containing all of our fat manifests), we publish (recursively) the fat manifest and all of the downstreams.

The verification step is failing here because I have the image registry information hard coded in the calling workflow. That said, if you manually run the verification, we see the expected information for that image.

```
 ⤿ cosign verify 
    --certificate-identity https://github.com/komish/openshift-preflight/.github/workflows/build-multiarch.yml@refs/heads/ghactions \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    quay.io/komish/preflight@sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1 | jq

Verification for quay.io/komish/preflight@sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
[
  {
    "critical": {
      "identity": {
        "docker-reference": "quay.io/komish/preflight"
      },
      "image": {
        "docker-manifest-digest": "sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1"
      },
      "type": "cosign container image signature"
    },
    "optional": {
      "1.3.6.1.4.1.57264.1.1": "https://token.actions.githubusercontent.com",
      "1.3.6.1.4.1.57264.1.2": "push",
      "1.3.6.1.4.1.57264.1.3": "e5bba2d0b9b16c7ce14bc94be883c28deed201f3",
      "1.3.6.1.4.1.57264.1.4": "Build Release",
      "1.3.6.1.4.1.57264.1.5": "komish/openshift-preflight",
      "1.3.6.1.4.1.57264.1.6": "refs/heads/ghactions",
      "Bundle": {
        "SignedEntryTimestamp": "MEUCIQCxiPx5EbV/rajcRtErmGRqxxilRdasoPn7O1tVsyIrnwIgOSyblkxhoPWj7sninAcmwLU1ylCDSIsbTAU9s28UGJY=",
        "Payload": {
          "body": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI4NmY2OWViNGFjMjc4YWNmYjI0YmU4NDc2MDkxYzJiMTBjOTQ4Y2U0YzM3NjdkZDA5MDQ0MWE1YzVjM2YxZDkwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJRFI3dXJSM2tUWXVYY3o3d2RuQmlzRG9SZWlNMFQzR0pvMUs5aElmYmlLekFpQWdMRHdJZHpSekM2OTFaYmhkSW5OU25VK0J1eXY4YUg2RHphK1NGVjBoc2c9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVUjJSRU5EUVRCTFowRjNTVUpCWjBsVlpEZG5ZVVJ3WVd4SmVtMW1RMHBYUkM5bVJUSmxUM2RRZDFBd2QwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcE5kMDE2U1ROTmFrbDNUV3BSZDFkb1kwNU5hazEzVFhwSk0wMXFTWGhOYWxGM1YycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZQTDBsM09XOTJVVUV6ZVVSaVdEVjVlQ3REY21oSVZsbDFkMjR2TW1vdmFGVXpjemNLYnpCcFNtODBiVVo2Y0VscVFucG9UbGh5ZG5KdWFscElibnB4Ym5OSFV6SmlUVlJRVGtWcllUTkZPVXRHZUd4blluRlBRMEZ0UlhkblowcGtUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZ3Y0ZGSUNuWjBUeTlpU0VSRFJYcGhlRXRPTldaaFZYbEtjelpqZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDJSbldVUldVakJTUVZGSUwwSkhkM2RoYjFwdllVaFNNR05JVFRaTWVUbHVZVmhTYjJSWFNYVlpNamwwVERKMGRtSlhiSHBoUXpsMlkwZFdkUXBqTW1od1dtNVJkR05JU214YWJYaHdXakpvTUV4NU5XNWhXRkp2WkZkSmRtUXlPWGxoTWxwellqTmtla3d5U2pGaFYzaHJURmN4TVdKSVVuQlpXRXBxQ21GRE5UVmlWM2hCWTIxV2JXTjVPVzlhVjBaclkzazVibUZIUm1wa1IyeDJZbTVOZDA5UldVdExkMWxDUWtGSFJIWjZRVUpCVVZGeVlVaFNNR05JVFRZS1RIazVNR0l5ZEd4aWFUVm9XVE5TY0dJeU5YcE1iV1J3WkVkb01WbHVWbnBhV0VwcVlqSTFNRnBYTlRCTWJVNTJZbFJCVTBKbmIzSkNaMFZGUVZsUEx3cE5RVVZEUWtGU2QyUllUbTlOUkZsSFEybHpSMEZSVVVKbk56aDNRVkZOUlV0SFZURlpiVXBvVFcxUmQxbHFiR2xOVkZwcVRqSk9iRTFVVW1sWmVtc3dDbGx0VlRSUFJFNXFUV3BvYTFwWFZtdE5ha0Y0V21wTmQwZDNXVXRMZDFsQ1FrRkhSSFo2UVVKQ1FWRk9VVzVXY0dKSFVXZFZiVlp6V2xkR2VscFVRVzhLUW1kdmNrSm5SVVZCV1U4dlRVRkZSa0pDY0hKaU1qRndZekpuZG1JelFteGliazV2WVZkYU1FeFlRbmxhVjFwellWZGtiMlJFUVdsQ1oyOXlRbWRGUlFwQldVOHZUVUZGUjBKQ1VubGFWMXA2VERKb2JGbFhVbnBNTW1SdldWZE9NR0ZYT1hWamVrTkNhWGRaUzB0M1dVSkNRVWhYWlZGSlJVRm5VamxDU0hOQkNtVlJRak5CVGpBNVRVZHlSM2g0UlhsWmVHdGxTRXBzYms1M1MybFRiRFkwTTJwNWRDODBaVXRqYjBGMlMyVTJUMEZCUVVKb2VWVlpVbkZCUVVGQlVVUUtRVVZuZDFKblNXaEJTMUF3YkVFMU1FcFJTbkozUjFCdE5rWnVVbEJDVVdsUVluRjJaV3RaZEdscVpsaElUR1oxTWtsakwwRnBSVUZyUTNReWNFTnJlZ3BKY2t4dVdtOTFTa2xPWlZsSGFYWXpTMUp1TWtkcGRqRnlha1IzT0dJeVptMVNZM2REWjFsSlMyOWFTWHBxTUVWQmQwMUVZVUZCZDFwUlNYaEJUMFZhQ21KQ2NUTlJXV05MV2k5eE1VNU5ha0k0WkU5VFJYb3pSV1p1YjJFMGNFUkZSRk0wY25ObFdWbERNR1JQWkM5cmFIRm9UMWRVZFZwR1QzVkdSR3BuU1hjS1RUTTVUa0prVFhOb1QyMVBZMUF3Ym13dmFFVXJOM2hUUjFnNGJIRklZaklyVUZaMlFsTkpTeXRETWtzdmVYaFVVSFp2ZVVOWVFtbDZNM0YzVG1VMVdBb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0ifX19fQ==",
          "integratedTime": 1679954561,
          "logIndex": 16459655,
          "logID": "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
        }
      },
      "Issuer": "https://token.actions.githubusercontent.com",
      "Subject": "https://github.com/komish/openshift-preflight/.github/workflows/build-multiarch.yml@refs/heads/ghactions",
      "githubWorkflowName": "Build Release",
      "githubWorkflowRef": "refs/heads/ghactions",
      "githubWorkflowRepository": "komish/openshift-preflight",
      "githubWorkflowSha": "e5bba2d0b9b16c7ce14bc94be883c28deed201f3",
      "githubWorkflowTrigger": "push"
    }
  }
]
```

What I'm checking for here is that the image I requested (here, by digest, because I've already moved the `ghactions` tag - but normally a user could check either one) was produced by the workflow I defined under the `--certificate-identity` flag. 

GitHub actions are a first-class integration with Cosign, and so here the GitHub actions bot token was used, and so the github OIDC for actions was used.

This is all metadata that was contained in the certificate issued by the root trust ("Fulcio") when we requested the signature.

We can see the certificate data as well. It contains the same values, which ties the identity associated with the signature to this asset.

```
 ⤿ cosign verify \
     --certificate-identity https://github.com/komish/openshift-preflight/.github/workflows/build-multiarch.yml@refs/heads/ghactions \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com quay.io/komish/preflight@sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1 \
         | jq .[0].optional.Bundle.Payload.body -r \
             | base64 -d \
                 | jq .spec.signature.publicKey.content -r \
                     | base64 -d

Verification for quay.io/komish/preflight@sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
-----BEGIN CERTIFICATE-----
MIIDvDCCA0KgAwIBAgIUd7gaDpalIzmfCJWD/fE2eOwPwP0wCgYIKoZIzj0EAwMw
NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
cm1lZGlhdGUwHhcNMjMwMzI3MjIwMjQwWhcNMjMwMzI3MjIxMjQwWjAAMFkwEwYH
KoZIzj0CAQYIKoZIzj0DAQcDQgAEO/Iw9ovQA3yDbX5yx+CrhHVYuwn/2j/hU3s7
o0iJo4mFzpIjBzhNXrvrnjZHnzqnsGS2bMTPNEka3E9KFxlgbqOCAmEwggJdMA4G
A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUppQH
vtO/bHDCEzaxKN5faUyJs6cwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
ZD8wdgYDVR0RAQH/BGwwaoZoaHR0cHM6Ly9naXRodWIuY29tL2tvbWlzaC9vcGVu
c2hpZnQtcHJlZmxpZ2h0Ly5naXRodWIvd29ya2Zsb3dzL2J1aWxkLW11bHRpYXJj
aC55bWxAcmVmcy9oZWFkcy9naGFjdGlvbnMwOQYKKwYBBAGDvzABAQQraHR0cHM6
Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTASBgorBgEEAYO/
MAECBARwdXNoMDYGCisGAQQBg78wAQMEKGU1YmJhMmQwYjliMTZjN2NlMTRiYzk0
YmU4ODNjMjhkZWVkMjAxZjMwGwYKKwYBBAGDvzABBAQNQnVpbGQgUmVsZWFzZTAo
BgorBgEEAYO/MAEFBBprb21pc2gvb3BlbnNoaWZ0LXByZWZsaWdodDAiBgorBgEE
AYO/MAEGBBRyZWZzL2hlYWRzL2doYWN0aW9uczCBiwYKKwYBBAHWeQIEAgR9BHsA
eQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABhyUYRqAAAAQD
AEgwRgIhAKP0lA50JQJrwGPm6FnRPBQiPbqvekYtijfXHLfu2Ic/AiEAkCt2pCkz
IrLnZouJINeYGiv3KRn2Giv1rjDw8b2fmRcwCgYIKoZIzj0EAwMDaAAwZQIxAOEZ
bBq3QYcKZ/q1NMjB8dOSEz3Efnoa4pDEDS4rseYYC0dOd/khqhOWTuZFOuFDjgIw
M39NBdMshOmOcP0nl/hE+7xSGX8lqHb2+PVvBSIK+C2K/yxTPvoyCXBiz3qwNe5X
-----END CERTIFICATE-----
```

We see the values we use to filter against here if we read this cert using `openssl`

```
 ⤿ openssl x509 -in certificate -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            77:b8:1a:0e:96:a5:23:39:9f:08:95:83:fd:f1:36:78:ec:0f:c0:fd
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: O = sigstore.dev, CN = sigstore-intermediate
        Validity
            Not Before: Mar 27 22:02:40 2023 GMT
            Not After : Mar 27 22:12:40 2023 GMT
        Subject: 
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:3b:f2:30:f6:8b:d0:03:7c:83:6d:7e:72:c7:e0:
                    ab:84:75:58:bb:09:ff:da:3f:e1:53:7b:3b:a3:48:
                    89:a3:89:85:ce:92:23:07:38:4d:5e:bb:eb:9e:36:
                    47:9f:3a:a7:b0:64:b6:6c:c4:cf:34:49:1a:dc:4f:
                    4a:17:19:60:6e
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature
            X509v3 Extended Key Usage: 
                Code Signing
            X509v3 Subject Key Identifier: 
                A6:94:07:BE:D3:BF:6C:70:C2:13:36:B1:28:DE:5F:69:4C:89:B3:A7
            X509v3 Authority Key Identifier: 
                keyid:DF:D3:E9:CF:56:24:11:96:F9:A8:D8:E9:28:55:A2:C6:2E:18:64:3F

            X509v3 Subject Alternative Name: critical
                URI:https://github.com/komish/openshift-preflight/.github/workflows/build-multiarch.yml@refs/heads/ghactions
            1.3.6.1.4.1.57264.1.1: 
                https://token.actions.githubusercontent.com
            1.3.6.1.4.1.57264.1.2: 
                push
            1.3.6.1.4.1.57264.1.3: 
                e5bba2d0b9b16c7ce14bc94be883c28deed201f3
            1.3.6.1.4.1.57264.1.4: 
                Build Release
            1.3.6.1.4.1.57264.1.5: 
                komish/openshift-preflight
            1.3.6.1.4.1.57264.1.6: 
                refs/heads/ghactions
            CT Precertificate SCTs: 
                Signed Certificate Timestamp:
                    Version   : v1 (0x0)
                    Log ID    : DD:3D:30:6A:C6:C7:11:32:63:19:1E:1C:99:67:37:02:
                                A2:4A:5E:B8:DE:3C:AD:FF:87:8A:72:80:2F:29:EE:8E
                    Timestamp : Mar 27 22:02:40.672 2023 GMT
                    Extensions: none
                    Signature : ecdsa-with-SHA256
                                30:46:02:21:00:A3:F4:94:0E:74:25:02:6B:C0:63:E6:
                                E8:59:D1:3C:14:22:3D:BA:AF:7A:46:2D:8A:37:D7:1C:
                                B7:EE:D8:87:3F:02:21:00:90:2B:76:A4:29:33:22:B2:
                                E7:66:8B:89:20:D7:98:1A:2B:F7:29:19:F6:1A:2B:F5:
                                AE:30:F0:F1:BD:9F:99:17
    Signature Algorithm: ecdsa-with-SHA384
         30:65:02:31:00:e1:19:6c:1a:b7:41:87:0a:67:fa:b5:34:c8:
         c1:f1:d3:92:13:3d:c4:7e:7a:1a:e2:90:c4:0d:2e:2b:b1:e6:
         18:0b:47:4e:77:f9:21:aa:13:96:4e:e6:45:3a:e1:43:8e:02:
         30:33:7f:4d:05:d3:2c:84:e9:8e:70:fd:27:97:f8:44:fb:bc:
         52:19:7f:25:a8:76:f6:f8:f5:6f:05:22:0a:f8:2d:8a:ff:2c:
         53:3e:fa:32:09:70:62:cf:7a:b0:35:ee:57
```

I mentioned earlier that the signature is stored in the container repository itself. We can use `cosign` to tell us what the expected file _should_ be.

```
 ⤿ cosign triangulate quay.io/komish/preflight@sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1
quay.io/komish/preflight:sha256-7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1.sig
```

We see the data associated with the signature if we pull that image down:

```
 ⤿ crane export quay.io/komish/preflight:sha256-7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1.sig  | jq
{
  "critical": {
    "identity": {
      "docker-reference": "quay.io/komish/preflight"
    },
    "image": {
      "docker-manifest-digest": "sha256:7e2edfe3c263c3278705d6b89b70d997b9b0f385be0775e93e3fcc62f5a22bd1"
    },
    "type": "cosign container image signature"
  },
  "optional": null
}
```

Finally, you might notice that the entries for each image are listed in the output of this action:

```
tlog entry created with index: 16459655
Pushing signature to: ***/preflight
tlog entry created with index: [16](https://github.com/komish/openshift-preflight/actions/runs/4536819338/jobs/7994363493#step:6:17)459658
Pushing signature to: ***/preflight
tlog entry created with index: 16459660
Pushing signature to: ***/preflight
```

These have been uploaded to the public transparency log that's maintained by Sigstore. The `rekor` [GH](https://github.com/sigstore/rekor) tool is used to view that log.

So if I use that tool and query the log index, I get the rekord:

```json
 ⤿ rekor get --log-index 16459655 --format json | jq
{
  "Attestation": "",
  "AttestationType": "",
  "Body": {
    "HashedRekordObj": {
      "data": {
        "hash": {
          "algorithm": "sha256",
          "value": "86f69eb4ac278acfb24be8476091c2b10c948ce4c3767dd090441a5c5c3f1d90"
        }
      },
      "signature": {
        "content": "MEQCIDR7urR3kTYuXcz7wdnBisDoReiM0T3GJo1K9hIfbiKzAiAgLDwIdzRzC691ZbhdInNSnU+Buyv8aH6Dza+SFV0hsg==",
        "publicKey": {
          "content": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR2RENDQTBLZ0F3SUJBZ0lVZDdnYURwYWxJem1mQ0pXRC9mRTJlT3dQd1Awd0NnWUlLb1pJemowRUF3TXcKTnpFVk1CTUdBMVVFQ2hNTWMybG5jM1J2Y21VdVpHVjJNUjR3SEFZRFZRUURFeFZ6YVdkemRHOXlaUzFwYm5SbApjbTFsWkdsaGRHVXdIaGNOTWpNd016STNNakl3TWpRd1doY05Nak13TXpJM01qSXhNalF3V2pBQU1Ga3dFd1lICktvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUVPL0l3OW92UUEzeURiWDV5eCtDcmhIVll1d24vMmovaFUzczcKbzBpSm80bUZ6cElqQnpoTlhydnJualpIbnpxbnNHUzJiTVRQTkVrYTNFOUtGeGxnYnFPQ0FtRXdnZ0pkTUE0RwpBMVVkRHdFQi93UUVBd0lIZ0RBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREF6QWRCZ05WSFE0RUZnUVVwcFFICnZ0Ty9iSERDRXpheEtONWZhVXlKczZjd0h3WURWUjBqQkJnd0ZvQVUzOVBwejFZa0VaYjVxTmpwS0ZXaXhpNFkKWkQ4d2RnWURWUjBSQVFIL0JHd3dhb1pvYUhSMGNITTZMeTluYVhSb2RXSXVZMjl0TDJ0dmJXbHphQzl2Y0dWdQpjMmhwWm5RdGNISmxabXhwWjJoMEx5NW5hWFJvZFdJdmQyOXlhMlpzYjNkekwySjFhV3hrTFcxMWJIUnBZWEpqCmFDNTViV3hBY21WbWN5OW9aV0ZrY3k5bmFHRmpkR2x2Ym5Nd09RWUtLd1lCQkFHRHZ6QUJBUVFyYUhSMGNITTYKTHk5MGIydGxiaTVoWTNScGIyNXpMbWRwZEdoMVluVnpaWEpqYjI1MFpXNTBMbU52YlRBU0Jnb3JCZ0VFQVlPLwpNQUVDQkFSd2RYTm9NRFlHQ2lzR0FRUUJnNzh3QVFNRUtHVTFZbUpoTW1Rd1lqbGlNVFpqTjJObE1UUmlZemswClltVTRPRE5qTWpoa1pXVmtNakF4WmpNd0d3WUtLd1lCQkFHRHZ6QUJCQVFOUW5WcGJHUWdVbVZzWldGelpUQW8KQmdvckJnRUVBWU8vTUFFRkJCcHJiMjFwYzJndmIzQmxibk5vYVdaMExYQnlaV1pzYVdkb2REQWlCZ29yQmdFRQpBWU8vTUFFR0JCUnlaV1p6TDJobFlXUnpMMmRvWVdOMGFXOXVjekNCaXdZS0t3WUJCQUhXZVFJRUFnUjlCSHNBCmVRQjNBTjA5TUdyR3h4RXlZeGtlSEpsbk53S2lTbDY0M2p5dC80ZUtjb0F2S2U2T0FBQUJoeVVZUnFBQUFBUUQKQUVnd1JnSWhBS1AwbEE1MEpRSnJ3R1BtNkZuUlBCUWlQYnF2ZWtZdGlqZlhITGZ1MkljL0FpRUFrQ3QycENregpJckxuWm91SklOZVlHaXYzS1JuMkdpdjFyakR3OGIyZm1SY3dDZ1lJS29aSXpqMEVBd01EYUFBd1pRSXhBT0VaCmJCcTNRWWNLWi9xMU5NakI4ZE9TRXozRWZub2E0cERFRFM0cnNlWVlDMGRPZC9raHFoT1dUdVpGT3VGRGpnSXcKTTM5TkJkTXNoT21PY1AwbmwvaEUrN3hTR1g4bHFIYjIrUFZ2QlNJSytDMksveXhUUHZveUNYQml6M3F3TmU1WAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
        }
      }
    }
  },
  "LogIndex": 16459655,
  "IntegratedTime": 1679954561,
  "UUID": "24296fb24b8ad77ab594d7532c8e78e92099589a6a057054715e659acf24c071ca8f1c13186fab1c",
  "LogID": "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
}
```

The value of the `HashedRekordObj` is the digest of the content I showed above from `crane export`. The publicKey should match what I showed earlier as well.

## Summary

With this change, we'll end up producing a signed image that a consumer of the Sigstore [Policy Controller](https://docs.sigstore.dev/policy-controller/overview/) can then use to assert the preflight image they run is the one produced by us. With that said, this isn't exactly a common workflow, and I know that. This is moreso just a starting PoC. I think next we'll look to expand this to sign our binaries, and potentially along with deploying our own transparency log, potentially sign results.json.