### PR TITLE
Replace 'deadcode' with 'unused' in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,7 @@ run:
 linters:
   enable:
   - asciicheck
-  - deadcode
+  - unused
   - depguard
   - gofumpt
   - goimports


### PR DESCRIPTION
The 'deadcode' linter has been deprecated from sometime. Replacing with 'unused' as suggested.