### PR TITLE
Revert "Bump operator-sdk to 1.28.1 to unlock the lastest Preflight f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ LABEL ARCH=${ARCH}
 LABEL OS=${OS}
 
 # Define versions for dependencies
-ARG OPERATOR_SDK_VERSION=1.28.1
+ARG OPERATOR_SDK_VERSION=1.28.0
 
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.28.1 |
+| OperatorSDK      | `operator-sdk`    |         v1.28.0 |
 
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
 development environment. Some checks may also require access to an OpenShift

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     rm oc.tar.gz
     export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
     export OS=$(uname | awk '{print tolower($0)}')
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.28.1
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.28.0
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,7 +15,7 @@ functional, and in your path.
 
 | Name             | Tool cli          | Minimum version |
 |----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.28.1 |
+| OperatorSDK      | `operator-sdk`    |         v1.28.0 |
 | OpenShift Client | `oc`              |         v4.7.19 |
 | Podman           | `podman`          |            v3.0 |
 

--- a/internal/runtime/assets.go
+++ b/internal/runtime/assets.go
@@ -21,7 +21,7 @@ import (
 // to be used outside of this package.
 var images = map[string]string{
 	// operator policy, operator-sdk scorecard
-	"scorecard": "quay.io/operator-framework/scorecard-test:v1.28.1",
+	"scorecard": "quay.io/operator-framework/scorecard-test:v1.28.0",
 }
 
 // imageList takes the images mapping and represents them using just


### PR DESCRIPTION
…or DCI"

This reverts commit 7a9372e8e0348399c71465faaeba13662c11464a.

I apologize for the issue. I forgot to protect it with the 'do-not-merge' label. The problem is that now (new improvements) operator-sdk rebuilds the storage and untar images during the release process, which caused the digest we hardcoded into operator-sdk [here](https://github.com/operator-framework/operator-sdk/commit/82b28e85707d2448e1cdd385ce0444ea16e5eb75) to disappear.

```
$ podman pull quay.io/operator-framework/scorecard-storage@sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056
Trying to pull quay.io/operator-framework/scorecard-storage@sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056...
Error: initializing source docker://quay.io/operator-framework/scorecard-storage@sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056: 
reading manifest sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056 in quay.io/operator-framework/scorecard-storage: 
manifest unknown
```

This pull request is intended to restore the functionality of Preflight by reverting the faulty change. I am also investigating how we can resolve the issue with operator-sdk. I will likely propose that they bump the label for the storage image and untar image with every release, instead of continuously overwriting the latest tag and its digest.