### PR TITLE
add scratch policy exception support for os_content_type

### DIFF
--- a/internal/lib/fakes_test.go
+++ b/internal/lib/fakes_test.go
@@ -129,6 +129,15 @@ func gpFuncReturnScratchException(ctx context.Context) (*pyxis.CertProject, erro
 	}, nil
 }
 
+// gpFuncReturnScratchImageException implements gpFunc and returns a scratch image exception.
+func gpFuncReturnScratchImageException(ctx context.Context) (*pyxis.CertProject, error) {
+	return &pyxis.CertProject{
+		Container: pyxis.Container{
+			OsContentType: "Scratch Image",
+		},
+	}, nil
+}
+
 // gpFuncReturnRootException implements gpFunc and returns a root exception.
 func gpFuncReturnRootException(ctx context.Context) (*pyxis.CertProject, error) {
 	return &pyxis.CertProject{

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -39,7 +39,7 @@ func GetContainerPolicyExceptions(ctx context.Context, pc PyxisClient) (policy.P
 		return "", fmt.Errorf("could not retrieve project: %w", err)
 	}
 	logger.V(log.DBG).Info("certification project", "name", certProject.Name)
-	if certProject.Container.Type == "scratch" {
+	if certProject.Container.Type == "scratch" || certProject.Container.OsContentType == "Scratch Image" {
 		return policy.PolicyScratch, nil
 	}
 

--- a/internal/lib/types_test.go
+++ b/internal/lib/types_test.go
@@ -71,8 +71,15 @@ var _ = Describe("Policy Resolution", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should return a scratch policy exception if the project has the flag in the API", func() {
+		It("should return a scratch policy exception if the project has type flag in the API", func() {
 			fakePC.getProjectsFunc = gpFuncReturnScratchException
+			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+			Expect(p).To(Equal(policy.PolicyScratch))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return a scratch policy exception if the project has os_content_type flag in the API", func() {
+			fakePC.getProjectsFunc = gpFuncReturnScratchImageException
 			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
 			Expect(p).To(Equal(policy.PolicyScratch))
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
- Add support for `os_content_type == "Scratch Image"`
- Relates: Jira ISV-1686