### PR TITLE
update cert_document URL

### DIFF
--- a/internal/policy/container/defaults.go
+++ b/internal/policy/container/defaults.go
@@ -1,3 +1,3 @@
 package container
 
-var certDocumentationURL = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
+var certDocumentationURL = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.63/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"


### PR DESCRIPTION
The check URL in the 'preflight check container' result is invalid

{
                "name": "HasModifiedFiles",
                "elapsed_time": 34305,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified",
                "help": "Check HasModifiedFiles encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Do not modify any files installed by RPM in the base Red Hat layer",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_softwarolicy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certifide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }