### PR TITLE
Add 'github-actions' config to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Automatically update github actions versions via dependabot.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

Similar to: 
- https://github.com/test-network-function/cnf-certification-test/pull/954
- https://github.com/test-network-function/cnf-certification-test/pull/936