### PR TITLE
updating ocp to k8s map for latest release

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -28,9 +28,10 @@ var ocpToKubeVersion = map[string]string{
 	"4.12": "1.25",
 	"4.13": "1.26",
 	"4.14": "1.27",
+	"4.15": "1.28",
 }
 
-const latestReleasedVersion = "4.13"
+const latestReleasedVersion = "4.14"
 
 func Validate(ctx context.Context, imagePath string) (*Report, error) {
 	logger := logr.FromContextOrDiscard(ctx)

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -107,7 +107,7 @@ var _ = Describe("BundleValidateCheck", func() {
 		Entry(">= 4.8", "v4.8", latestReleasedVersion, true),
 		Entry(">= 4.9", "v4.9", latestReleasedVersion, true),
 		Entry(">= 4.11", "v4.11", latestReleasedVersion, true),
-		Entry(">= 4.13, which is more than released", "v4.13", "4.13", true),
+		Entry(">= 4.15, which is more than released", "v4.15", "4.15", true),
 		Entry("begins = with error", "=foo", "", false),
 		Entry("bare version with error", "vfoo", "", false),
 		Entry("range with error", "v4.6-vfoo", "", false),


### PR DESCRIPTION
- Updating OCP to K8s map since 4.14 is now GA