### PR TITLE
Process image manifest if platform not specified

### DIFF
--- a/cmd/preflight/cmd/support.go
+++ b/cmd/preflight/cmd/support.go
@@ -10,21 +10,21 @@ import (
 )
 
 const (
-	baseURL              = "https://connect.redhat.com/support/technology-partner/#/case/new?"
-	typeParam            = "type"
-	typeValue            = "CERT"
-	sourceParam          = "source"
-	sourceValue          = "preflight"
-	certProjectTypeParam = "cert_project_type"
-	certProjectIDParam   = "cert_project_id"
-	pullRequestURLParam  = "pull_request_url"
-	operatorBundleImage  = "Operator Bundle Image"
-	containerImage       = "Container Image"
+	baseURL                 = "https://connect.redhat.com/support/technology-partner/#/case/new?"
+	typeParam               = "type"
+	typeValue               = "CERT"
+	sourceParam             = "source"
+	sourceValue             = "preflight"
+	certProjectTypeParam    = "cert_project_type"
+	certProjectIDParam      = "cert_project_id"
+	pullRequestURLParam     = "pull_request_url"
+	operatorBundleImageText = "Operator Bundle Image"
+	containerImageText      = "Container Image"
 )
 
 var projectTypeMapping = map[string]string{
-	"container": containerImage,
-	"operator":  operatorBundleImage,
+	"container": containerImageText,
+	"operator":  operatorBundleImageText,
 }
 
 func supportCmd() *cobra.Command {

--- a/container/check_container.go
+++ b/container/check_container.go
@@ -71,12 +71,13 @@ func (c *containerCheck) Run(ctx context.Context) (certification.Results, error)
 	}
 
 	cfg := runtime.Config{
-		Image:        c.image,
-		DockerConfig: c.dockerconfigjson,
-		Scratch:      pol == policy.PolicyScratch,
-		Bundle:       false,
-		Insecure:     c.insecure,
-		Platform:     c.platform,
+		Image:              c.image,
+		DockerConfig:       c.dockerconfigjson,
+		Scratch:            pol == policy.PolicyScratch,
+		Bundle:             false,
+		Insecure:           c.insecure,
+		Platform:           c.platform,
+		ManifestListDigest: c.manifestListDigest,
 	}
 	eng, err := engine.New(ctx, checks, nil, cfg)
 	if err != nil {
@@ -151,6 +152,15 @@ func WithInsecureConnection() Option {
 	}
 }
 
+// WithManifestListDigest signifies that we have a manifest list and should add
+// this digest to any Pyxis calls.
+// This is only valid when submitting to Pyxis. Otherwise, it will be ignored.
+func WithManifestListDigest(manifestListDigest string) Option {
+	return func(cc *containerCheck) {
+		cc.manifestListDigest = manifestListDigest
+	}
+}
+
 type containerCheck struct {
 	image                  string
 	dockerconfigjson       string
@@ -159,4 +169,5 @@ type containerCheck struct {
 	pyxisHost              string
 	platform               string
 	insecure               bool
+	manifestListDigest     string
 }

--- a/internal/image/types.go
+++ b/internal/image/types.go
@@ -4,10 +4,11 @@ import v1 "github.com/google/go-containerregistry/pkg/v1"
 
 // ImageReference holds all things image-related
 type ImageReference struct {
-	ImageURI        string
-	ImageFSPath     string
-	ImageInfo       v1.Image
-	ImageRepository string
-	ImageRegistry   string
-	ImageTagOrSha   string
+	ImageURI           string
+	ImageFSPath        string
+	ImageInfo          v1.Image
+	ImageRepository    string
+	ImageRegistry      string
+	ImageTagOrSha      string
+	ManifestListDigest string
 }

--- a/internal/pyxis/types.go
+++ b/internal/pyxis/types.go
@@ -60,11 +60,12 @@ type ParsedData struct {
 }
 
 type Repository struct {
-	Published  bool   `json:"published" default:"false"`
-	PushDate   string `json:"push_date,omitempty"` // time.Now
-	Registry   string `json:"registry,omitempty"`
-	Repository string `json:"repository,omitempty"`
-	Tags       []Tag  `json:"tags,omitempty"`
+	Published          bool   `json:"published" default:"false"`
+	PushDate           string `json:"push_date,omitempty"` // time.Now
+	Registry           string `json:"registry,omitempty"`
+	Repository         string `json:"repository,omitempty"`
+	Tags               []Tag  `json:"tags,omitempty"`
+	ManifestListDigest string `json:"manifest_list_digest,omitempty"`
 }
 
 type Label struct {

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Platform               string
 	Insecure               bool
 	Offline                bool
+	ManifestListDigest     string
 	// Operator-Specific Fields
 	Namespace         string
 	ServiceAccount    string

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -64,12 +64,12 @@ var _ = Describe("Viper to Runtime Config", func() {
 		})
 	})
 
-	It("should only have 23 struct keys for tests to be valid", func() {
+	It("should only have 24 struct keys for tests to be valid", func() {
 		// If this test fails, it means a developer has added or removed
 		// keys from runtime.Config, and so these tests may no longer be
 		// accurate in confirming that the derived configuration from viper
 		// matches.
 		keys := reflect.TypeOf(Config{}).NumField()
-		Expect(keys).To(Equal(23))
+		Expect(keys).To(Equal(24))
 	})
 })


### PR DESCRIPTION
If --platform is not given on 'check container', preflight will now process an manifest list if that's what the URL points to. If platform is specified, only process that platform. It would be the equivalent of running preflight on each of the images in the manifest, with the 'arch' specified.

Fixes #955