### PR TITLE
add exec.LookPath to check operator-sdk is in $PATH

### DIFF
--- a/internal/operatorsdk/operatorsdk.go
+++ b/internal/operatorsdk/operatorsdk.go
@@ -34,6 +34,12 @@ type execContext = func(name string, arg ...string) *exec.Cmd
 func (o operatorSdk) Scorecard(ctx context.Context, image string, opts OperatorSdkScorecardOptions) (*OperatorSdkScorecardReport, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
+	// checking to make sure operator-sdk is in the $PATH
+	_, err := exec.LookPath("operator-sdk")
+	if err != nil {
+		return nil, err
+	}
+
 	cmdArgs := []string{"scorecard"}
 	if opts.OutputFormat == "" {
 		opts.OutputFormat = "json"

--- a/internal/operatorsdk/operatorsdk_test.go
+++ b/internal/operatorsdk/operatorsdk_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
@@ -27,6 +28,13 @@ var _ = Describe("OperatorSdk", func() {
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(os.RemoveAll, tmpdir)
 		aw, err := artifacts.NewFilesystemWriter(artifacts.WithDirectory(tmpdir))
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(tmpdir, "operator-sdk"), []byte("testcontents"), 0o755)
+		Expect(err).ToNot(HaveOccurred())
+
+		// updating PATH env to include the directory created in the test
+		err = os.Setenv("PATH", os.Getenv("PATH")+":"+tmpdir)
 		Expect(err).ToNot(HaveOccurred())
 
 		testcontext = artifacts.ContextWithWriter(context.Background(), aw)


### PR DESCRIPTION
## Motivation 
The ux when a user does not have `operator-sdk` in their path leads to a confusing error that is hard to track down.

Current Error Message:
```
time="2024-10-02T15:57:04+02:00" level=info msg="check completed" check=ScorecardBasicSpecCheck err="failed to run operator-sdk scorecard: unexpected end of JSON input" result=ERROR
```

This error is not clear at all what is going on, but we do not have direct control of this once we shell out to `operator-sdk`

## Changes
Add an explicit check to make sure that `operator-sdk` binary is in the users `PATH`. This provides an error message that is more clearer.

New Error Message:
```
time="2024-10-16T13:05:53-07:00" level=info msg="check completed" check=ScorecardBasicSpecCheck err="exec: \"operator-sdk\": executable file not found in $PATH" result=ERROR
```

## Note
Since this is in the `Scorecard` method, it does not matter which check `Basic` or `OlmSuite` gets called, this error will appear.

- Relates: #1203