### PR TITLE
adding PyxisHost value to ContainerCheckConfig for ubi check

### DIFF
--- a/container/check_container.go
+++ b/container/check_container.go
@@ -96,6 +96,7 @@ func (c *containerCheck) resolve(ctx context.Context) error {
 		DockerConfig:           c.dockerconfigjson,
 		PyxisAPIToken:          c.pyxisToken,
 		CertificationProjectID: c.certificationProjectID,
+		PyxisHost:              c.pyxisHost,
 	})
 	if err != nil {
 		return fmt.Errorf("%w: %s", preflighterr.ErrCannotInitializeChecks, err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -753,7 +753,7 @@ func InitializeOperatorChecks(ctx context.Context, p policy.Policy, cfg Operator
 
 // ContainerCheckConfig contains configuration relevant to an individual check's execution.
 type ContainerCheckConfig struct {
-	DockerConfig, PyxisAPIToken, CertificationProjectID string
+	DockerConfig, PyxisAPIToken, CertificationProjectID, PyxisHost string
 }
 
 // InitializeContainerChecks returns the appropriate checks for policy p given cfg.
@@ -769,7 +769,7 @@ func InitializeContainerChecks(ctx context.Context, p policy.Policy, cfg Contain
 			&containerpol.RunAsNonRootCheck{},
 			&containerpol.HasModifiedFilesCheck{},
 			containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisClient(
-				check.DefaultPyxisHost,
+				cfg.PyxisHost,
 				cfg.PyxisAPIToken,
 				cfg.CertificationProjectID,
 				&http.Client{Timeout: 60 * time.Second})),
@@ -783,7 +783,7 @@ func InitializeContainerChecks(ctx context.Context, p policy.Policy, cfg Contain
 			&containerpol.HasRequiredLabelsCheck{},
 			&containerpol.HasModifiedFilesCheck{},
 			containerpol.NewBasedOnUbiCheck(pyxis.NewPyxisClient(
-				check.DefaultPyxisHost,
+				cfg.PyxisHost,
 				cfg.PyxisAPIToken,
 				cfg.CertificationProjectID,
 				&http.Client{Timeout: 60 * time.Second})),


### PR DESCRIPTION
## Motivation
To be able to lookup pre-prod ubi images in pyxis for testing.

## Fix
Add `PyxisHost` as to the `ContainerCheckConfig`, and use the value of  of `c.pyxisHost` that we have from the `checkContainer` struct.