### PR TITLE
Keep preflight.log and artifacts from being written during tests

### DIFF
--- a/cmd/preflight/cmd/root_test.go
+++ b/cmd/preflight/cmd/root_test.go
@@ -50,6 +50,8 @@ func executeCommandWithLogger(root *cobra.Command, l logr.Logger, args ...string
 }
 
 var _ = Describe("cmd package utility functions", func() {
+	BeforeEach(createAndCleanupDirForArtifactsAndLogs)
+
 	Describe("Get the root command", func() {
 		Context("when calling the root command function", func() {
 			It("should return a root command", func() {


### PR DESCRIPTION
It was missed that the root_test.go should have the BeforeEach that creates the artifacts dir in a temp location, and sets the preflight.log to there as well, then cleans up after.