### PR TITLE
adding crane retry logic for crane ListTags lookup

### DIFF
--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -39,7 +39,7 @@ func GenerateCraneOptions(ctx context.Context, craneConfig CraneConfig) []crane.
 			OS:           "linux",
 			Architecture: craneConfig.CranePlatform(),
 		}),
-		retryOnceAfter(5 * time.Second),
+		RetryOnceAfter(5 * time.Second),
 	}
 
 	if craneConfig.CraneInsecure() {
@@ -60,8 +60,8 @@ func GenerateCraneOptions(ctx context.Context, craneConfig CraneConfig) []crane.
 	return options
 }
 
-// retryOnceAfter is a crane option that retries once after t duration.
-func retryOnceAfter(t time.Duration) crane.Option {
+// RetryOnceAfter is a crane option that retries once after t duration.
+func RetryOnceAfter(t time.Duration) crane.Option {
 	return func(o *crane.Options) {
 		o.Remote = append(o.Remote, remote.WithRetryBackoff(remote.Backoff{
 			Duration: t,

--- a/internal/policy/container/has_unique_tag.go
+++ b/internal/policy/container/has_unique_tag.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/authn"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/option"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 )
@@ -58,6 +60,7 @@ func (p *hasUniqueTagCheck) getDataToValidate(ctx context.Context, image string)
 	options := []crane.Option{
 		crane.WithContext(ctx),
 		crane.WithAuthFromKeychain(authn.PreflightKeychain(ctx, authn.WithDockerConfig(p.dockercfg))),
+		option.RetryOnceAfter(5 * time.Second),
 	}
 
 	return crane.ListTags(image, options...)


### PR DESCRIPTION
## Motivation
We have this logic in our pull logic, but not in our `list-tags` logic, so this check fails if a registry flakes out.

## Changes
Exposing the existing option method that is used in our pull logic and adding it to our `HasUniqueTag` check.