### PR TITLE
removing kube-rbac-proxy from test data

### DIFF
--- a/internal/bundle/testdata/invalid_bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/bundle/testdata/invalid_bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -109,17 +109,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/bundle/testdata/malformed_annotations_file/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/bundle/testdata/malformed_annotations_file/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/bundle/testdata/no_annotations_file/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/bundle/testdata/no_annotations_file/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/bundle/testdata/valid_bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/bundle/testdata/valid_bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/policy/operator/testdata/all_namespaces/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/all_namespaces/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/policy/operator/testdata/disconnected_bundle/manifests/simple-disconnected-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/disconnected_bundle/manifests/simple-disconnected-operator.clusterserviceversion.yaml
@@ -143,29 +143,6 @@ spec:
                                 - linux
                 containers:
                   - args:
-                      - --secure-listen-address=0.0.0.0:8443
-                      - --upstream=http://127.0.0.1:8080/
-                      - --logtostderr=true
-                      - --v=0
-                    image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-                    name: kube-rbac-proxy
-                    ports:
-                      - containerPort: 8443
-                        name: https
-                        protocol: TCP
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 5m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                  - args:
                       - --health-probe-bind-address=:8081
                       - --metrics-bind-address=127.0.0.1:8080
                       - --leader-elect
@@ -269,8 +246,6 @@ spec:
   relatedImages:
     - image: quay.io/fedora/fedora@sha256:ce08a91085403ecbc637eb2a96bd3554d75537871a12a14030b89243501050f2
       name: fedora
-    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-      name: kube-rbac-proxy
     - image: quay.io/opdev/simple-disconnected-operator-cm@sha256:b4d060da584f7f5f7935e8fb78a0b62b1abb829717ad522190ac7747abd9fbd1
       name: manager
   version: 0.0.1

--- a/internal/policy/operator/testdata/incorrect_optional_annotations_bundle/manifests/optional-annotations-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/incorrect_optional_annotations_bundle/manifests/optional-annotations-operator.clusterserviceversion.yaml
@@ -150,29 +150,6 @@ spec:
                                 - linux
                 containers:
                   - args:
-                      - --secure-listen-address=0.0.0.0:8443
-                      - --upstream=http://127.0.0.1:8080/
-                      - --logtostderr=true
-                      - --v=0
-                    image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-                    name: kube-rbac-proxy
-                    ports:
-                      - containerPort: 8443
-                        name: https
-                        protocol: TCP
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 5m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                  - args:
                       - --health-probe-bind-address=:8081
                       - --metrics-bind-address=127.0.0.1:8080
                       - --leader-elect
@@ -276,8 +253,6 @@ spec:
   relatedImages:
     - image: quay.io/fedora/fedora@sha256:ce08a91085403ecbc637eb2a96bd3554d75537871a12a14030b89243501050f2
       name: fedora
-    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-      name: kube-rbac-proxy
     - image: quay.io/opdev/optional-annotations-operator-cm@sha256:b4d060da584f7f5f7935e8fb78a0b62b1abb829717ad522190ac7747abd9fbd1
       name: manager
   version: 0.0.1

--- a/internal/policy/operator/testdata/incorrect_required_annotations_bundle/manifests/required-annotations-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/incorrect_required_annotations_bundle/manifests/required-annotations-operator.clusterserviceversion.yaml
@@ -149,29 +149,6 @@ spec:
                                 - linux
                 containers:
                   - args:
-                      - --secure-listen-address=0.0.0.0:8443
-                      - --upstream=http://127.0.0.1:8080/
-                      - --logtostderr=true
-                      - --v=0
-                    image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-                    name: kube-rbac-proxy
-                    ports:
-                      - containerPort: 8443
-                        name: https
-                        protocol: TCP
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 5m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                  - args:
                       - --health-probe-bind-address=:8081
                       - --metrics-bind-address=127.0.0.1:8080
                       - --leader-elect
@@ -275,8 +252,6 @@ spec:
   relatedImages:
     - image: quay.io/fedora/fedora@sha256:ce08a91085403ecbc637eb2a96bd3554d75537871a12a14030b89243501050f2
       name: fedora
-    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-      name: kube-rbac-proxy
     - image: quay.io/opdev/required-annotations-operator-cm@sha256:b4d060da584f7f5f7935e8fb78a0b62b1abb829717ad522190ac7747abd9fbd1
       name: manager
   version: 0.0.1

--- a/internal/policy/operator/testdata/invalid_bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/invalid_bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -109,17 +109,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/policy/operator/testdata/multi_namespace/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/multi_namespace/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/policy/operator/testdata/own_namespace/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/own_namespace/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/internal/policy/operator/testdata/required_annotations_bundle/manifests/required-annotations-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/required_annotations_bundle/manifests/required-annotations-operator.clusterserviceversion.yaml
@@ -149,29 +149,6 @@ spec:
                                 - linux
                 containers:
                   - args:
-                      - --secure-listen-address=0.0.0.0:8443
-                      - --upstream=http://127.0.0.1:8080/
-                      - --logtostderr=true
-                      - --v=0
-                    image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-                    name: kube-rbac-proxy
-                    ports:
-                      - containerPort: 8443
-                        name: https
-                        protocol: TCP
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 5m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
-                  - args:
                       - --health-probe-bind-address=:8081
                       - --metrics-bind-address=127.0.0.1:8080
                       - --leader-elect
@@ -275,8 +252,6 @@ spec:
   relatedImages:
     - image: quay.io/fedora/fedora@sha256:ce08a91085403ecbc637eb2a96bd3554d75537871a12a14030b89243501050f2
       name: fedora
-    - image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f
-      name: kube-rbac-proxy
     - image: quay.io/opdev/required-annotations-operator-cm@sha256:b4d060da584f7f5f7935e8fb78a0b62b1abb829717ad522190ac7747abd9fbd1
       name: manager
   version: 0.0.1

--- a/internal/policy/operator/testdata/single_namespace/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/single_namespace/manifests/memcached-operator.clusterserviceversion.yaml
@@ -87,17 +87,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect

--- a/test/containerfiles/failed-bundle-assets/manifests/sample-operator.clusterserviceversion.yaml
+++ b/test/containerfiles/failed-bundle-assets/manifests/sample-operator.clusterserviceversion.yaml
@@ -79,17 +79,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect


### PR DESCRIPTION
- Removing `kube-rbac-proxy` from tests data
- Fixes: #1231