### PR TITLE
Update coveralls in CI to v2

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -83,15 +83,12 @@ jobs:
 
     - name: Test
       run: make cover
-
-    - name: Convert coverage.out to coverage.lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.9
-    
+     
     - name: Coveralls
-      uses: coverallsapp/github-action@v1.1.2
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.lcov
+        file: coverage.out
 
   build-multiarch:
     needs: build-main

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,15 +50,11 @@ jobs:
     - name: Test
       run: make cover
 
-
-    - name: Convert coverage.out to coverage.lcov
-      uses: jandelgado/gcov2lcov-action@v1.0.9
-    
     - name: Coveralls
-      uses: coverallsapp/github-action@v1.1.2
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.lcov
+        file: coverage.out
 
     - name: Build Multi-arch
       run: make build-multi-arch


### PR DESCRIPTION
No longer needs a converter from golang coverage to gcov. Simplifies the workflows.