### PR TITLE
Resolve race condition in test execution preventing multiple tests from asserting config state

### DIFF
--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -93,7 +93,7 @@ certification_project_id: mycertid`
 				})
 				It("should still execute with no error", func() {
 					// Make sure that we've read the config file
-					initConfig()
+					initConfig(viper.Instance())
 					submit = true
 
 					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -21,7 +21,7 @@ import (
 var configFileUsed bool
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(func() { initConfig(viper.Instance()) })
 }
 
 func rootCmd() *cobra.Command {
@@ -54,8 +54,7 @@ func Execute() error {
 	return rootCmd().ExecuteContext(context.Background())
 }
 
-func initConfig() {
-	viper := viper.Instance()
+func initConfig(viper *spfviper.Viper) {
 	// set up ENV var support
 	viper.SetEnvPrefix("pflt")
 	viper.AutomaticEnv()

--- a/cmd/preflight/cmd/root_test.go
+++ b/cmd/preflight/cmd/root_test.go
@@ -73,14 +73,18 @@ var _ = Describe("cmd package utility functions", func() {
 	)
 
 	Describe("Initialize Viper configuration", func() {
-		Context("when initConfig() is called", func() {
+		var testViper *spfviper.Viper
+		BeforeEach(func() {
+			testViper = spfviper.New()
+		})
+		Context("when initConfig is called", func() {
 			Context("and no envvars are set", func() {
 				It("should have defaults set correctly", func() {
-					initConfig()
-					Expect(viper.Instance().GetString("namespace")).To(Equal(DefaultNamespace))
-					Expect(viper.Instance().GetString("artifacts")).To(Equal(artifacts.DefaultArtifactsDir))
-					Expect(viper.Instance().GetString("logfile")).To(Equal(DefaultLogFile))
-					Expect(viper.Instance().GetString("loglevel")).To(Equal(DefaultLogLevel))
+					initConfig(testViper)
+					Expect(testViper.GetString("namespace")).To(Equal(DefaultNamespace))
+					Expect(testViper.GetString("artifacts")).To(Equal(artifacts.DefaultArtifactsDir))
+					Expect(testViper.GetString("logfile")).To(Equal(DefaultLogFile))
+					Expect(testViper.GetString("loglevel")).To(Equal(DefaultLogLevel))
 				})
 			})
 			Context("and envvars are set", func() {
@@ -89,11 +93,11 @@ var _ = Describe("cmd package utility functions", func() {
 					os.Setenv("PFLT_LOGLEVEL", "trace")
 				})
 				It("should have overrides in place", func() {
-					initConfig()
-					Expect(viper.Instance().GetString("namespace")).To(Equal(DefaultNamespace))
-					Expect(viper.Instance().GetString("artifacts")).To(Equal(artifacts.DefaultArtifactsDir))
-					Expect(viper.Instance().GetString("logfile")).To(Equal("/tmp/foo.log"))
-					Expect(viper.Instance().GetString("loglevel")).To(Equal("trace"))
+					initConfig(testViper)
+					Expect(testViper.GetString("namespace")).To(Equal(DefaultNamespace))
+					Expect(testViper.GetString("artifacts")).To(Equal(artifacts.DefaultArtifactsDir))
+					Expect(testViper.GetString("logfile")).To(Equal("/tmp/foo.log"))
+					Expect(testViper.GetString("loglevel")).To(Equal("trace"))
 				})
 				AfterEach(func() {
 					os.Unsetenv("PFLT_LOGFILE")
@@ -101,11 +105,9 @@ var _ = Describe("cmd package utility functions", func() {
 				})
 			})
 			When("a config file is present", func() {
-				var v *spfviper.Viper
 				BeforeEach(func() {
-					v = viper.Instance()
 					fs := afero.NewMemMapFs()
-					v.SetFs(fs)
+					testViper.SetFs(fs)
 					configFile := `namespace: configspace
 artifacts: configartifacts
 logfile: configlogfile
@@ -117,14 +119,14 @@ loglevel: configloglevel`
 					cwd, err := os.Getwd()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(afero.WriteFile(fs, filepath.Join(cwd, "config.yaml"), bytes.NewBufferString(configFile).Bytes(), 0o644)).To(Succeed())
-					DeferCleanup(v.SetFs, afero.NewOsFs())
+					DeferCleanup(testViper.SetFs, afero.NewOsFs())
 				})
 				It("should read all of the config", func() {
-					initConfig()
-					Expect(v.GetString("namespace")).To(Equal("configspace"))
-					Expect(v.GetString("artifacts")).To(Equal("configartifacts"))
-					Expect(v.GetString("logfile")).To(Equal("configlogfile"))
-					Expect(v.GetString("loglevel")).To(Equal("configloglevel"))
+					initConfig(testViper)
+					Expect(testViper.GetString("namespace")).To(Equal("configspace"))
+					Expect(testViper.GetString("artifacts")).To(Equal("configartifacts"))
+					Expect(testViper.GetString("logfile")).To(Equal("configlogfile"))
+					Expect(testViper.GetString("loglevel")).To(Equal("configloglevel"))
 				})
 			})
 		})


### PR DESCRIPTION
The ideal long-term state is probably going to be something like https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/958, but for now, this should resolve the issues in our testing where we occasionally flake.

The issue seems to be a race condition where specs that call `initConfig`, which internally modifies the application-wide `viper.Instance()` would conflict, causing the assertions being made on config items to fail.

This PR modifies initConfig to accept an instance of a viper configuration. In production, we'll always want to pass in `viper.Instance()`, but for testing, we can pass in the instance we want and then make our assertions on a test instance.