### PR TITLE
Check policy directly in submit

### DIFF
--- a/container/check_container.go
+++ b/container/check_container.go
@@ -58,9 +58,6 @@ func (c *containerCheck) Run(ctx context.Context) (certification.Results, error)
 			return certification.Results{}, fmt.Errorf("%w: %s", preflighterr.ErrCannotResolvePolicyException, err)
 		}
 
-		// adding policy to context to be retrieved later in the submit flow
-		ctx = policy.NewContext(ctx, override)
-
 		pol = override
 	}
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -39,7 +39,7 @@ func GetContainerPolicyExceptions(ctx context.Context, pc PyxisClient) (policy.P
 		return "", fmt.Errorf("could not retrieve project: %w", err)
 	}
 	logger.V(log.DBG).Info("certification project", "name", certProject.Name)
-	if certProject.Container.Type == "scratch" || certProject.Container.OsContentType == "Scratch Image" {
+	if certProject.ScratchProject() {
 		return policy.PolicyScratch, nil
 	}
 

--- a/internal/lib/types.go
+++ b/internal/lib/types.go
@@ -158,9 +158,15 @@ func (s *ContainerCertificationSubmitter) Submit(ctx context.Context) error {
 		pyxis.WithArtifact(logfile, filepath.Base(s.PreflightLogFile)),
 	}
 
+	pol := policy.PolicyContainer
+
+	if certProject.ScratchProject() {
+		pol = policy.PolicyScratch
+	}
+
 	// only read the rpm manifest file off of disk if the policy executed is not scratch
 	// scratch images do not have rpm manifests, the rpm-manifest.json file is not written to disk by the engine during execution
-	if policy.FromContext(ctx) != policy.PolicyScratch {
+	if pol != policy.PolicyScratch {
 		rpmManifest, err := os.Open(path.Join(artifactWriter.Path(), check.DefaultRPMManifestFilename))
 		if err != nil {
 			return fmt.Errorf(

--- a/internal/lib/types_test.go
+++ b/internal/lib/types_test.go
@@ -259,15 +259,14 @@ var _ = Describe("Container Certification Submitter", func() {
 		Context("and no docker config command argument was provided", func() {
 			BeforeEach(func() {
 				fakePC.setSRFuncSubmitSuccessfully("", "")
+				fakePC.getProjectsFunc = gpFuncReturnScratchException
 			})
 			It("should not throw an error", func() {
 				sbmt.DockerConfig = ""
 				err := os.Remove(dockerConfigPath)
 				Expect(err).ToNot(HaveOccurred())
 
-				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
-
-				err = sbmt.Submit(scratchContext)
+				err = sbmt.Submit(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -278,9 +277,7 @@ var _ = Describe("Container Certification Submitter", func() {
 				fakePC.getProjectsFunc = gpFuncReturnHostedRegistry
 			})
 			It("should not throw an error", func() {
-				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
-
-				err := sbmt.Submit(scratchContext)
+				err := sbmt.Submit(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -312,9 +309,7 @@ var _ = Describe("Container Certification Submitter", func() {
 				err := os.Remove(path.Join(aw.Path(), check.DefaultRPMManifestFilename))
 				Expect(err).ToNot(HaveOccurred())
 
-				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
-
-				err = sbmt.Submit(scratchContext)
+				err = sbmt.Submit(testcontext)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(check.DefaultRPMManifestFilename))
 			})
@@ -323,14 +318,13 @@ var _ = Describe("Container Certification Submitter", func() {
 		Context("and scratch policy was executed, so no rpmManifest exists on disk", func() {
 			BeforeEach(func() {
 				fakePC.setSRFuncSubmitSuccessfully("12345", "12345")
+				fakePC.getProjectsFunc = gpFuncReturnScratchException
 			})
 			It("should not throw an error", func() {
 				err := os.Remove(path.Join(aw.Path(), check.DefaultRPMManifestFilename))
 				Expect(err).ToNot(HaveOccurred())
 
-				scratchContext := policy.NewContext(testcontext, policy.PolicyScratch)
-
-				err = sbmt.Submit(scratchContext)
+				err = sbmt.Submit(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -349,12 +343,11 @@ var _ = Describe("Container Certification Submitter", func() {
 		Context("and the submission fails", func() {
 			BeforeEach(func() {
 				fakePC.submitResultsFunc = srFuncReturnError
+				fakePC.getProjectsFunc = gpFuncReturnScratchException
 			})
 
 			It("should throw an error", func() {
-				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
-
-				err := sbmt.Submit(scratchContext)
+				err := sbmt.Submit(testcontext)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -378,9 +371,7 @@ var _ = Describe("Container Certification Submitter", func() {
 			})
 
 			It("should throw an error finalizing the submission", func() {
-				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
-
-				err := sbmt.Submit(scratchContext)
+				err := sbmt.Submit(testcontext)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unable to finalize data"))
 			})
@@ -389,11 +380,10 @@ var _ = Describe("Container Certification Submitter", func() {
 		Context("and the submission succeeds", func() {
 			BeforeEach(func() {
 				fakePC.setSRFuncSubmitSuccessfully("", "")
+				fakePC.getProjectsFunc = gpFuncReturnScratchException
 			})
 			It("should not throw an error", func() {
-				scratchContext := policy.NewContext(testcontext, policy.PolicyContainer)
-
-				err := sbmt.Submit(scratchContext)
+				err := sbmt.Submit(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,7 +1,5 @@
 package policy
 
-import "context"
-
 type Policy = string
 
 const (
@@ -10,23 +8,3 @@ const (
 	PolicyScratch   Policy = "scratch"
 	PolicyRoot      Policy = "root"
 )
-
-// NewContext adds Policy p to the context ctx.
-func NewContext(ctx context.Context, p Policy) context.Context {
-	return context.WithValue(ctx, policyContextKey, p)
-}
-
-// FromContext returns the policy from the context, or empty string.
-func FromContext(ctx context.Context) Policy {
-	p := ctx.Value(policyContextKey)
-	if policy, ok := p.(Policy); ok {
-		return policy
-	}
-
-	return ""
-}
-
-// contextKey is a key used to store/retrieve Policy in/from context.Context.
-type contextKey string
-
-const policyContextKey contextKey = "Policy"

--- a/internal/pyxis/builder.go
+++ b/internal/pyxis/builder.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
 )
 
 // certificationInputBuilder facilitates the building of CertificationInput for
@@ -18,7 +16,7 @@ type certificationInputBuilder struct {
 }
 
 // NewCertificationInput accepts required values for submitting to Pyxis, and returns a CertificationInputBuilder for
-// adding additional files as artifacts to the submission. The caller must call Finalize() in order to receive
+// adding additional files as artifacts to the submission. The caller must call finalize() in order to receive
 // a *CertificationInput.
 func NewCertificationInput(ctx context.Context, project *CertProject, opts ...CertificationInputOption) (*CertificationInput, error) {
 	if project == nil {
@@ -37,16 +35,16 @@ func NewCertificationInput(ctx context.Context, project *CertProject, opts ...Ce
 		}
 	}
 
-	return b.finalize(ctx)
+	return b.finalize()
 }
 
-// Finalize runs a collection of safeguards to try to ensure we get a reliable
+// finalize runs a collection of safeguards to try to ensure we get a reliable
 // CertificationInput. This also wires up information that's shared across
 // the various included assets (e.g. ISVPID) where applicable, and returns an
 // unmodifiable CertificationInput.
 //
 // If any required values are not included, an error is thrown.
-func (b *certificationInputBuilder) finalize(ctx context.Context) (*CertificationInput, error) {
+func (b *certificationInputBuilder) finalize() (*CertificationInput, error) {
 	// safeguards, make sure things aren't nil for any reason.
 	if b.CertImage == nil {
 		return nil, fmt.Errorf("a CertImage was not provided and is required")
@@ -55,7 +53,7 @@ func (b *certificationInputBuilder) finalize(ctx context.Context) (*Certificatio
 		return nil, fmt.Errorf("test results were not provided and are required")
 	}
 
-	if b.RpmManifest == nil && policy.FromContext(ctx) != policy.PolicyScratch {
+	if b.RpmManifest == nil && !b.CertProject.ScratchProject() {
 		return nil, fmt.Errorf("the RPM manifest was not provided and is required")
 	}
 

--- a/internal/pyxis/submit.go
+++ b/internal/pyxis/submit.go
@@ -83,17 +83,19 @@ func (p *pyxisClient) SubmitResults(ctx context.Context, certInput *Certificatio
 		}
 	}
 
-	// Create the RPM manifest, or get it if it already exists.
-	rpmManifest := certInput.RpmManifest
-	rpmManifest.ImageID = certImage.ID
-	_, err = p.createRPMManifest(ctx, rpmManifest)
-	if err != nil {
-		if !errors.Is(err, ErrPyxis409StatusCode) {
-			return nil, fmt.Errorf("could not create rpm manifest: %v", err)
-		}
-		_, err = p.getRPMManifest(ctx, rpmManifest.ImageID)
+	if !certProject.ScratchProject() {
+		// Create the RPM manifest, or get it if it already exists.
+		rpmManifest := certInput.RpmManifest
+		rpmManifest.ImageID = certImage.ID
+		_, err = p.createRPMManifest(ctx, rpmManifest)
 		if err != nil {
-			return nil, fmt.Errorf("could not get rpm manifest: %v", err)
+			if !errors.Is(err, ErrPyxis409StatusCode) {
+				return nil, fmt.Errorf("could not create rpm manifest: %v", err)
+			}
+			_, err = p.getRPMManifest(ctx, rpmManifest.ImageID)
+			if err != nil {
+				return nil, fmt.Errorf("could not get rpm manifest: %v", err)
+			}
 		}
 	}
 

--- a/internal/pyxis/types.go
+++ b/internal/pyxis/types.go
@@ -104,6 +104,11 @@ type CertProject struct {
 	Type                string    `json:"type,omitempty"` // required
 }
 
+func (cp CertProject) ScratchProject() bool {
+	// ScratchProject returns true if the CertProject is designated Scratch in Pyxis.
+	return cp.Container.Type == "scratch" || cp.Container.OsContentType == "Scratch Image"
+}
+
 type Container struct {
 	DockerConfigJSON string `json:"docker_config_json,omitempty"`
 	HostedRegistry   bool   `json:"hosted_registry,omitempty"`


### PR DESCRIPTION
There is no need to stuff the policy in the context. In the places that we need it, we can either make another API call, or, as the case with Submit is, we already have what we need in the certProject.