### PR TITLE
adding logic to deployablebyolm to validate packagename

### DIFF
--- a/internal/policy/operator/deployable_by_olm_test.go
+++ b/internal/policy/operator/deployable_by_olm_test.go
@@ -72,7 +72,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 
 				// changing the namespace since OwnNamespace operators CSV get applied to `InstallNamespace`
 				ownCSV := csv.DeepCopy()
-				ownCSV.Namespace = "testPackage"
+				ownCSV.Namespace = "p-testPackage"
 
 				deployableByOLMCheck.client = clientBuilder.
 					WithObjects(ownCSV).
@@ -108,8 +108,8 @@ var _ = Describe("DeployableByOLMCheck", func() {
 			BeforeEach(func() {
 				badSub := sub
 				Expect(deployableByOLMCheck.client.Get(testcontext, crclient.ObjectKey{
-					Name:      "testPackage",
-					Namespace: "testPackage",
+					Name:      "p-testPackage",
+					Namespace: "p-testPackage",
 				}, &badSub)).To(Succeed())
 				badSub.Status.InstalledCSV = ""
 				Expect(deployableByOLMCheck.client.Update(testcontext, &badSub, &crclient.UpdateOptions{})).To(Succeed())

--- a/internal/policy/operator/operator_suite_test.go
+++ b/internal/policy/operator/operator_suite_test.go
@@ -105,7 +105,7 @@ var pods = corev1.PodList{
 var csv = operatorsv1alpha1.ClusterServiceVersion{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "csv-v0.0.0",
-		Namespace: "testPackage-target",
+		Namespace: "p-testPackage-target",
 	},
 	Spec: operatorsv1alpha1.ClusterServiceVersionSpec{},
 	Status: operatorsv1alpha1.ClusterServiceVersionStatus{
@@ -152,8 +152,8 @@ var secret = corev1.Secret{
 
 var sub = operatorsv1alpha1.Subscription{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "testPackage",
-		Namespace: "testPackage",
+		Name:      "p-testPackage",
+		Namespace: "p-testPackage",
 	},
 	Status: operatorsv1alpha1.SubscriptionStatus{
 		InstalledCSV: "csv-v0.0.0",
@@ -162,8 +162,8 @@ var sub = operatorsv1alpha1.Subscription{
 
 var og = operatorsv1.OperatorGroup{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "testPackage",
-		Namespace: "testPackage",
+		Name:      "p-testPackage",
+		Namespace: "p-testPackage",
 	},
 	Status: operatorsv1.OperatorGroupStatus{
 		LastUpdated: nil,


### PR DESCRIPTION
- Adding logic to `DeployableByOlm` to validate that packagename complies with DNS-1035 labeling constraints.
   - `App` name was changed for `OperatorGroup`, `CatalogSource` and `Subscription` to address cross referencing.
- Updating test/mock data.

- Relates: redhat-openshift-ecosystem/community-operators-prod#4150

Testing
- Stage ProjectID: 664646cee2c5eef0d5b58e40
- Files with prefixed name uploaded successfully
![Screenshot from 2024-05-16 13-51-35](https://github.com/redhat-openshift-ecosystem/openshift-preflight/assets/88156657/38dcbcfe-f485-4f33-ba23-7434f5d7718f)
