### PR TITLE
Handle empty object references in Image Streams

### DIFF
--- a/internal/openshift/openshift.go
+++ b/internal/openshift/openshift.go
@@ -405,7 +405,7 @@ func (oe *openshiftClient) GetImages(ctx context.Context) (map[string]struct{}, 
 	}
 	for _, imageStream := range imageStreamList.Items {
 		for _, tag := range imageStream.Spec.Tags {
-			if tag.From.Kind == "DockerImage" {
+			if tag.From != nil && tag.From.Kind == "DockerImage" {
 				imageList[tag.From.Name] = struct{}{}
 			}
 		}

--- a/internal/openshift/openshift_test.go
+++ b/internal/openshift/openshift_test.go
@@ -81,6 +81,15 @@ var _ = Describe("OpenShift Engine", func() {
 						},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "imagestream-empty-objectref",
+						Namespace: "testns",
+					},
+					Spec: imagestreamv1.ImageStreamSpec{
+						Tags: []imagestreamv1.TagReference{},
+					},
+				},
 			},
 		}
 


### PR DESCRIPTION
The `ImageStream{}.Tags[].From` is a pointer to a corev1.ObjectReference and, and if it's missing, we'll panic because we access a field within without checking if it exists. 

This PR updates this logic so that it will only pull the reference if it exists. A corresponding test entry has been added.