### PR TITLE
adding a new container policy for konflux pipeline execution

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -176,6 +176,11 @@ func checkContainerRunE(cmd *cobra.Command, args []string, runpreflight runPrefl
 		pc := lib.NewPyxisClient(ctx, cfg.CertificationProjectID, cfg.PyxisAPIToken, cfg.PyxisHost)
 		resultSubmitter := lib.ResolveSubmitter(pc, cfg.CertificationProjectID, cfg.DockerConfig, cfg.LogFile)
 
+		// use a noop submitter, since the konflux system has no need to submit results to pyxis.
+		if cfg.Konflux {
+			resultSubmitter = lib.NewNoopSubmitter(true, nil)
+		}
+
 		// Run the  container check.
 		cmd.SilenceUsage = true
 
@@ -341,6 +346,10 @@ func generateContainerCheckOptions(cfg *runtime.Config) []container.Option {
 		// This is a secondary check to be safe.
 		cfg.Submit = false
 		o = append(o, container.WithInsecureConnection())
+	}
+
+	if cfg.Konflux {
+		o = append(o, container.WithKonflux())
 	}
 
 	return o

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -432,6 +432,18 @@ var _ = Describe("Check Container Command", func() {
 			})
 		})
 	})
+	Context("when PFLT_KONFLUX env is set to true", func() {
+		BeforeEach(func() {
+			viper.Reset()
+			initConfig(viper.Instance())
+			os.Setenv("PFLT_KONFLUX", "true")
+			DeferCleanup(os.Unsetenv, "PFLT_KONFLUX")
+		})
+		It("should run successfully", func() {
+			_, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnNil), logr.Discard(), src)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })
 
 func mockRunPreflightReturnNil(context.Context, func(ctx context.Context) (certification.Results, error), cli.CheckConfig, formatters.ResponseFormatter, lib.ResultWriter, lib.ResultSubmitter) error {

--- a/container/check_container.go
+++ b/container/check_container.go
@@ -92,6 +92,10 @@ func (c *containerCheck) resolve(ctx context.Context) error {
 		c.policy = override
 	}
 
+	if c.konflux {
+		c.policy = policy.PolicyKonflux
+	}
+
 	newChecks, err := engine.InitializeContainerChecks(ctx, c.policy, engine.ContainerCheckConfig{
 		DockerConfig:           c.dockerconfigjson,
 		PyxisAPIToken:          c.pyxisToken,
@@ -193,6 +197,13 @@ func WithManifestListDigest(manifestListDigest string) Option {
 	}
 }
 
+// WithKonflux signifies that we are running on the konflux platform
+func WithKonflux() Option {
+	return func(cc *containerCheck) {
+		cc.konflux = true
+	}
+}
+
 type containerCheck struct {
 	image                  string
 	dockerconfigjson       string
@@ -205,4 +216,5 @@ type containerCheck struct {
 	checks                 []check.Check
 	resolved               bool
 	policy                 policy.Policy
+	konflux                bool
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -311,6 +311,10 @@ var _ = Describe("Check Initialization", func() {
 			_, err := InitializeContainerChecks(context.TODO(), policy.PolicyRoot, ContainerCheckConfig{})
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("should properly return checks for the konflux policy", func() {
+			_, err := InitializeContainerChecks(context.TODO(), policy.PolicyKonflux, ContainerCheckConfig{})
+			Expect(err).ToNot(HaveOccurred())
+		})
 		It("should throw an error if the policy is unknown", func() {
 			_, err := InitializeContainerChecks(context.TODO(), policy.Policy("foo"), ContainerCheckConfig{})
 			Expect(err).To(HaveOccurred())
@@ -342,6 +346,7 @@ var _ = Describe("Check Name Queries", func() {
 			"LayerCountAcceptable",
 			"HasNoProhibitedPackages",
 			"HasRequiredLabel",
+			"HasNoProhibitedLabels",
 			"RunAsNonRoot",
 			"HasModifiedFiles",
 			"BasedOnUbi",
@@ -358,19 +363,21 @@ var _ = Describe("Check Name Queries", func() {
 			"FollowsRestrictedNetworkEnablementGuidelines",
 			"RequiredAnnotations",
 		}),
-		Entry("scratch container policy", ScratchNonRootContainerPolicy, []string{
+		Entry("scratch nonroot container policy", ScratchNonRootContainerPolicy, []string{
 			"HasLicense",
 			"HasUniqueTag",
 			"LayerCountAcceptable",
 			"HasRequiredLabel",
+			"HasNoProhibitedLabels",
 			"RunAsNonRoot",
 			"HasProhibitedContainerName",
 		}),
-		Entry("scratch container policy", ScratchRootContainerPolicy, []string{
+		Entry("scratch root container policy", ScratchRootContainerPolicy, []string{
 			"HasLicense",
 			"HasUniqueTag",
 			"LayerCountAcceptable",
 			"HasRequiredLabel",
+			"HasNoProhibitedLabels",
 			"HasProhibitedContainerName",
 		}),
 		Entry("root container policy", RootExceptionContainerPolicy, []string{
@@ -379,9 +386,20 @@ var _ = Describe("Check Name Queries", func() {
 			"LayerCountAcceptable",
 			"HasNoProhibitedPackages",
 			"HasRequiredLabel",
+			"HasNoProhibitedLabels",
 			"HasModifiedFiles",
 			"BasedOnUbi",
 			"HasProhibitedContainerName",
+		}),
+		Entry("konflux container policy", KonfluxContainerPolicy, []string{
+			"HasLicense",
+			"HasUniqueTag",
+			"LayerCountAcceptable",
+			"HasNoProhibitedPackages",
+			"HasRequiredLabel",
+			"RunAsNonRoot",
+			"HasModifiedFiles",
+			"BasedOnUbi",
 		}),
 	)
 

--- a/internal/policy/container/has_prohibited_labels.go
+++ b/internal/policy/container/has_prohibited_labels.go
@@ -1,0 +1,65 @@
+package container
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+
+	"github.com/go-logr/logr"
+)
+
+var trademarkLabels = []string{"name", "vendor", "maintainer"}
+
+var _ check.Check = &HasNoProhibitedLabelsCheck{}
+
+type HasNoProhibitedLabelsCheck struct{}
+
+func (p *HasNoProhibitedLabelsCheck) Validate(ctx context.Context, imgRef image.ImageReference) (result bool, err error) {
+	labels, err := getContainerLabels(imgRef.ImageInfo)
+	if err != nil {
+		return false, fmt.Errorf("could not retrieve image labels: %v", err)
+	}
+
+	return p.validate(ctx, labels)
+}
+
+func (p *HasNoProhibitedLabelsCheck) validate(ctx context.Context, labels map[string]string) (bool, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	trademarkViolationLabels := []string{}
+	for _, label := range trademarkLabels {
+		if violatesRedHatTrademark(labels[label]) {
+			trademarkViolationLabels = append(trademarkViolationLabels, label)
+		}
+	}
+
+	// TODO: We should be reporting this in the results, not in a log message
+	if len(trademarkViolationLabels) > 0 {
+		logger.V(log.DBG).Info("labels violate Red Hat trademark", "trademarkViolationLabels", trademarkViolationLabels)
+	}
+
+	return len(trademarkViolationLabels) == 0, nil
+}
+
+func (p *HasNoProhibitedLabelsCheck) Name() string {
+	return "HasNoProhibitedLabels"
+}
+
+func (p *HasNoProhibitedLabelsCheck) Metadata() check.Metadata {
+	return check.Metadata{
+		Description:      "Checking if the labels (name, vendor, maintainer) violate Red Hat trademark.",
+		Level:            "good",
+		KnowledgeBaseURL: certDocumentationURL,
+		CheckURL:         certDocumentationURL,
+	}
+}
+
+func (p *HasNoProhibitedLabelsCheck) Help() check.HelpText {
+	return check.HelpText{
+		Message:    "Check HasNoProhibitedLabelsCheck encountered an error. Please review the preflight.log file for more information.",
+		Suggestion: "Ensure the name, vendor, and maintainer label on your image do not violate the Red Hat trademark.",
+	}
+}

--- a/internal/policy/container/has_prohibited_labels_test.go
+++ b/internal/policy/container/has_prohibited_labels_test.go
@@ -1,0 +1,81 @@
+package container
+
+import (
+	"context"
+
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+)
+
+func getTrademarkLabels(bad bool) map[string]string {
+	labels := map[string]string{
+		"name":       "name",
+		"vendor":     "vendor",
+		"maintainer": "maintainer",
+	}
+
+	if bad {
+		labels["maintainer"] = "Red Hat"
+	}
+
+	return labels
+}
+
+func getProhibitedConfigFile() (*cranev1.ConfigFile, error) {
+	return &cranev1.ConfigFile{
+		Config: cranev1.Config{
+			Labels: getTrademarkLabels(false),
+		},
+	}, nil
+}
+
+func getBadProhibitedConfigFile() (*cranev1.ConfigFile, error) {
+	return &cranev1.ConfigFile{
+		Config: cranev1.Config{
+			Labels: getTrademarkLabels(true),
+		},
+	}, nil
+}
+
+var _ = Describe("HasNoProhibitedLabelsCheck", func() {
+	var (
+		hasProhibitedLabelsCheck HasNoProhibitedLabelsCheck
+		imageRef                 image.ImageReference
+	)
+
+	BeforeEach(func() {
+		fakeImage := fakecranev1.FakeImage{
+			ConfigFileStub: getProhibitedConfigFile,
+		}
+		imageRef.ImageInfo = &fakeImage
+	})
+
+	Describe("Checking for prohibited labels", func() {
+		Context("When it has no prohibited labels", func() {
+			It("should pass Validate", func() {
+				ok, err := hasProhibitedLabelsCheck.Validate(context.TODO(), imageRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		Context("When it has prohibited labels", func() {
+			BeforeEach(func() {
+				fakeImage := fakecranev1.FakeImage{
+					ConfigFileStub: getBadProhibitedConfigFile,
+				}
+				imageRef.ImageInfo = &fakeImage
+			})
+			It("should not pass Validate", func() {
+				ok, err := hasProhibitedLabelsCheck.Validate(context.TODO(), imageRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+
+	AssertMetaData(&hasProhibitedLabelsCheck)
+})

--- a/internal/policy/container/has_required_labels.go
+++ b/internal/policy/container/has_required_labels.go
@@ -9,12 +9,9 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 
 	"github.com/go-logr/logr"
-	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 var requiredLabels = []string{"name", "vendor", "version", "release", "summary", "description", "maintainer"}
-
-var trademarkLabels = []string{"name", "vendor", "maintainer"}
 
 var _ check.Check = &HasRequiredLabelsCheck{}
 
@@ -23,7 +20,7 @@ var _ check.Check = &HasRequiredLabelsCheck{}
 type HasRequiredLabelsCheck struct{}
 
 func (p *HasRequiredLabelsCheck) Validate(ctx context.Context, imgRef image.ImageReference) (bool, error) {
-	labels, err := p.getDataForValidate(imgRef.ImageInfo)
+	labels, err := getContainerLabels(imgRef.ImageInfo)
 	if err != nil {
 		return false, fmt.Errorf("could not retrieve image labels: %v", err)
 	}
@@ -31,20 +28,8 @@ func (p *HasRequiredLabelsCheck) Validate(ctx context.Context, imgRef image.Imag
 	return p.validate(ctx, labels)
 }
 
-func (p *HasRequiredLabelsCheck) getDataForValidate(image cranev1.Image) (map[string]string, error) {
-	configFile, err := image.ConfigFile()
-	return configFile.Config.Labels, err
-}
-
 func (p *HasRequiredLabelsCheck) validate(ctx context.Context, labels map[string]string) (bool, error) {
 	logger := logr.FromContextOrDiscard(ctx)
-
-	trademarkViolationLabels := []string{}
-	for _, label := range trademarkLabels {
-		if violatesRedHatTrademark(labels[label]) {
-			trademarkViolationLabels = append(trademarkViolationLabels, label)
-		}
-	}
 
 	missingLabels := []string{}
 	for _, label := range requiredLabels {
@@ -58,11 +43,7 @@ func (p *HasRequiredLabelsCheck) validate(ctx context.Context, labels map[string
 		logger.V(log.DBG).Info("expected labels are missing", "missingLabels", missingLabels)
 	}
 
-	if len(trademarkViolationLabels) > 0 {
-		logger.V(log.DBG).Info("labels violate Red Hat trademark", "trademarkViolationLabels", trademarkViolationLabels)
-	}
-
-	return len(missingLabels) == 0 && len(trademarkViolationLabels) == 0, nil
+	return len(missingLabels) == 0, nil
 }
 
 func (p *HasRequiredLabelsCheck) Name() string {
@@ -71,8 +52,7 @@ func (p *HasRequiredLabelsCheck) Name() string {
 
 func (p *HasRequiredLabelsCheck) Metadata() check.Metadata {
 	return check.Metadata{
-		Description: "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata " +
-			"and that they do not violate Red Hat trademark.",
+		Description:      "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata",
 		Level:            "good",
 		KnowledgeBaseURL: certDocumentationURL,
 		CheckURL:         certDocumentationURL,
@@ -81,8 +61,7 @@ func (p *HasRequiredLabelsCheck) Metadata() check.Metadata {
 
 func (p *HasRequiredLabelsCheck) Help() check.HelpText {
 	return check.HelpText{
-		Message: "Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
-		Suggestion: "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description, maintainer " +
-			"and validate that they do not violate Red Hat trademark.",
+		Message:    "Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
+		Suggestion: "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description, maintainer.",
 	}
 }

--- a/internal/policy/container/labels.go
+++ b/internal/policy/container/labels.go
@@ -1,0 +1,9 @@
+package container
+
+import cranev1 "github.com/google/go-containerregistry/pkg/v1"
+
+// getContainerLabels is a helper function to obtain the labels from an images configfile
+func getContainerLabels(image cranev1.Image) (map[string]string, error) {
+	configFile, err := image.ConfigFile()
+	return configFile.Config.Labels, err
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -8,4 +8,5 @@ const (
 	PolicyScratchNonRoot Policy = "scratch-nonroot"
 	PolicyScratchRoot    Policy = "scratch-root"
 	PolicyRoot           Policy = "root"
+	PolicyKonflux        Policy = "konflux"
 )

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Insecure               bool
 	Offline                bool
 	ManifestListDigest     string
+	Konflux                bool
 	// Operator-Specific Fields
 	Namespace           string
 	ServiceAccount      string
@@ -74,6 +75,7 @@ func (c *Config) storeContainerPolicyConfiguration(vcfg viper.Viper) {
 	c.Platform = vcfg.GetString("platform")
 	c.Insecure = vcfg.GetBool("insecure")
 	c.Offline = vcfg.GetBool("offline")
+	c.Konflux = vcfg.GetBool("konflux")
 }
 
 // storeOperatorPolicyConfiguration reads operator-policy-specific config

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -74,6 +74,6 @@ var _ = Describe("Viper to Runtime Config", func() {
 		// accurate in confirming that the derived configuration from viper
 		// matches.
 		keys := reflect.TypeOf(Config{}).NumField()
-		Expect(keys).To(Equal(26))
+		Expect(keys).To(Equal(27))
 	})
 })


### PR DESCRIPTION
## Motivation
Today, for konflux all policies are ran and since the introduction of the Red Hat trademark violation policies, we have been unable to ship a new image to be used in konflux. This means they are missing out on some bugfixes and performance enhancements.

## Changes
- ~~Introduce a new `konflux` sub command ie `preflight check konflux` . This cmd builds out the proper `Options` to be used in/by the engine.~~
- Add a new `PolicyKonflux` and corresponding container policy with matching tests.
- Revert `HasRequiredLabelsCheck` to only check for required labels.
- Add `HasProhibitedLabelsCheck` to check for Red Hat Trademark violations within a containers labels, and exclude this from the `PolicyKonflux`.
- Update `ResolveSubmitter` to also look for `konflux` flag so a `NoopSubmitter` is returned even if a user tried to provide a pyixs component/key and the `konflux` env.