### PR TITLE
Ensure all disconnected annotations are accounted for when reviewing guidelines

### DIFF
--- a/internal/csv/csv.go
+++ b/internal/csv/csv.go
@@ -24,7 +24,7 @@ const (
 	CSIAnnotation                    = "features.operators.openshift.io/csi"
 )
 
-// SupportsDisconnected accepts a stringified list of supported features
+// SupportsDisconnectedViaInfrastructureFeatures accepts a stringified list of supported features
 // and returns true if "disconnected" is listed as a supported feature.
 //
 // E.g. '["disconnected"]'.
@@ -32,7 +32,9 @@ const (
 // This is case insensitive, as each infrastructure
 // is normalized before checking. A failure to unmarshal this structure
 // returns false.
-func SupportsDisconnected(infrastructureFeatures string) bool {
+//
+// This is a legacy annotation and will be superceded by the DisconnectedAnnotation in the future.
+func SupportsDisconnectedViaInfrastructureFeatures(infrastructureFeatures string) bool {
 	var features []string
 
 	err := json.Unmarshal([]byte(infrastructureFeatures), &features)
@@ -49,10 +51,25 @@ func SupportsDisconnected(infrastructureFeatures string) bool {
 	return false
 }
 
+// SupportsDisconnected accepts the value of the DisconnectedAnnotation and returns whether it is
+// set to the exact value of "true", which is the expected value indicating support. For this annotation,
+// an explicit value of "false" is treated the same as any other non-true value.
+func SupportsDisconnected(annotationValue string) bool {
+	return annotationValue == "true"
+}
+
 // HasInfrastructureFeaturesAnnotation returns true if the infrastructure-features annotation
-// exists in the .metadata.annotations block of csv.
+// exists in the .metadata.annotations block of csv. This is the legacy annotation
+// superceded by the DisconnectedAnnotation
 func HasInfrastructureFeaturesAnnotation(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
 	_, ok := csv.GetAnnotations()[InfrastructureFeaturesAnnotation]
+	return ok
+}
+
+// HasDisconnectedAnnotation returns true if the disconnected annotation exists in the
+// .metadata.annotations block of csv.
+func HasDisconnectedAnnotation(csv *operatorsv1alpha1.ClusterServiceVersion) bool {
+	_, ok := csv.GetAnnotations()[DisconnectedAnnotation]
 	return ok
 }
 

--- a/internal/csv/csv_test.go
+++ b/internal/csv/csv_test.go
@@ -13,9 +13,36 @@ import (
 
 var _ = Describe("CSV Functions", func() {
 	DescribeTable(
+		"Validating the independent disconnected annotation values",
+		func(value string, expected bool) {
+			actual := SupportsDisconnected(value)
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("set to \"true\"", "true", true),
+		Entry("set to \"false\"", "false", false),
+		Entry("set to \"TRUE\"", "TRUE", false),
+		Entry("set to a random string", "abc", false),
+	)
+
+	When("Checking CSVs for the Disconnected Annotation", func() {
+		var csv operatorsv1alpha1.ClusterServiceVersion
+		It("Should return false if the annotation is missing", func() {
+			annotations := map[string]string{}
+			csv.Annotations = annotations
+			Expect(HasDisconnectedAnnotation(&csv)).To(BeFalse())
+		})
+
+		It("Should return true if the annotation is present, regardless of its value", func() {
+			annotations := map[string]string{DisconnectedAnnotation: "foo"}
+			csv.Annotations = annotations
+			Expect(HasDisconnectedAnnotation(&csv)).To(BeTrue())
+		})
+	})
+
+	DescribeTable(
 		"Validating infrastructure features list disconnected",
 		func(featurelist string, expected bool) {
-			actual := SupportsDisconnected(featurelist)
+			actual := SupportsDisconnectedViaInfrastructureFeatures(featurelist)
 			Expect(actual).To(Equal(expected))
 		},
 		Entry("disconnected in all caps", `["DISCONNECTED"]`, true),


### PR DESCRIPTION
We recently added support for new annotations for various infrastructure features, including disconnected/restricted network support, but our informational check that reviews the CSV's implementation of the guidelines for disconnected support was not accounting for the new annotation.

As a result, we'd emit logs indicating that "this operator didn't support deployment into environments with restricted networks" even if the new annotation was present, which was misleading. 

This PR properly checks both annotations, and in the presence of either with a value indicating support for deployment into these environments, executes the logic to see how closely the maintainer adheres to the guidelines.

This also adds relevant tests, and relabels/documents the older annotation as "legacy".