### PR TITLE
handling pyxis version check errors to display preflight release url

### DIFF
--- a/internal/pyxis/pyxis_suite_test.go
+++ b/internal/pyxis/pyxis_suite_test.go
@@ -157,6 +157,12 @@ func pyxisTestResultsHandler(ctx context.Context) http.HandlerFunc {
 		switch {
 		case request.Header["X-Api-Key"][0] == "my-bad-testresults-api-token":
 			response.WriteHeader(http.StatusUnauthorized)
+		case request.Header["X-Api-Key"][0] == "my-unrecognized-perflight-version":
+			response.WriteHeader(http.StatusBadRequest)
+			mustWrite(response, `{"detail":"not recognized"}`)
+		case request.Header["X-Api-Key"][0] == "my-unsupported-perflight-version":
+			response.WriteHeader(http.StatusBadRequest)
+			mustWrite(response, `{"detail":"not supported"}`)
 		default:
 			mustWrite(response, `{"image":"quay.io/awesome/image:latest","passed": true}`)
 		}

--- a/internal/pyxis/submit_test.go
+++ b/internal/pyxis/submit_test.go
@@ -293,6 +293,38 @@ var _ = Describe("Pyxis Submit", func() {
 		})
 	})
 
+	Context("createTestResults 400 version not supported", func() {
+		BeforeEach(func() {
+			pyxisClient.APIToken = "my-unsupported-perflight-version"
+			pyxisClient.ProjectID = "my-awesome-project-id"
+		})
+		Context("when a project is submitted", func() {
+			Context("and an unsupported preflight version is sent to createTestResults", func() {
+				It("should error", func() {
+					certResults, err := pyxisClient.SubmitResults(ctx, &certInput)
+					Expect(err).To(HaveOccurred())
+					Expect(certResults).To(BeNil())
+				})
+			})
+		})
+	})
+
+	Context("createTestResults 400 version not recognized", func() {
+		BeforeEach(func() {
+			pyxisClient.APIToken = "my-unrecognized-perflight-version"
+			pyxisClient.ProjectID = "my-awesome-project-id"
+		})
+		Context("when a project is submitted", func() {
+			Context("and an unrecognized preflight version is sent to createTestResults", func() {
+				It("should error", func() {
+					certResults, err := pyxisClient.SubmitResults(ctx, &certInput)
+					Expect(err).To(HaveOccurred())
+					Expect(certResults).To(BeNil())
+				})
+			})
+		})
+	})
+
 	Context("GetProject", func() {
 		Context("when a project is submitted", func() {
 			Context("and it is not already In Progress", func() {


### PR DESCRIPTION
- Handling the two possible 400 series error messages.
- Displaying the latest preflight release URL to the user.

**Note: I'm not sure if how I'm using the logger here is correct for this part of the application. Suggestions welcome.**

Sample Pyxis Responses:
![Screenshot from 2024-03-12 12-39-13](https://github.com/redhat-openshift-ecosystem/openshift-preflight/assets/88156657/b576fb4d-09af-4f87-96de-671e0ed4f02b)
![Screenshot from 2024-03-12 12-38-52](https://github.com/redhat-openshift-ecosystem/openshift-preflight/assets/88156657/5dd61efd-d173-4f34-bba6-47f463922678)
