### PR TITLE
updating container image to be based off of ubi 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /go/src/preflight
 RUN make build RELEASE_TAG=${release_tag}
 
 # ubi8:latest
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 ARG quay_expiration
 ARG release_tag
 ARG preflight_commit


### PR DESCRIPTION
# Motivation
Our last build from main was giving the below error at runtime

```
+ preflight check operator quay.io/acornett/simple-demo-operator-bundle:v0.0.6
preflight: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by preflight)
preflight: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by preflight)
```

We found that the golang builder image switch versions of glibc from our last release till when main was built yesterday.

# Solution
- Short term we will upgrade to UBI 9
- Long term we will create a story to build preflight to not rely on `glibc` by default.