### PR TITLE
Update golangci-lint to 1.52.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ clean:
 	$(shell if [ -f "$(BINARY)-$(GOOS)-$(GOARCH)" ]; then rm -f $(BINARY)-$(GOOS)-$(GOARCH); fi)))
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.50.0
+GOLANGCI_LINT_VERSION ?= v1.52.2
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))


### PR DESCRIPTION
Subject line covers it. I randomly ran into an issue with the old version on Golang 1.20 that would cause every ounce of my machine's CPU to get used up and crash the system. Nooo clue what happened.