### PR TITLE
Refactor options code to its own package

### DIFF
--- a/container/check_container.go
+++ b/container/check_container.go
@@ -70,7 +70,15 @@ func (c *containerCheck) Run(ctx context.Context) (certification.Results, error)
 		return certification.Results{}, fmt.Errorf("%w: %s", preflighterr.ErrCannotInitializeChecks, err)
 	}
 
-	eng, err := engine.New(ctx, c.image, checks, nil, c.dockerconfigjson, false, pol == policy.PolicyScratch, c.insecure, c.platform)
+	cfg := runtime.Config{
+		Image:        c.image,
+		DockerConfig: c.dockerconfigjson,
+		Scratch:      pol == policy.PolicyScratch,
+		Bundle:       false,
+		Insecure:     c.insecure,
+		Platform:     c.platform,
+	}
+	eng, err := engine.New(ctx, checks, nil, cfg)
 	if err != nil {
 		return certification.Results{}, err
 	}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -31,7 +31,7 @@ import (
 
 var _ = Describe("Execute Checks tests", func() {
 	var src string
-	var engine CraneEngine
+	var engine craneEngine
 	var testcontext context.Context
 	var s *httptest.Server
 	var u *url.URL
@@ -109,18 +109,18 @@ var _ = Describe("Execute Checks tests", func() {
 		)
 
 		emptyConfig := runtime.Config{}
-		engine = CraneEngine{
-			DockerConfig: emptyConfig.DockerConfig,
-			Image:        src,
-			Checks: []check.Check{
+		engine = craneEngine{
+			dockerConfig: emptyConfig.DockerConfig,
+			image:        src,
+			checks: []check.Check{
 				goodCheck,
 				errorCheck,
 				failedCheck,
 				optionalCheckPassing,
 				optionalCheckFailing,
 			},
-			IsBundle:  false,
-			IsScratch: false,
+			isBundle:  false,
+			isScratch: false,
 		}
 	})
 	Context("Run the checks", func() {
@@ -134,7 +134,7 @@ var _ = Describe("Execute Checks tests", func() {
 		})
 		Context("it is a bundle", func() {
 			It("should succeed and generate a bundle hash", func() {
-				engine.IsBundle = true
+				engine.isBundle = true
 				err := engine.ExecuteChecks(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(engine.results.CertificationHash).ToNot(BeEmpty())
@@ -142,7 +142,7 @@ var _ = Describe("Execute Checks tests", func() {
 		})
 		Context("the image is invalid", func() {
 			It("should throw a crane error on pull", func() {
-				engine.Image = "does.not/exist/anywhere:ever"
+				engine.image = "does.not/exist/anywhere:ever"
 				err := engine.ExecuteChecks(testcontext)
 				Expect(err).To(HaveOccurred())
 			})
@@ -164,7 +164,7 @@ var _ = Describe("Execute Checks tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should just hang forever err and hash mean nothing", func() {
-				engine.IsBundle = true
+				engine.isBundle = true
 				err := engine.ExecuteChecks(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(engine.results.CertificationHash).ToNot(BeEmpty())
@@ -172,7 +172,7 @@ var _ = Describe("Execute Checks tests", func() {
 		})
 		Context("it is a bundle made with tar layer", func() {
 			BeforeEach(func() {
-				engine.IsBundle = true
+				engine.isBundle = true
 
 				var buf bytes.Buffer
 
@@ -189,7 +189,7 @@ var _ = Describe("Execute Checks tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should succeed and generate a bundle hash", func() {
-				engine.IsBundle = true
+				engine.isBundle = true
 				err := engine.ExecuteChecks(testcontext)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(engine.results.CertificationHash).ToNot(BeEmpty())
@@ -197,7 +197,7 @@ var _ = Describe("Execute Checks tests", func() {
 		})
 		Context("it is a bundle made and one of the layers is not a tar", func() {
 			BeforeEach(func() {
-				engine.IsBundle = true
+				engine.isBundle = true
 
 				want := []byte(`{"foo":"bar"}`)
 				layer := static.NewLayer(want, types.MediaType("application/json"))
@@ -210,7 +210,7 @@ var _ = Describe("Execute Checks tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should throw an EOF error on untar", func() {
-				engine.IsBundle = true
+				engine.isBundle = true
 				err := engine.ExecuteChecks(testcontext)
 				Expect(err).To(HaveOccurred())
 				Expect(engine.results.CertificationHash).To(BeEmpty())

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	goruntime "runtime"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
@@ -266,7 +265,8 @@ var _ = Describe("Tag and digest binding information function", func() {
 var _ = Describe("CheckInitialization", func() {
 	When("initializing the engine", func() {
 		It("should not return an error", func() {
-			_, err := New(context.TODO(), "example.com/some/image:latest", []check.Check{}, nil, "", false, false, false, goruntime.GOARCH)
+			cfg := runtime.Config{}
+			_, err := New(context.TODO(), []check.Check{}, nil, cfg)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -1,0 +1,73 @@
+package option
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/authn"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+type CraneConfig interface {
+	CraneDockerConfig() string
+	CranePlatform() string
+	CraneInsecure() bool
+}
+
+func GenerateCraneOptions(ctx context.Context, craneConfig CraneConfig) []crane.Option {
+	// prepare crane runtime options, if necessary
+	options := []crane.Option{
+		crane.WithContext(ctx),
+		crane.WithAuthFromKeychain(
+			authn.PreflightKeychain(
+				ctx,
+				// We configure the Preflight Keychain here.
+				// In theory, we should not require further configuration
+				// downstream because the PreflightKeychain is a singleton.
+				// However, as long as we pass this same DockerConfig
+				// value downstream, it shouldn't matter if the
+				// keychain is reconfigured downstream.
+				authn.WithDockerConfig(craneConfig.CraneDockerConfig()),
+			),
+		),
+		crane.WithPlatform(&cranev1.Platform{
+			OS:           "linux",
+			Architecture: craneConfig.CranePlatform(),
+		}),
+		retryOnceAfter(5 * time.Second),
+	}
+
+	if craneConfig.CraneInsecure() {
+		// Adding WithTransport opt is a workaround to allow for access to HTTPS
+		// container registries with self-signed or non-trusted certificates.
+		//
+		// See https://github.com/google/go-containerregistry/issues/1553 for more context. If this issue
+		// is resolved, then this workaround can likely be removed or adjusted to use new features in the
+		// go-containerregistry project.
+		rt := remote.DefaultTransport.(*http.Transport).Clone()
+		rt.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true, //nolint: gosec
+		}
+
+		options = append(options, crane.Insecure, crane.WithTransport(rt))
+	}
+
+	return options
+}
+
+// retryOnceAfter is a crane option that retries once after t duration.
+func retryOnceAfter(t time.Duration) crane.Option {
+	return func(o *crane.Options) {
+		o.Remote = append(o.Remote, remote.WithRetryBackoff(remote.Backoff{
+			Duration: t,
+			Factor:   1.0,
+			Jitter:   0.1,
+			Steps:    2,
+		}))
+	}
+}

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"os"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/option"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
 
 	"github.com/spf13/viper"
@@ -82,3 +83,18 @@ func (c *Config) storeOperatorPolicyConfiguration(vcfg viper.Viper) {
 	c.Channel = vcfg.GetString("channel")
 	c.IndexImage = vcfg.GetString("indeximage")
 }
+
+// This is to satisfy the CraneConfig interface
+func (c *Config) CraneDockerConfig() string {
+	return c.DockerConfig
+}
+
+func (c *Config) CranePlatform() string {
+	return c.Platform
+}
+
+func (c *Config) CraneInsecure() bool {
+	return c.Insecure
+}
+
+var _ option.CraneConfig = &Config{}

--- a/operator/check_operator.go
+++ b/operator/check_operator.go
@@ -9,6 +9,7 @@ import (
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/engine"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 )
 
 type Option = func(*operatorCheck)
@@ -59,7 +60,15 @@ func (c operatorCheck) Run(ctx context.Context) (certification.Results, error) {
 		return certification.Results{}, fmt.Errorf("%w: %s", preflighterr.ErrCannotInitializeChecks, err)
 	}
 
-	eng, err := engine.New(ctx, c.image, checks, c.kubeconfig, c.dockerConfigFilePath, true, true, c.insecure, goruntime.GOARCH)
+	cfg := runtime.Config{
+		Image:        c.image,
+		DockerConfig: c.dockerConfigFilePath,
+		Scratch:      true,
+		Bundle:       true,
+		Insecure:     c.insecure,
+		Platform:     goruntime.GOARCH,
+	}
+	eng, err := engine.New(ctx, checks, c.kubeconfig, cfg)
 	if err != nil {
 		return certification.Results{}, err
 	}


### PR DESCRIPTION
The Crane options code is now being used in multiple places, so it was time to refactor it out into its own package.

This touches a few places, but remains "backward-compatible".

Any breakage of current functionality or current public API should be considered a bug.