### PR TITLE
updating documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ subject to change, and some features are not fully implemented.
 ## Certification Workflow Guide
 
 For the complete container and operator bundle certification workflow instructions, please reference our 
-[official certification documentation](https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html/red_hat_software_certification_workflow_guide/index).
+[official certification documentation](https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html/red_hat_software_certification_workflow_guide/index).
 
 ## Requirements
 

--- a/internal/policy/container/defaults.go
+++ b/internal/policy/container/defaults.go
@@ -1,3 +1,3 @@
 package container
 
-var certDocumentationURL = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
+var certDocumentationURL = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"

--- a/internal/policy/operator/certified_images.go
+++ b/internal/policy/operator/certified_images.go
@@ -110,8 +110,8 @@ func (p *certifiedImagesCheck) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Checking that all images referenced in the CSV are certified. Currently, this check is not enforced.",
 		Level:            "optional",
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 

--- a/internal/policy/operator/related_images.go
+++ b/internal/policy/operator/related_images.go
@@ -83,8 +83,8 @@ func (p *RelatedImagesCheck) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Check that all images in the CSV are listed in RelatedImages section. Currently, this check is not enforced.",
 		Level:            "optional",
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 

--- a/internal/policy/operator/required_annotations.go
+++ b/internal/policy/operator/required_annotations.go
@@ -89,8 +89,8 @@ func (h RequiredAnnotations) Metadata() check.Metadata {
 		Description: "Checks that the CSV has all of the required feature annotations.",
 		// TODO: This will start as warn, but will need to move to `best`
 		Level:            check.LevelWarn,
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 

--- a/internal/policy/operator/restricted_network_aware.go
+++ b/internal/policy/operator/restricted_network_aware.go
@@ -90,8 +90,8 @@ func (p FollowsRestrictedNetworkEnablementGuidelines) Metadata() check.Metadata 
 		// TODO: If this check is enforced and no longer optional, we need to identify ways to reduce false failures that may be caused by
 		// developers injecting related images in other ways.
 		Level:            "optional",
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.69/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 


### PR DESCRIPTION
Partner certification documentation has been updated to use the current year as the version number.  This simplifies and creates annual static links.

I believe this also solves the https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/1083