### PR TITLE
Ignore build-id directory in HasModifiedFiles

### DIFF
--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -306,9 +306,10 @@ func findRPMDB(ctx context.Context, layer v1.Layer) (found bool, pkglist []*rpmd
 // directoryIsExcluded excludes a directory and any file contained in that directory.
 func directoryIsExcluded(ctx context.Context, s string) bool {
 	excl := map[string]struct{}{
-		"etc": {},
-		"var": {},
-		"run": {},
+		"etc":               {},
+		"var":               {},
+		"run":               {},
+		"usr/lib/.build-id": {},
 	}
 
 	for k := range excl {


### PR DESCRIPTION
The usr/lib/.build-id directory often has modifications. We don't care about these getting modified. So, ignore in the initial scan.