### PR TITLE
add allowedArchitectures function to filter out unsupported arches

### DIFF
--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Check Container Command", func() {
 		manifestListSrc = fmt.Sprintf("%s/test/cranelist", u.Host)
 		manifests["index"] = manifestListSrc
 
-		platforms := [4]string{"amd64", "arm64", "ppc64le", "s390x"}
+		platforms := [5]string{"amd64", "arm64", "ppc64le", "s390x", "arm"}
 		lst, err := random.Index(1024, 5, int64(len(platforms)+1))
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
- Fixes: #1125 
- Adding a new allowedArchitectures function to filter out unsupported architectures from manifestlist submissions.
- This will unblock users that have `arm` or other unsupported arches to continue with the submission process of supported architectures.