### PR TITLE
handling pyxis version check errors to display preflight release url

### DIFF
--- a/internal/pyxis/pyxis.go
+++ b/internal/pyxis/pyxis.go
@@ -4,14 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/shurcooL/graphql"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 )
 
 const (
@@ -409,6 +412,7 @@ func (p *pyxisClient) updateProject(ctx context.Context, certProject *CertProjec
 }
 
 func (p *pyxisClient) createTestResults(ctx context.Context, testResults *TestResults) (*TestResults, error) {
+	logger := logr.FromContextOrDiscard(ctx)
 	b, err := json.Marshal(testResults)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal test results: %w", err)
@@ -431,6 +435,14 @@ func (p *pyxisClient) createTestResults(ctx context.Context, testResults *TestRe
 	}
 
 	if ok := checkStatus(resp.StatusCode); !ok {
+		// checking to see if the users is using an unsupported versions
+		// if so display preflights latest download url to the user
+		if resp.StatusCode == http.StatusBadRequest &&
+			(strings.Contains(string(body), "not recognized") || strings.Contains(string(body), "not supported")) {
+			logger.Error(errors.New("invalid preflight version, please download the latest version and re-submit"),
+				"release-url", fmt.Sprintf("https://%s/releases/latest", version.Version.Name))
+		}
+
 		return nil, fmt.Errorf(
 			"status code: %d: body: %s",
 			resp.StatusCode,

--- a/internal/pyxis/pyxis_suite_test.go
+++ b/internal/pyxis/pyxis_suite_test.go
@@ -157,6 +157,12 @@ func pyxisTestResultsHandler(ctx context.Context) http.HandlerFunc {
 		switch {
 		case request.Header["X-Api-Key"][0] == "my-bad-testresults-api-token":
 			response.WriteHeader(http.StatusUnauthorized)
+		case request.Header["X-Api-Key"][0] == "my-unrecognized-preflight-version":
+			response.WriteHeader(http.StatusBadRequest)
+			mustWrite(response, `{"detail":"not recognized"}`)
+		case request.Header["X-Api-Key"][0] == "my-unsupported-preflight-version":
+			response.WriteHeader(http.StatusBadRequest)
+			mustWrite(response, `{"detail":"not supported"}`)
 		case request.Method == http.MethodPatch && request.Header["X-Api-Key"][0] == "my-bad-results-patch-api-token":
 			response.WriteHeader(http.StatusInternalServerError)
 		default:

--- a/internal/pyxis/submit_test.go
+++ b/internal/pyxis/submit_test.go
@@ -305,6 +305,38 @@ var _ = Describe("Pyxis Submit", func() {
 		})
 	})
 
+	Context("createTestResults 400 version not supported", func() {
+		BeforeEach(func() {
+			pyxisClient.APIToken = "my-unsupported-preflight-version"
+			pyxisClient.ProjectID = "my-awesome-project-id"
+		})
+		Context("when a project is submitted", func() {
+			Context("and an unsupported preflight version is sent to createTestResults", func() {
+				It("should error", func() {
+					certResults, err := pyxisClient.SubmitResults(ctx, &certInput)
+					Expect(err).To(HaveOccurred())
+					Expect(certResults).To(BeNil())
+				})
+			})
+		})
+	})
+
+	Context("createTestResults 400 version not recognized", func() {
+		BeforeEach(func() {
+			pyxisClient.APIToken = "my-unrecognized-preflight-version"
+			pyxisClient.ProjectID = "my-awesome-project-id"
+		})
+		Context("when a project is submitted", func() {
+			Context("and an unrecognized preflight version is sent to createTestResults", func() {
+				It("should error", func() {
+					certResults, err := pyxisClient.SubmitResults(ctx, &certInput)
+					Expect(err).To(HaveOccurred())
+					Expect(certResults).To(BeNil())
+				})
+			})
+		})
+	})
+
 	Context("GetProject", func() {
 		Context("when a project is submitted", func() {
 			Context("and it is not already In Progress", func() {


### PR DESCRIPTION
- Relates: ##1135

- Handling the two possible 400 series error messages.
- Displaying the latest preflight release URL to the user.


Sample Pyxis Responses:
![Screenshot from 2024-03-12 12-39-13](https://github.com/redhat-openshift-ecosystem/openshift-preflight/assets/88156657/b576fb4d-09af-4f87-96de-671e0ed4f02b)
![Screenshot from 2024-03-12 12-38-52](https://github.com/redhat-openshift-ecosystem/openshift-preflight/assets/88156657/5dd61efd-d173-4f34-bba6-47f463922678)
