### PR TITLE
Updated bundle fails scorecard-test to v1.30.0

### DIFF
--- a/test/containerfiles/failed-bundle-assets/tests/scorecard/config.yaml
+++ b/test/containerfiles/failed-bundle-assets/tests/scorecard/config.yaml
@@ -8,42 +8,42 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
     labels:
       suite: basic
       test: basic-check-spec-test
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
     labels:
       suite: olm
       test: olm-status-descriptors-test


### PR DESCRIPTION
Current version was set to 1.7.2  which looks to be way outdated.