### PR TITLE
Ignore ghost and artifact RPM files

### DIFF
--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -383,7 +383,9 @@ func installedFileMapWithExclusions(ctx context.Context, pkglist []*rpmdb.Packag
 		rpmdb.RPMFILE_DOC |
 		rpmdb.RPMFILE_LICENSE |
 		rpmdb.RPMFILE_MISSINGOK |
-		rpmdb.RPMFILE_README
+		rpmdb.RPMFILE_README |
+		rpmdb.RPMFILE_ARTIFACT |
+		rpmdb.RPMFILE_GHOST
 	m := map[string]string{}
 	for _, pkg := range pkglist {
 		files, err := pkg.InstalledFiles()


### PR DESCRIPTION
If a file is marked as a ghost or artifact, it should be ignored in the context of HasModifiedFiles.