### PR TITLE
removing dependency on ocp-olm-catalog-validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42
 	github.com/operator-framework/operator-manifest-tools v0.2.3-0.20230227155221-caa8b9e1ab12
 	github.com/redhat-certification/chart-verifier v0.0.0-20230309162114-4bccec13d65a
-	github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator v0.1.0
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/afero v1.9.5
@@ -46,6 +45,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bshuster-repo/logrus-logstash-hook v1.0.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,7 +165,9 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bombsimon/logrusr/v4 v4.0.0 h1:Pm0InGphX0wMhPqC02t31onlq9OVyJ98eP/Vh63t1Oo=
 github.com/bombsimon/logrusr/v4 v4.0.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
+github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.2 h1:JYRWo+QGnQdedgshosug9hxpPYTB9oJ1ZZD3fY31alU=
+github.com/bshuster-repo/logrus-logstash-hook v1.0.2/go.mod h1:HgYntJprnHSPaF9VPPPLP1L5S1vMWxRfa1J+vzDrDTw=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
@@ -797,8 +799,6 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-certification/chart-verifier v0.0.0-20230309162114-4bccec13d65a h1:P5RVjmb7z1Cgx6fyEZTcvGgJ8CRxeadlBU+mP0V+yHk=
 github.com/redhat-certification/chart-verifier v0.0.0-20230309162114-4bccec13d65a/go.mod h1:DpkJejLu9gwCZbS4FiqWMXks+yuqQfyQPnuPItDyyRE=
-github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator v0.1.0 h1:4EHstmf5aq2aalaQwb4Fila8GJeDd+O3A6ASC70fQio=
-github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator v0.1.0/go.mod h1:GfYbSrt58GvB8zQlTIaSAMx7d9uAJGnXLDggRqw7C3s=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -8,13 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/operator-framework/api/pkg/validation"
-	olmvalidation "github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator/pkg/validation"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/yaml"
@@ -30,7 +29,7 @@ var ocpToKubeVersion = map[string]string{
 	"4.13": "1.26",
 }
 
-const latestReleasedVersion = "4.11"
+const latestReleasedVersion = "4.12"
 
 func Validate(ctx context.Context, imagePath string) (*Report, error) {
 	logger := logr.FromContextOrDiscard(ctx)
@@ -44,7 +43,6 @@ func Validate(ctx context.Context, imagePath string) (*Report, error) {
 	validators := validation.DefaultBundleValidators.WithValidators(
 		validation.AlphaDeprecatedAPIsValidator,
 		validation.OperatorHubValidator,
-		olmvalidation.OpenShiftValidator,
 	)
 
 	objs := bundle.ObjectsToValidate()


### PR DESCRIPTION
## Motivation
With trying to debug an issue with an error in a PR for the hosted pipeline found [here](https://github.com/redhat-openshift-ecosystem/certified-operators/pull/2109). It was determined that the `ocp validator` was calling `AlphaDeprecatedAPIsValidator` from `operator-sdk`, and making decisions based on the outcome of that call. The problem is that it seems this library was only targeting deprecations in `4.9`, and was leading to unnecessary failures for later versions of OCP. Also, this meant that prelfight was calling `AlphaDeprecatedAPIsValidator` twice.

## Conculsion
After meeting with the business, we can remove this extra library call, since `AlphaDeprecatedAPIsValidator` gives us 4.9, 4.12, and 4.13 k8's api deprecations out of the box, and we need not update/maintain another library to do so.