### PR TITLE
updating operator-sdk to 1.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ LABEL ARCH=${ARCH}
 LABEL OS=${OS}
 
 # Define versions for dependencies
-ARG OPERATOR_SDK_VERSION=1.26.0
+ARG OPERATOR_SDK_VERSION=1.28.0
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.26.0 |
+| OperatorSDK      | `operator-sdk`    |         v1.28.0 |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
 development environment. Some checks may also require access to an OpenShift

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.26.0
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.28.0
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.26.0 |
+| OperatorSDK      | `operator-sdk`    |         v1.28.0 |
 | OpenShift Client | `oc`              |         v4.7.19 |
 | Podman           | `podman`          |            v3.0 |
 

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/onsi/gomega v1.27.5
 	github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
-	github.com/operator-framework/api v0.16.0
-	github.com/operator-framework/operator-manifest-tools v0.2.2
+	github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42
+	github.com/operator-framework/operator-manifest-tools v0.2.3-0.20230227155221-caa8b9e1ab12
 	github.com/redhat-certification/chart-verifier v0.0.0-20230309162114-4bccec13d65a
 	github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator v0.1.0
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
@@ -204,5 +204,3 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
-
-replace github.com/operator-framework/api v0.16.0 => github.com/operator-framework/api v0.16.1-0.20220823134246-5f99430d4ec4

--- a/go.sum
+++ b/go.sum
@@ -737,10 +737,10 @@ github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75 h1:OQJsfiach1cKBI1xU
 github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/operator-framework/api v0.16.1-0.20220823134246-5f99430d4ec4 h1:juST/k+hHmKD/BlZ4GCzeDdxvNsxB4wHlDyfAPYmSrU=
-github.com/operator-framework/api v0.16.1-0.20220823134246-5f99430d4ec4/go.mod h1:kk8xJahHJR3bKqrA+A+1VIrhOTmyV76k+ARv+iV+u1Q=
-github.com/operator-framework/operator-manifest-tools v0.2.2 h1:mALhDVeXCkwh5xsXt4m0eatfL7hxfPOQSTLDSoe/0mo=
-github.com/operator-framework/operator-manifest-tools v0.2.2/go.mod h1:pYXBtryqeokM8MiCtSsGxQUI/vZgcFLMhEI0gkt9KFI=
+github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42 h1:d/Pnr19TnmIq3zQ6ebewC+5jt5zqYbRkvYd37YZENQY=
+github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=
+github.com/operator-framework/operator-manifest-tools v0.2.3-0.20230227155221-caa8b9e1ab12 h1:PXejNY6ZFU6CutIkowf/ECsuT/xcLAIgmXQxG43SHnY=
+github.com/operator-framework/operator-manifest-tools v0.2.3-0.20230227155221-caa8b9e1ab12/go.mod h1:5OAMYmIkFCiiHfS1r3HcIYu3F/sum38pofSoLZy7Cbw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=

--- a/internal/runtime/assets.go
+++ b/internal/runtime/assets.go
@@ -21,7 +21,7 @@ import (
 // to be used outside of this package.
 var images = map[string]string{
 	// operator policy, operator-sdk scorecard
-	"scorecard": "quay.io/operator-framework/scorecard-test:v1.26.0",
+	"scorecard": "quay.io/operator-framework/scorecard-test:v1.28.0",
 }
 
 // imageList takes the images mapping and represents them using just


### PR DESCRIPTION
- Updating `operator-sdk` to 1.28.0 to have latest scorecard image changes
- Using the same dependencies as operator-sdk, so our tests continue to work properly