### PR TITLE
Update `README` deprecated `certification-project-id` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To check a container, utilize the `check container` sub-command:
 ```text
 preflight check container quay.io/example-namespace/example-container:0.0.1 \
 --pyxis-api-token=abcdefghijklmnopqrstuvwxyz123456 \
---certification-project-id=1234567890a987654321bcde 
+--certification-component-id=1234567890a987654321bcde 
 ```
 
 To check an Operator bundle, utilize the `check Operator` sub-command:


### PR DESCRIPTION
When you run the example command specified in the documentation:
```
# preflight check container quay.io/example-namespace/example-container:0.0.1 \
> --pyxis-api-token=abcdefghijklmnopqrstuvwxyz123456 \
> --certification-project-id=1234567890a987654321bcde 
Flag --certification-project-id has been deprecated, please use --certification-component-id instead
```

The option was renamed in https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1222.