### PR TITLE
Remove lib from actions and workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
     - release-*
-    - lib
 
 jobs:
   build:


### PR DESCRIPTION
When the lib branch was active, we added it to the workflows to allow for CI to run. The branch is no longer there, so no need to be in the actions.

Fixes #888