### PR TITLE
explicitly set CGO_ENABLED=0 in the build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ARCHITECTURES=amd64 arm64 ppc64le s390x
 
 .PHONY: build
 build:
-	go build -o $(BINARY) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
+	CGO_ENABLED=0 go build -o $(BINARY) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 	@ls | grep -e '^preflight$$' &> /dev/null
 
 .PHONY: build-multi-arch
@@ -20,7 +20,7 @@ build-multi-arch: $(addprefix build-linux-,$(ARCHITECTURES))
 define ARCHITECTURE_template
 .PHONY: build-linux-$(1)
 build-linux-$(1):
-	GOOS=linux GOARCH=$(1) go build -o $(BINARY)-linux-$(1) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
+	GOOS=linux GOARCH=$(1) CGO_ENABLED=0 go build -o $(BINARY)-linux-$(1) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
 				-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 endef
 


### PR DESCRIPTION
# Notes
- Setting `CGO_ENABLED=0` to no longer rely on glibc
- Fixes: #1015  

# Testing
## Building a container
```
[1/2] STEP 8/8: RUN make build RELEASE_TAG=${release_tag}
CGO_ENABLED=0 go build -o preflight -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=e0487c15207258f90cd49de63bea73da54ef9200 -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=0.0.0" cmd/preflight/main.go
```

## Running the container
```
podman run -it --rm --entrypoint /bin/bash quay.io/acornett/preflight:e0487c15207258f90cd49de63bea73da54ef9200
[root@346122e2a5a6 /]# ldd /usr/local/bin/preflight 
        not a dynamic executable
```

## Testing Release from Forked Repo
I created a release in my fork [here](https://github.com/acornett21/openshift-preflight/releases/tag/1.6.9-fix-glibc) and this was successfully tested on RHEL8