### PR TITLE
conditionally calling pyxis.WithRPMManifest based on the policy value in ctx

### DIFF
--- a/container/check_container.go
+++ b/container/check_container.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
-
 	goruntime "runtime"
+	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
@@ -58,6 +57,9 @@ func (c *containerCheck) Run(ctx context.Context) (certification.Results, error)
 		if err != nil {
 			return certification.Results{}, fmt.Errorf("%w: %s", preflighterr.ErrCannotResolvePolicyException, err)
 		}
+
+		// adding policy to context to be retrieved later in the submit flow
+		ctx = policy.NewContext(ctx, override)
 
 		pol = override
 	}

--- a/internal/lib/types_test.go
+++ b/internal/lib/types_test.go
@@ -265,7 +265,9 @@ var _ = Describe("Container Certification Submitter", func() {
 				err := os.Remove(dockerConfigPath)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = sbmt.Submit(testcontext)
+				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
+
+				err = sbmt.Submit(scratchContext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -276,7 +278,9 @@ var _ = Describe("Container Certification Submitter", func() {
 				fakePC.getProjectsFunc = gpFuncReturnHostedRegistry
 			})
 			It("should not throw an error", func() {
-				err := sbmt.Submit(testcontext)
+				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
+
+				err := sbmt.Submit(scratchContext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -308,9 +312,26 @@ var _ = Describe("Container Certification Submitter", func() {
 				err := os.Remove(path.Join(aw.Path(), check.DefaultRPMManifestFilename))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = sbmt.Submit(testcontext)
+				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
+
+				err = sbmt.Submit(scratchContext)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(check.DefaultRPMManifestFilename))
+			})
+		})
+
+		Context("and scratch policy was executed, so no rpmManifest exists on disk", func() {
+			BeforeEach(func() {
+				fakePC.setSRFuncSubmitSuccessfully("12345", "12345")
+			})
+			It("should not throw an error", func() {
+				err := os.Remove(path.Join(aw.Path(), check.DefaultRPMManifestFilename))
+				Expect(err).ToNot(HaveOccurred())
+
+				scratchContext := policy.NewContext(testcontext, policy.PolicyScratch)
+
+				err = sbmt.Submit(scratchContext)
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -331,7 +352,9 @@ var _ = Describe("Container Certification Submitter", func() {
 			})
 
 			It("should throw an error", func() {
-				err := sbmt.Submit(testcontext)
+				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
+
+				err := sbmt.Submit(scratchContext)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -355,7 +378,9 @@ var _ = Describe("Container Certification Submitter", func() {
 			})
 
 			It("should throw an error finalizing the submission", func() {
-				err := sbmt.Submit(testcontext)
+				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
+
+				err := sbmt.Submit(scratchContext)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unable to finalize data"))
 			})
@@ -366,7 +391,9 @@ var _ = Describe("Container Certification Submitter", func() {
 				fakePC.setSRFuncSubmitSuccessfully("", "")
 			})
 			It("should not throw an error", func() {
-				err := sbmt.Submit(testcontext)
+				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
+
+				err := sbmt.Submit(scratchContext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,5 +1,7 @@
 package policy
 
+import "context"
+
 type Policy = string
 
 const (
@@ -8,3 +10,23 @@ const (
 	PolicyScratch   Policy = "scratch"
 	PolicyRoot      Policy = "root"
 )
+
+// NewContext adds Policy p to the context ctx.
+func NewContext(ctx context.Context, p Policy) context.Context {
+	return context.WithValue(ctx, policyContextKey, p)
+}
+
+// FromContext returns the policy from the context, or empty string.
+func FromContext(ctx context.Context) Policy {
+	p := ctx.Value(policyContextKey)
+	if policy, ok := p.(Policy); ok {
+		return policy
+	}
+
+	return ""
+}
+
+// contextKey is a key used to store/retrieve Policy in/from context.Context.
+type contextKey string
+
+const policyContextKey contextKey = "Policy"

--- a/test/containerfiles/container-passes.Dockerfile
+++ b/test/containerfiles/container-passes.Dockerfile
@@ -4,7 +4,7 @@ RUN useradd preflightuser
 
 COPY --chown=preflightuser:preflightuser example-license.txt /licenses/
 
-LABEL name="preflight test image" \ 
+LABEL name="preflight test image container-policy" \
       vendor="preflight test vendor" \
       version="1" \
       release="1" \


### PR DESCRIPTION
- Adding `Policy` to `context`
- Retrieving `Policy` from `context` for all policies except `scratch` in the submission flow while reading the `rpm.Manifest`, since scratch policy will not write this file to disk.
- Fixes: #1011 