### PR TITLE
Clarify docker-config is required for public Dockerhub registries

### DIFF
--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -158,7 +158,7 @@ You will also need:
 - A Docker Auth file, can be specified multiple ways
   - If PFLT_DOCKERCONFIG envvar is set, or --docker-config is passed on the command line, this will be used to pull images.
     If also submitting, the file specified will be sent to Red Hat. If the image under test is on a public registry, there is
-    no need to pass this parameter.
+    no need to pass this parameter. For DockerHub registries, this is required even if the registry is public.
 
 ### Testing a Container
 Running container policy checks against a container iteratively until all tests pass.


### PR DESCRIPTION
While submitting images to Red Hat, I noticed we weren't able to pull even though the images are in a public DockerHub registry. Red Hat support explained that the `--docker-config` flag is required for DockerHub registries. Updating here to help others, as I assumed it wasn't needed since this was a public registry.