### PR TITLE
Make .cache exclusion broader

### DIFF
--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -352,7 +352,7 @@ func prefixAndSuffixIsExcluded(ctx context.Context, s string) bool {
 		Prefix string
 		Suffix string
 	}{
-		{Prefix: "usr/lib64/", Suffix: ".cache"},
+		{Prefix: "usr/", Suffix: ".cache"},
 	}
 
 	for _, v := range excl {


### PR DESCRIPTION
Expand the .cache exlusion to be anywhere in usr/ instead of usr/lib64/.