### PR TITLE
adding 'restricted' to SecurityContextConfig when creating a Catalog

### DIFF
--- a/internal/openshift/openshift.go
+++ b/internal/openshift/openshift.go
@@ -251,6 +251,9 @@ func (oe openshiftClient) CreateCatalogSource(ctx context.Context, data CatalogS
 			Image:       data.Image,
 			DisplayName: data.Name,
 			Secrets:     data.Secrets,
+			GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+				SecurityContextConfig: operatorsv1alpha1.Restricted,
+			},
 		},
 	}
 	err := oe.Client.Create(ctx, catalogSource)


### PR DESCRIPTION
- Fixes: #1169 
- Updating `CatalogSource` creation to include `SecurityContextCOnfig` type of `restricted`.
- Applying this globally with no conditional logic since this is works as expected for the versions of OCP that are currently supported (4.12-4.15), and solves the problem on 4.16.
