### PR TITLE
Use mutate.Extract for all images

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -41,6 +41,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -73,6 +74,12 @@ type CraneEngine struct {
 
 	imageRef image.ImageReference
 	results  certification.Results
+}
+
+func export(img cranev1.Image, w io.Writer) error {
+	fs := mutate.Extract(img)
+	_, err := io.Copy(w, fs)
+	return err
 }
 
 func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
@@ -157,7 +164,7 @@ func (c *CraneEngine) ExecuteChecks(ctx context.Context) error {
 		// extraction. These errors will be returned by the reader end
 		// on subsequent reads. If err == nil, the reader will return
 		// EOF.
-		w.CloseWithError(crane.Export(img, w))
+		w.CloseWithError(export(img, w))
 	}()
 
 	logger.V(log.DBG).Info("extracting container filesystem", "path", containerFSPath)


### PR DESCRIPTION
Crane's crane.Export function was special-casing when there is a single layer. It doesn't call mutate.Extract if there is a single layer. Problem is, if there are whiteout files in that first layer, they don't get handled.

So instead, we will just have our own 'export' function that just calls mutate.Extract no matter what.

Fixes #928