### PR TITLE
always send registry/repo info the pyxis for validation

### DIFF
--- a/internal/pyxis/submit.go
+++ b/internal/pyxis/submit.go
@@ -33,15 +33,12 @@ func (p *pyxisClient) SubmitResults(ctx context.Context, certInput *Certificatio
 		return nil, fmt.Errorf("certImage has not been properly populated")
 	}
 
-	// Set this project's metadata to match the image that we're certifying.
-	if certProject.Container.Registry == "" {
-		// normalizing index.docker.io to docker.io for the certProject
-		certProject.Container.Registry = normalizeDockerRegistry(certImage.Repositories[0].Registry)
-	}
-
-	if certProject.Container.Repository == "" {
-		certProject.Container.Repository = certImage.Repositories[0].Repository
-	}
+	// Always set the project's metadata to match the image that we're certifying. These values will always be sent
+	// to pyxis which has the validation rules on if the values can be updated, and will throw an exception if they
+	// are not allowed to be updated, ie if the images/projects are already published.
+	// Also normalizing index.docker.io to docker.io for the certProject
+	certProject.Container.Registry = normalizeDockerRegistry(certImage.Repositories[0].Registry)
+	certProject.Container.Repository = certImage.Repositories[0].Repository
 
 	// always update the project no matter the status to ensure the dockerconfig preflight used to pull the image
 	// is the dockerfile that resides on the project and other backend processes ie clair use the same file


### PR DESCRIPTION
- Removing checks for empty values on the project struct for registry/repo.
- Preflight will always send these values and rely on backend validation to be thrown, if cases when an update cannot occur.
- Jira: ISVISSUE-378 

Testing:
- ProjectIDs in `stage`: 6419dd419dbbe3aeba4fba45, 6463be0445e6b1d4c73bb4e2.
- Tried to change the image under test for these which would change registry/repo info.

Error Received:
```
Error: could not submit to pyxis: could not update project: status code: 400: body: {"detail": "The 'container.repository' field is immutable for projects if the project is associated with at least one published image.", "status": 400, "title": "Bad Request", "type": "about:blank", "trace_id": "0xcfa4fcfbdbd8367b26532bb27cefcd59"}
```