### PR TITLE
updating go version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-FROM docker.io/golang:1.22 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG quay_expiration
 ARG release_tag
 ARG ARCH

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ clean:
 	$(shell if [ -f "$(BINARY)-$(GOOS)-$(GOARCH)" ]; then rm -f $(BINARY)-$(GOOS)-$(GOARCH); fi)))
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.58.0
+GOLANGCI_LINT_VERSION ?= v1.62.2
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 22, host: 2322, id: "ssh"
   config.vm.provision "shell", inline: <<-SHELL
     dnf -y update
-   
+
     dnf -y install \
     podman \
     buildah \
@@ -23,9 +23,9 @@ Vagrant.configure("2") do |config|
     containers-common \
     openscap-containers
 
-    curl -L https://go.dev/dl/go1.22.3.linux-amd64.tar.gz --output go1.22.3.linux-amd64.tar.gz
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.3.linux-amd64.tar.gz
-    rm go1.22.3.linux-amd64.tar.gz
+    curl -L https://go.dev/dl/go1.23.2.linux-amd64.tar.gz --output go1.23.2.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
+    rm go1.23.2.linux-amd64.tar.gz
 
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz --output oc.tar.gz
     tar -C /usr/local/bin -xzf oc.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-openshift-ecosystem/openshift-preflight
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.2
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
## Changes
- Updated `go` to latest 1.23 version
- Updated `golangci-lint` to build/run properly with go 1.23