### PR TITLE
updating to operator-sdk v1.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ LABEL ARCH=${ARCH}
 LABEL OS=${OS}
 
 # Define versions for dependencies
-ARG OPERATOR_SDK_VERSION=1.28.0
+ARG OPERATOR_SDK_VERSION=1.28.1
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.28.0 |
+| OperatorSDK      | `operator-sdk`    |         v1.28.1 |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
 development environment. Some checks may also require access to an OpenShift

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.28.0
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.28.1
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.28.0 |
+| OperatorSDK      | `operator-sdk`    |         v1.28.1 |
 | OpenShift Client | `oc`              |         v4.7.19 |
 | Podman           | `podman`          |            v3.0 |
 

--- a/internal/runtime/assets.go
+++ b/internal/runtime/assets.go
@@ -21,7 +21,7 @@ import (
 // to be used outside of this package.
 var images = map[string]string{
 	// operator policy, operator-sdk scorecard
-	"scorecard": "quay.io/operator-framework/scorecard-test:v1.28.0",
+	"scorecard": "quay.io/operator-framework/scorecard-test:v1.28.1",
 }
 
 // imageList takes the images mapping and represents them using just


### PR DESCRIPTION
- Updating to v1.28.1 of operator-sdk
- This has the change to use `shas` for scorecard images, so that disconnected envs can work properly again.