### PR TITLE
remove verbosity from target image log line 

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -77,7 +77,7 @@ type CraneEngine struct {
 
 func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 	logger := logr.FromContextOrDiscard(ctx)
-	logger.V(log.DBG).Info("target image", "image", c.Image)
+	logger.Info("target image", "image", c.Image)
 
 	// prepare crane runtime options, if necessary
 	options := []crane.Option{


### PR DESCRIPTION
- Fixes: #938 
- Image registry/repo should always be logged, so logs that are uploaded to pyxis have all the necessary information for cert ops to better troubleshoot.