### PR TITLE
fix: prevent sha based image urls

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -136,6 +136,9 @@ func checkContainerRunE(cmd *cobra.Command, args []string, runpreflight runPrefl
 	}
 
 	containerImage := args[0]
+	if strings.Contains(containerImage, "@sha256:") {
+		return fmt.Errorf("SHA-based references are not supported")
+	}
 
 	// Render the Viper configuration as a runtime.Config
 	cfg, err := runtime.NewConfigFrom(*viper.Instance())


### PR DESCRIPTION
sha-based image urls are not supported by pyxis. This will cause issues with the catalog and connect frontend.

Thread: https://redhat-internal.slack.com/archives/C04HSBW15T5/p1743155899936809

