### PR TITLE
Return a failure instead of an error if no pinned images are found

### DIFF
--- a/internal/policy/operator/certified_images.go
+++ b/internal/policy/operator/certified_images.go
@@ -76,6 +76,11 @@ func (p *certifiedImagesCheck) dataToValidate(ctx context.Context, imagePath str
 func (p *certifiedImagesCheck) validate(ctx context.Context, imageDigests []string) (bool, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
+	if len(imageDigests) == 0 {
+		logger.Info("warning: pinned images are expected but none were discovered")
+		return false, nil
+	}
+
 	pyxisImages, err := p.imageFinder.FindImagesByDigest(ctx, imageDigests)
 	if err != nil {
 		return false, err
@@ -99,7 +104,8 @@ func (p *certifiedImagesCheck) validate(ctx context.Context, imageDigests []stri
 			p.nonCertifiedImages = append(p.nonCertifiedImages, fullImg)
 		}
 	}
-	return true, nil
+
+	return len(p.nonCertifiedImages) == 0, nil
 }
 
 func (p *certifiedImagesCheck) Name() string {

--- a/internal/policy/operator/certified_images_test.go
+++ b/internal/policy/operator/certified_images_test.go
@@ -143,11 +143,11 @@ spec:
 		AfterEach(func() {
 			certifiedImagesCheck.imageFinder = &certifiedImageFinder{}
 		})
-		It("should still succeed", func() {
+		It("should fail", func() {
 			certifiedImagesCheck.imageFinder = &uncertifiedImageFinder{}
 			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(BeTrue())
+			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))
 		})
 	})
@@ -155,11 +155,11 @@ spec:
 		AfterEach(func() {
 			certifiedImagesCheck.imageFinder = &certifiedImageFinder{}
 		})
-		It("should still succeed", func() {
+		It("should fail", func() {
 			certifiedImagesCheck.imageFinder = &missingImageFinder{}
 			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(BeTrue())
+			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))
 		})
 	})
@@ -184,7 +184,7 @@ spec:
 		})
 	})
 	When("the images in the CSV aren't pinned", func() {
-		It("should succeed, but mark the image as non-certified", func() {
+		It("should fail", func() {
 			csvContents := `kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 spec:
@@ -200,7 +200,7 @@ spec:
 			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
 			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(BeTrue())
+			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))
 		})
 	})


### PR DESCRIPTION
If no pinned images were found, we would throw an error for the CertifiedImages check, which isn't technically valid (because we didn't fail to run). This PR converts that into a failure instead. We would get the error in trying to query Pyxis for images with the provided digests. We're returning the error (not Pyxis), but we still want to catch it when returned and make sure it translates to a failure result and not a check execution error.

It also seems like this check had an older style "optional" configuration, which was to return true regardless of things that would cause this check to fail.  I've now made this check's return value accurate to its execution, and allow for the "optional" tag enforce that it's non-blocking.

Finally, I've updated tests which asserted that the things would pass according to the older style of "optional". They would now fail, so the checks needed to be updated accordingly.

This check remains non-blocking for certification.