### PR TITLE
fixing fmt issue in check_container.go

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -346,7 +346,6 @@ func artifactsTar(ctx context.Context, src string, w io.Writer) error {
 
 			return nil
 		}()
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- It appears the fmt library has been updated, and PR builds are failing.
- This updates the code that builds are complaining about.