### PR TITLE
changing cosign certificate identity url to use github.repository

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -86,6 +86,6 @@ jobs:
         if: ${{ inputs.sign == true && github.event.release && github.event.action == 'published' }}
         run: |
           cosign verify \
-            --certificate-identity https://github.com/redhat-openshift-ecosystem/openshift-preflight/.github/workflows/build-multiarch.yml@refs/tags/${{ inputs.tag }} \
+            --certificate-identity https://github.com/${{ github.repository }}/.github/workflows/build-multiarch.yml@refs/tags/${{ inputs.tag }} \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             ${{ secrets.registry }}/${{ inputs.name }}:${{ inputs.tag }}


### PR DESCRIPTION
- Changing cosign certificate identy url to use `github.repository` so the cosign action can be tested in forks.

Testing
- This [release](https://github.com/acornett21/openshift-preflight/actions/runs/8756700691/job/24034359682) shows that the fix from yesterday, resolves the cosign issue.
