### PR TITLE
Exclude usr/tmp from HasModifiedFiles

### DIFF
--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -310,6 +310,7 @@ func directoryIsExcluded(ctx context.Context, s string) bool {
 		"var":               {},
 		"run":               {},
 		"usr/lib/.build-id": {},
+		"usr/tmp":           {},
 	}
 
 	for k := range excl {


### PR DESCRIPTION
It's a symlink to /var/tmp, so don't care what happens.

Fixes: #1001