### PR TITLE
updating connect url's to point to new routes

### DIFF
--- a/cmd/preflight/cmd/check_test.go
+++ b/cmd/preflight/cmd/check_test.go
@@ -17,6 +17,7 @@ var _ = Describe("cmd package check command", func() {
 		var (
 			projectID = "this-is-my-project-id"
 			imageID   = "my-image-id"
+			resultsID = "my-results-id"
 		)
 		BeforeEach(func() {
 			viper.Instance().SetEnvPrefix("pflt")
@@ -28,7 +29,7 @@ var _ = Describe("cmd package check command", func() {
 		})
 		Context("Regular Connect URL", func() {
 			It("should return a URL with just a project ID", func() {
-				expected := "https://connect.redhat.com/projects/this-is-my-project-id"
+				expected := "https://connect.redhat.com/component/view/this-is-my-project-id"
 				actual := lib.BuildConnectURL(projectID)
 				Expect(expected).To(Equal(actual))
 			})
@@ -38,28 +39,28 @@ var _ = Describe("cmd package check command", func() {
 				os.Setenv("PFLT_PYXIS_ENV", "qa")
 			})
 			It("should return a URL for QA", func() {
-				expected := "https://connect.qa.redhat.com/projects/this-is-my-project-id"
+				expected := "https://connect.qa.redhat.com/component/view/this-is-my-project-id"
 				actual := lib.BuildConnectURL(projectID)
 				Expect(expected).To(Equal(actual))
 			})
 		})
-		Context("UAT Scan Results URL", func() {
+		Context("UAT Test Results URL", func() {
 			BeforeEach(func() {
 				os.Setenv("PFLT_PYXIS_ENV", "uat")
 			})
 			It("should return a URL for UAT", func() {
-				expected := "https://connect.uat.redhat.com/projects/this-is-my-project-id/images/my-image-id/scan-results"
-				actual := lib.BuildScanResultsURL(projectID, imageID)
+				expected := "https://connect.uat.redhat.com/component/view/this-is-my-project-id/certification/test-results/my-results-id"
+				actual := lib.BuildTestResultsURL(projectID, resultsID)
 				Expect(expected).To(Equal(actual))
 			})
 		})
-		Context("QA Overview URL", func() {
+		Context("QA Images URL", func() {
 			BeforeEach(func() {
 				os.Setenv("PFLT_PYXIS_ENV", "qa")
 			})
 			It("should return a URL for QA", func() {
-				expected := "https://connect.qa.redhat.com/projects/this-is-my-project-id/overview"
-				actual := lib.BuildOverviewURL(projectID)
+				expected := "https://connect.qa.redhat.com/component/view/this-is-my-project-id/images"
+				actual := lib.BuildImagesURL(projectID)
 				Expect(expected).To(Equal(actual))
 			})
 		})
@@ -67,14 +68,19 @@ var _ = Describe("cmd package check command", func() {
 			BeforeEach(func() {
 				os.Setenv("PFLT_PYXIS_HOST", "my.pyxis.host/some/path")
 			})
-			It("should return a Prod overview URL", func() {
-				expected := "https://connect.redhat.com/projects/this-is-my-project-id/overview"
-				actual := lib.BuildOverviewURL(projectID)
+			It("should return a Prod Images URL", func() {
+				expected := "https://connect.redhat.com/component/view/this-is-my-project-id/images"
+				actual := lib.BuildImagesURL(projectID)
 				Expect(expected).To(Equal(actual))
 			})
-			It("should return a Prod scan URL", func() {
-				expected := "https://connect.redhat.com/projects/this-is-my-project-id/images/my-image-id/scan-results"
-				actual := lib.BuildScanResultsURL(projectID, imageID)
+			It("should return a Prod Test Results URL", func() {
+				expected := "https://connect.redhat.com/component/view/this-is-my-project-id/certification/test-results/my-results-id"
+				actual := lib.BuildTestResultsURL(projectID, resultsID)
+				Expect(expected).To(Equal(actual))
+			})
+			It("should return a Prod Vulnerabilities URL", func() {
+				expected := "https://connect.redhat.com/component/view/this-is-my-project-id/security/vulnerabilities/my-image-id"
+				actual := lib.BuildVulnerabilitiesURL(projectID, imageID)
 				Expect(expected).To(Equal(actual))
 			})
 		})

--- a/internal/lib/fakes_test.go
+++ b/internal/lib/fakes_test.go
@@ -55,7 +55,7 @@ func (pc *FakePyxisClient) baseProject(projectID string) pyxis.CertProject {
 
 // successfulCertResults returns a pyxis.CertificationResults for use in tests emulating successful
 // submission.
-func (pc *FakePyxisClient) successfulCertResults(projectID, certImageID string) pyxis.CertificationResults {
+func (pc *FakePyxisClient) successfulCertResults(projectID, certImageID, testResultsID string) pyxis.CertificationResults {
 	pid := "000000000000"
 	if len(projectID) > 0 {
 		pid = projectID
@@ -65,12 +65,21 @@ func (pc *FakePyxisClient) successfulCertResults(projectID, certImageID string) 
 	if len(certImageID) > 0 {
 		ciid = certImageID
 	}
+
+	trid := "222222222222"
+	if len(testResultsID) > 0 {
+		trid = testResultsID
+	}
+
 	return pyxis.CertificationResults{
 		CertProject: &pyxis.CertProject{
 			ID: pid,
 		},
 		CertImage: &pyxis.CertImage{
 			ID: ciid,
+		},
+		TestResults: &pyxis.TestResults{
+			ID: trid,
 		},
 	}
 }
@@ -85,7 +94,7 @@ func (pc *FakePyxisClient) setGPFuncReturnBaseProject(projectID string) {
 
 func (pc *FakePyxisClient) setSRFuncSubmitSuccessfully(projectID, certImageID string) {
 	baseproj := pc.baseProject(projectID)
-	certresults := pc.successfulCertResults(baseproj.ID, certImageID)
+	certresults := pc.successfulCertResults(baseproj.ID, certImageID, "")
 	pc.submitResultsFunc = func(context.Context, *pyxis.CertificationInput) (*pyxis.CertificationResults, error) {
 		return &certresults, nil
 	}

--- a/internal/lib/types.go
+++ b/internal/lib/types.go
@@ -193,8 +193,9 @@ func (s *ContainerCertificationSubmitter) Submit(ctx context.Context) error {
 	logger.Info("Test results have been submitted to Red Hat.")
 	logger.Info("These results will be reviewed by Red Hat for final certification.")
 	logger.Info(fmt.Sprintf("The container's image id is: %s.", certResults.CertImage.ID))
-	logger.Info(fmt.Sprintf("Please check %s to view scan results.", BuildScanResultsURL(s.CertificationProjectID, certResults.CertImage.ID)))
-	logger.Info(fmt.Sprintf("Please check %s to monitor the progress.", BuildOverviewURL(s.CertificationProjectID)))
+	logger.Info(fmt.Sprintf("Please check %s to view test results.", BuildTestResultsURL(s.CertificationProjectID, certResults.TestResults.ID)))
+	logger.Info(fmt.Sprintf("Please check %s to view security vulnerabilities.", BuildVulnerabilitiesURL(s.CertificationProjectID, certResults.CertImage.ID)))
+	logger.Info(fmt.Sprintf("Please check %s to monitor the progress.", BuildImagesURL(s.CertificationProjectID)))
 
 	return nil
 }
@@ -238,20 +239,24 @@ func (s *NoopSubmitter) SetReason(reason string) {
 }
 
 func BuildConnectURL(projectID string) string {
-	connectURL := fmt.Sprintf("https://connect.redhat.com/projects/%s", projectID)
+	connectURL := fmt.Sprintf("https://connect.redhat.com/component/view/%s", projectID)
 
 	pyxisEnv := viper.Instance().GetString("pyxis_env")
 	if len(pyxisEnv) > 0 && pyxisEnv != "prod" {
-		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/projects/%s", viper.Instance().GetString("pyxis_env"), projectID)
+		connectURL = fmt.Sprintf("https://connect.%s.redhat.com/component/view/%s", viper.Instance().GetString("pyxis_env"), projectID)
 	}
 
 	return connectURL
 }
 
-func BuildOverviewURL(projectID string) string {
-	return fmt.Sprintf("%s/overview", BuildConnectURL(projectID))
+func BuildImagesURL(projectID string) string {
+	return fmt.Sprintf("%s/images", BuildConnectURL(projectID))
 }
 
-func BuildScanResultsURL(projectID string, imageID string) string {
-	return fmt.Sprintf("%s/images/%s/scan-results", BuildConnectURL(projectID), imageID)
+func BuildTestResultsURL(projectID string, testResultsID string) string {
+	return fmt.Sprintf("%s/certification/test-results/%s", BuildConnectURL(projectID), testResultsID)
+}
+
+func BuildVulnerabilitiesURL(projectID string, imageID string) string {
+	return fmt.Sprintf("%s/security/vulnerabilities/%s", BuildConnectURL(projectID), imageID)
 }


### PR DESCRIPTION
- Fixes: #1164 
- Updating Connect URL's to point to new routes, that we display to the user after running preflight. This does not affect internal API calls to backend services.
- Since Connect layout is different, also adding a new route for Vulnerabilities.
   - This is due to tests/overview/etc not being default landing pages, and pages having nested sidebars.
