### PR TITLE
adding a flag for csv timeout for check operator cmd

### DIFF
--- a/cmd/preflight/cmd/check_operator.go
+++ b/cmd/preflight/cmd/check_operator.go
@@ -52,6 +52,12 @@ func checkOperatorCmd(runpreflight runPreflight) *cobra.Command {
 		"If empty, the default operator channel in bundle's annotations file is used.. (env: PFLT_CHANNEL)")
 	_ = viper.BindPFlag("channel", checkOperatorCmd.Flags().Lookup("channel"))
 
+	checkOperatorCmd.Flags().Duration("csv-timeout", 0, "The Duration of time to wait for the ClusterServiceVersion to become healthy.\n"+
+		"If empty the default of 180s will be used. (env: PFLT_CSV_TIMEOUT)")
+	_ = viper.BindPFlag("csv_timeout", checkOperatorCmd.Flags().Lookup("csv-timeout"))
+
+	_ = checkOperatorCmd.Flags().MarkHidden("csv-timeout")
+
 	return checkOperatorCmd
 }
 
@@ -167,6 +173,10 @@ func generateOperatorCheckOptions(cfg *runtime.Config) []operator.Option {
 
 	if cfg.Insecure {
 		opts = append(opts, operator.WithInsecureConnection())
+	}
+
+	if cfg.CSVTimeout != 0 {
+		opts = append(opts, operator.WithCSVTimeout(cfg.CSVTimeout))
 	}
 
 	return opts

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 
@@ -88,6 +89,9 @@ func initConfig(viper *spfviper.Viper) {
 
 	// Set up scorecard wait time default
 	viper.SetDefault("scorecard_wait_time", DefaultScorecardWaitTime)
+
+	// Set up csv timout default
+	viper.SetDefault("csv_timeout", runtime.DefaultCSVTimeout)
 }
 
 // preRunConfig is used by cobra.PreRun in all non-root commands to load all necessary configurations

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -722,6 +722,7 @@ type OperatorCheckConfig struct {
 	ScorecardImage, ScorecardWaitTime, ScorecardNamespace, ScorecardServiceAccount string
 	IndexImage, DockerConfig, Channel                                              string
 	Kubeconfig                                                                     []byte
+	CSVTimeout                                                                     time.Duration
 }
 
 // InitializeOperatorChecks returns opeartor checks for policy p give cfg.
@@ -731,7 +732,7 @@ func InitializeOperatorChecks(ctx context.Context, p policy.Policy, cfg Operator
 		return []check.Check{
 			operatorpol.NewScorecardBasicSpecCheck(operatorsdk.New(cfg.ScorecardImage, exec.Command), cfg.ScorecardNamespace, cfg.ScorecardServiceAccount, cfg.Kubeconfig, cfg.ScorecardWaitTime),
 			operatorpol.NewScorecardOlmSuiteCheck(operatorsdk.New(cfg.ScorecardImage, exec.Command), cfg.ScorecardNamespace, cfg.ScorecardServiceAccount, cfg.Kubeconfig, cfg.ScorecardWaitTime),
-			operatorpol.NewDeployableByOlmCheck(cfg.IndexImage, cfg.DockerConfig, cfg.Channel),
+			operatorpol.NewDeployableByOlmCheck(cfg.IndexImage, cfg.DockerConfig, cfg.Channel, operatorpol.WithCSVTimeout(cfg.CSVTimeout)),
 			operatorpol.NewValidateOperatorBundleCheck(),
 			operatorpol.NewCertifiedImagesCheck(pyxis.NewPyxisClient(
 				check.DefaultPyxisHost,

--- a/internal/policy/operator/default.go
+++ b/internal/policy/operator/default.go
@@ -32,8 +32,6 @@ const (
 var (
 	subscriptionTimeout time.Duration = 180 * time.Second
 
-	csvTimeout time.Duration = 180 * time.Second
-
 	approvedRegistries = map[string]struct{}{
 		"registry.connect.dev.redhat.com":   {},
 		"registry.connect.qa.redhat.com":    {},

--- a/internal/policy/operator/deployable_by_olm_test.go
+++ b/internal/policy/operator/deployable_by_olm_test.go
@@ -29,7 +29,6 @@ var _ = Describe("DeployableByOLMCheck", func() {
 	BeforeEach(func() {
 		// override default timeout
 		subscriptionTimeout = 1 * time.Second
-		csvTimeout = 1 * time.Second
 
 		fakeImage := fakecranev1.FakeImage{}
 		imageRef.ImageInfo = &fakeImage
@@ -37,7 +36,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 
 		now := metav1.Now()
 		og.Status.LastUpdated = &now
-		deployableByOLMCheck = *NewDeployableByOlmCheck("test_indeximage", "", "")
+		deployableByOLMCheck = *NewDeployableByOlmCheck("test_indeximage", "", "", WithCSVTimeout(1*time.Second))
 		scheme := apiruntime.NewScheme()
 		Expect(openshift.AddSchemes(scheme)).To(Succeed())
 		clientBuilder = fake.NewClientBuilder().

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"os"
+	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/option"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
@@ -37,6 +38,7 @@ type Config struct {
 	Channel           string
 	IndexImage        string
 	Kubeconfig        string
+	CSVTimeout        time.Duration
 }
 
 // ReadOnly returns an uneditably configuration.
@@ -83,6 +85,7 @@ func (c *Config) storeOperatorPolicyConfiguration(vcfg viper.Viper) {
 	c.ScorecardWaitTime = vcfg.GetString("scorecard_wait_time")
 	c.Channel = vcfg.GetString("channel")
 	c.IndexImage = vcfg.GetString("indeximage")
+	c.CSVTimeout = vcfg.GetDuration("csv_timeout")
 }
 
 // This is to satisfy the CraneConfig interface

--- a/internal/runtime/config_read.go
+++ b/internal/runtime/config_read.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"time"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/config"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
 )
@@ -100,4 +102,8 @@ func (ro *ReadOnlyConfig) Platform() string {
 
 func (ro *ReadOnlyConfig) Insecure() bool {
 	return ro.cfg.Insecure
+}
+
+func (ro *ReadOnlyConfig) CSVTimeout() time.Duration {
+	return ro.cfg.CSVTimeout
 }

--- a/internal/runtime/config_read_test.go
+++ b/internal/runtime/config_read_test.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -30,6 +32,7 @@ var _ = Describe("Runtime ReadOnlyConfig test", func() {
 			Channel:                "channel",
 			IndexImage:             "indeximg",
 			Kubeconfig:             "kubeconfig",
+			CSVTimeout:             180 * time.Second,
 		}
 		cro := c.ReadOnly()
 		It("should return values assigned to corresponding struct fields", func() {
@@ -55,6 +58,7 @@ var _ = Describe("Runtime ReadOnlyConfig test", func() {
 			Expect(cro.Channel()).To(Equal("channel"))
 			Expect(cro.IndexImage()).To(Equal("indeximg"))
 			Expect(cro.Kubeconfig()).To(Equal("kubeconfig"))
+			Expect(cro.CSVTimeout()).To(Equal(180 * time.Second))
 		})
 	})
 })

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -54,6 +54,8 @@ var _ = Describe("Viper to Runtime Config", func() {
 		expectedRuntimeCfg.Channel = "mychannel"
 		baseViperCfg.Set("indeximage", "myindeximage")
 		expectedRuntimeCfg.IndexImage = "myindeximage"
+		baseViperCfg.Set("csv_timeout", DefaultCSVTimeout)
+		expectedRuntimeCfg.CSVTimeout = DefaultCSVTimeout
 	})
 
 	Context("With values in a viper config", func() {
@@ -64,12 +66,12 @@ var _ = Describe("Viper to Runtime Config", func() {
 		})
 	})
 
-	It("should only have 24 struct keys for tests to be valid", func() {
+	It("should only have 25 struct keys for tests to be valid", func() {
 		// If this test fails, it means a developer has added or removed
 		// keys from runtime.Config, and so these tests may no longer be
 		// accurate in confirming that the derived configuration from viper
 		// matches.
 		keys := reflect.TypeOf(Config{}).NumField()
-		Expect(keys).To(Equal(24))
+		Expect(keys).To(Equal(25))
 	})
 })

--- a/internal/runtime/defaults.go
+++ b/internal/runtime/defaults.go
@@ -1,0 +1,5 @@
+package runtime
+
+import "time"
+
+var DefaultCSVTimeout = 180 * time.Second

--- a/operator/check_operator.go
+++ b/operator/check_operator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	goruntime "runtime"
+	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
@@ -92,6 +93,7 @@ func (c *operatorCheck) resolve(ctx context.Context) error {
 		DockerConfig:            c.dockerConfigFilePath,
 		Channel:                 c.operatorChannel,
 		Kubeconfig:              c.kubeconfig,
+		CSVTimeout:              c.csvTimeout,
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %s", preflighterr.ErrCannotInitializeChecks, err)
@@ -164,6 +166,14 @@ func WithInsecureConnection() Option {
 	}
 }
 
+// WithCSVTimeout overrides the default csvTimeout value, for operators that take
+// additional time to install.
+func WithCSVTimeout(csvTimeout time.Duration) Option {
+	return func(oc *operatorCheck) {
+		oc.csvTimeout = csvTimeout
+	}
+}
+
 type operatorCheck struct {
 	// required
 	image      string
@@ -180,4 +190,5 @@ type operatorCheck struct {
 	checks                  []check.Check
 	resolved                bool
 	policy                  policy.Policy
+	csvTimeout              time.Duration
 }


### PR DESCRIPTION
- Adding a flag to set the `csv timeout` during DeployableByOLM check
- Adding new defaults file to the `runtime` package to avoid `import cycle` dependency issue(s) 
- Fixes: #1119 