### PR TITLE
Add check for old-style scratch project

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -39,7 +39,8 @@ func GetContainerPolicyExceptions(ctx context.Context, pc PyxisClient) (policy.P
 		return "", fmt.Errorf("could not retrieve project: %w", err)
 	}
 	logger.V(log.DBG).Info("certification project", "name", certProject.Name)
-	if certProject.Container.Type == "scratch" {
+	if certProject.Container.Type == "scratch" ||
+	   certProject.Container.OsContentType =="Scratch Image" {	// Older projects put the scratch flag here
 		return policy.PolicyScratch, nil
 	}
 


### PR DESCRIPTION
Support Case: 03509612

Add check for old-style location of Scratch Image definition.

Old Pyxis projects (PIDs starting with 5xxx...) put the Scratch Image status in container.os_content_type = "Scratch Image" rather than in container.type.

It looks like part of the change was added (the older field was defined in types.go), but no code was added in lib/libs.go.

