### PR TITLE
move latest ocp version to 4.13

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -27,9 +27,10 @@ var ocpToKubeVersion = map[string]string{
 	"4.11": "1.24",
 	"4.12": "1.25",
 	"4.13": "1.26",
+	"4.14": "1.27",
 }
 
-const latestReleasedVersion = "4.12"
+const latestReleasedVersion = "4.13"
 
 func Validate(ctx context.Context, imagePath string) (*Report, error) {
 	logger := logr.FromContextOrDiscard(ctx)


### PR DESCRIPTION
- OCP 4.13 is GA and in production, updating our bundle validate logic
- Adding in 4.14 to metrix so we have a 'next' version to lookup