### PR TITLE
reordering submit flow to create test results as first action

### DIFF
--- a/internal/pyxis/pyxis_suite_test.go
+++ b/internal/pyxis/pyxis_suite_test.go
@@ -157,8 +157,10 @@ func pyxisTestResultsHandler(ctx context.Context) http.HandlerFunc {
 		switch {
 		case request.Header["X-Api-Key"][0] == "my-bad-testresults-api-token":
 			response.WriteHeader(http.StatusUnauthorized)
+		case request.Method == http.MethodPatch && request.Header["X-Api-Key"][0] == "my-bad-results-patch-api-token":
+			response.WriteHeader(http.StatusInternalServerError)
 		default:
-			mustWrite(response, `{"image":"quay.io/awesome/image:latest","passed": true}`)
+			mustWrite(response, `{"_id": "54321","image": "quay.io/awesome/image:latest","passed": true}`)
 		}
 	}
 }

--- a/internal/pyxis/pyxis_test.go
+++ b/internal/pyxis/pyxis_test.go
@@ -12,6 +12,7 @@ var _ = Describe("Pyxis", func() {
 	ctx := context.Background()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/query/", pyxisGraphqlFindImagesHandler(ctx))
+	mux.HandleFunc("/api/v1/projects/certification/test-results/id/54321", pyxisTestResultsHandler(ctx))
 	pyxisClient := NewPyxisClient("my.pyxis.host/query/", "my-spiffy-api-token", "my-awesome-project-id", &http.Client{Transport: localRoundTripper{handler: mux}})
 
 	Context("Find Images", func() {

--- a/internal/pyxis/submit_test.go
+++ b/internal/pyxis/submit_test.go
@@ -17,6 +17,8 @@ var _ = Describe("Pyxis Submit", func() {
 
 	// These go from most explicit to least explicit. They will be check that way by the ServeMux.
 	mux.HandleFunc("/api/v1/projects/certification/id/my-awesome-project-id/test-results", pyxisTestResultsHandler(ctx))
+	mux.HandleFunc("/api/v1/projects/certification/id/my-image-project-id/test-results", pyxisTestResultsHandler(ctx))
+	mux.HandleFunc("/api/v1/projects/certification/test-results/id/54321", pyxisTestResultsHandler(ctx))
 	mux.HandleFunc("/api/v1/projects/certification/id/my-image-project-id/images", pyxisImageHandler(ctx))
 	mux.HandleFunc("/api/v1/projects/certification/id/", pyxisProjectHandler(ctx))
 	mux.HandleFunc("/api/v1/images/id/updateImage", pyxisImageHandler(ctx))
@@ -96,6 +98,16 @@ var _ = Describe("Pyxis Submit", func() {
 				certInput.CertImage = &CertImage{}
 			})
 			It("should get invalid cert image error", func() {
+				certResults, err := pyxisClient.SubmitResults(ctx, &certInput)
+				Expect(err).To(HaveOccurred())
+				Expect(certResults).To(BeNil())
+			})
+		})
+		Context("and POST call to test-results is success and PATCH is a failure", func() {
+			JustBeforeEach(func() {
+				pyxisClient.APIToken = "my-bad-results-patch-api-token"
+			})
+			It("should get an unknown error", func() {
 				certResults, err := pyxisClient.SubmitResults(ctx, &certInput)
 				Expect(err).To(HaveOccurred())
 				Expect(certResults).To(BeNil())


### PR DESCRIPTION
- Reordering submit flow to create test results early, then update them in the case where we have successfully created an image to link to the results.
- We need not worry about re-try, or re-run (of preflight like in other API calls) or any of the other things we worry about for other pyxis routes, since pyxis/connect will just ignore (not show?) any results not linked to any images.
- `createTestResults` was modified to account for both `PATCH/POST`, since there would be less duplicate code, if others are happier with two distinct methods, I'm happy to refactor that way as well.
- JIRA: EET-3965