### PR TITLE
refactor operator newcheck constructor defaults

### DIFF
--- a/cmd/preflight/cmd/defaults.go
+++ b/cmd/preflight/cmd/defaults.go
@@ -1,9 +1,8 @@
 package cmd
 
 var (
-	DefaultLogFile           = "preflight.log"
-	DefaultLogLevel          = "info"
-	DefaultNamespace         = "default"
-	DefaultServiceAccount    = "default"
-	DefaultScorecardWaitTime = "240"
+	DefaultLogFile        = "preflight.log"
+	DefaultLogLevel       = "info"
+	DefaultNamespace      = "default"
+	DefaultServiceAccount = "default"
 )

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -88,7 +88,7 @@ func initConfig(viper *spfviper.Viper) {
 	viper.SetDefault("serviceaccount", DefaultServiceAccount)
 
 	// Set up scorecard wait time default
-	viper.SetDefault("scorecard_wait_time", DefaultScorecardWaitTime)
+	viper.SetDefault("scorecard_wait_time", runtime.DefaultScorecardWaitTime)
 
 	// Set up csv timout default
 	viper.SetDefault("csv_timeout", runtime.DefaultCSVTimeout)

--- a/internal/policy/operator/deployable_by_olm.go
+++ b/internal/policy/operator/deployable_by_olm.go
@@ -99,8 +99,7 @@ func (p *DeployableByOlmCheck) initOpenShifeEngine() {
 	}
 }
 
-// WithCSVTimeout overrides the default csvTimeout value, for operators that take
-// additional time to install.
+// WithCSVTimeout customizes how long to wait for a ClusterServiceVersion to become healthy.
 func WithCSVTimeout(csvTimeout time.Duration) Option {
 	return func(oc *DeployableByOlmCheck) {
 		oc.csvTimeout = csvTimeout

--- a/internal/runtime/defaults.go
+++ b/internal/runtime/defaults.go
@@ -5,4 +5,5 @@ import "time"
 var (
 	DefaultCSVTimeout          = 180 * time.Second
 	DefaultSubscriptionTimeout = 180 * time.Second
+	DefaultScorecardWaitTime   = "240"
 )

--- a/operator/check_operator.go
+++ b/operator/check_operator.go
@@ -16,16 +16,14 @@ import (
 
 type Option = func(*operatorCheck)
 
-// TODO(): replace this value when the default in package cmd is moved to a central location
-const defaultScorecardWaitTime = "240"
-
 // NewCheck is a check runner that executes the Operator Policy.
 func NewCheck(image, indeximage string, kubeconfig []byte, opts ...Option) *operatorCheck {
 	c := &operatorCheck{
 		image:               image,
 		kubeconfig:          kubeconfig,
 		indeximage:          indeximage,
-		scorecardWaitTime:   defaultScorecardWaitTime,
+		scorecardWaitTime:   runtime.DefaultScorecardWaitTime,
+		csvTimeout:          runtime.DefaultCSVTimeout,
 		subscriptionTimeout: runtime.DefaultSubscriptionTimeout,
 	}
 
@@ -168,8 +166,7 @@ func WithInsecureConnection() Option {
 	}
 }
 
-// WithCSVTimeout overrides the default csvTimeout value, for operators that take
-// additional time to install.
+// WithCSVTimeout customizes how long to wait for a ClusterServiceVersion to become healthy.
 func WithCSVTimeout(csvTimeout time.Duration) Option {
 	return func(oc *operatorCheck) {
 		oc.csvTimeout = csvTimeout


### PR DESCRIPTION
- Moving scorecard default timeout to runtime like csv and subscription timeout
- Update WithCSVTimeout method description for consistency