### PR TITLE
Do not process attestation manifests

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -432,6 +432,10 @@ func platformsToBeProcessed(cmd *cobra.Command, cfg *runtime.Config) ([]string, 
 				// The user selected a platform. If this isn't it, continue.
 				continue
 			}
+			if img.Platform.Architecture == "unknown" && img.Platform.OS == "unknown" {
+				// This must be an attestation manifest. Skip it.
+				continue
+			}
 			containerImagePlatforms = append(containerImagePlatforms, img.Platform.Architecture)
 		}
 		if platformChanged && len(containerImagePlatforms) == 0 {


### PR DESCRIPTION
Some docker-built containers may have a so-called attestation manifest. These are not meant to be processed as normal images, but instead, will have an arch and OS of "unknown".

Preflight will now ignore any image listed in a manifest that has arch and OS as "unknown".