### PR TITLE
setting up log formatter early to force a proper format

### DIFF
--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -88,6 +88,8 @@ func initConfig() {
 func preRunConfig(cmd *cobra.Command, args []string) {
 	viper := viper.Instance()
 	l := logrus.New()
+	l.SetFormatter(&logrus.TextFormatter{DisableColors: true})
+
 	// set up logging
 	logname := viper.GetString("logfile")
 	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
@@ -101,7 +103,6 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 		l.SetLevel(ll)
 	}
 
-	l.SetFormatter(&logrus.TextFormatter{})
 	if !configFileUsed {
 		l.Debug("config file not found, proceeding without it")
 	}


### PR DESCRIPTION
@komish pointed out in the `--offline` pr that the first run of preflight logs differently (see below). The root case to this is that if we can't do an `os.Open` and fall bace to logging to stderr the logrus textformatter just does what it wants.

This pr moves up the logic and forces us to disable color, which then gives us a consistent format to a console as we would to a file with timestamp format.

Example of the error
```
 ./preflight check container --offline quay.io/opdev/simple-demo-operator:latest
INFO[0000] certification library version                 version="0.0.0 <commit: cd9998494513973fb4fd6e4e657f38f9890dc2ee>"
INFO[0005] check completed                               check=HasLicense result=PASSED
INFO[0005] check completed                               check=HasUniqueTag result=PASSED
INFO[0005] check completed                               check=LayerCountAcceptable result=PASSED
INFO[0005] check completed                               check=HasNoProhibitedPackages result=PASSED
INFO[0005] check completed                               check=HasRequiredLabel result=PASSED
INFO[0005] USER 65532:65532 specified that is non-root  
INFO[0005] check completed                               check=RunAsNonRoot result=PASSED
INFO[0006] check completed                               check=HasModifiedFiles result=PASSED
INFO[0007] check completed                               check=BasedOnUbi result=PASSED

... truncated ...
```