### PR TITLE
Update lint to use golangci-lint v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,59 +1,79 @@
+version: "2"
 run:
-  # Default timeout is 1m, up to give more room
+  # Default timeout is 0 (no limit), have an upper limit
   timeout: 4m
-
-linters:
-  enable:
-  - asciicheck
-  - unused
-  - depguard
-  - gofumpt
-  - goimports
-  - importas
-  - revive
-  - misspell
-  - stylecheck
-  - tparallel
-  - unconvert
-  - unparam
-  - whitespace
-
-linters-settings:
-  importas:
-    alias:
-    - pkg: k8s.io/api/core/v1
-      alias: corev1
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/apimachinery/pkg/api/errors
-      alias: apierrors
-    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
-      alias: operatorsv1alpha1
-    - pkg: github.com/operator-framework/api/pkg/operators/v1
-      alias: operatorsv1
-    - pkg: github.com/openshift/api/image/v1
-      alias: imagestreamv1
-  revive:
-    rules:
-    - name: dot-imports
-      severity: warning
-      disabled: true
-  stylecheck:
-    dot-import-whitelist:
-      - github.com/onsi/gomega
-      - github.com/onsi/ginkgo
-      - github.com/onsi/ginkgo/v2
-  goimports:
-    local-prefixes: github.com/redhat-openshift-ecosystem/openshift-preflight
-  depguard:
-    rules:
-      main:
-        list-mode: lax
-        files:
-          - !$test
-        allow:
-          - $gostd
-
 output:
   formats:
-    - format: tab
+    tab:
+      path: stdout
+      colors: false
+linters:
+  enable:
+    - asciicheck
+    - depguard
+    - importas
+    - misspell
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          files:
+            - ""
+          allow:
+            - $gostd
+    importas:
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+          alias: operatorsv1alpha1
+        - pkg: github.com/operator-framework/api/pkg/operators/v1
+          alias: operatorsv1
+        - pkg: github.com/openshift/api/image/v1
+          alias: imagestreamv1
+    revive:
+      rules:
+        - name: dot-imports
+          severity: warning
+          disabled: true
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo
+        - github.com/onsi/ginkgo/v2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/redhat-openshift-ecosystem/openshift-preflight
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ clean:
 	$(shell if [ -f "$(BINARY)-$(GOOS)-$(GOARCH)" ]; then rm -f $(BINARY)-$(GOOS)-$(GOARCH); fi)))
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.62.2
+GOLANGCI_LINT_VERSION ?= v2.1.6
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 GOFUMPT = $(shell pwd)/bin/gofumpt
 gofumpt: ## Download envtest-setup locally if necessary.

--- a/internal/formatters/formatters_test.go
+++ b/internal/formatters/formatters_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Formatters", func() {
 	Describe("When creating a new generic formatter", func() {
 		Context("with improper arguments", func() {
 			expectedResult := []byte(fmt.Errorf("failed to create a new generic formatter: formatter name is required").Error())
-			var fn formatters.FormatterFunc //nolint:gosimple // We want to be explicit here for clarity
+			var fn formatters.FormatterFunc //nolint:staticcheck // We want to be explicit here for clarity
 			fn = func(context.Context, certification.Results) ([]byte, error) {
 				return expectedResult, nil
 			}
@@ -65,7 +65,7 @@ var _ = Describe("Formatters", func() {
 			expectedResult := []byte("this is a test")
 			name := "testFormatter"
 			extension := "txt"
-			var fn formatters.FormatterFunc //nolint:gosimple // We want to be explicit here for clarity
+			var fn formatters.FormatterFunc //nolint:staticcheck // We want to be explicit here for clarity
 			fn = func(context.Context, certification.Results) ([]byte, error) {
 				return expectedResult, nil
 			}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -36,11 +36,11 @@ func (s bufferSink) Enabled(level int) bool {
 }
 
 func (s bufferSink) Error(err error, msg string, keysAndValues ...interface{}) {
-	s.buffer.WriteString(fmt.Sprintf("%s %v %s %v\n", s.name, err.Error(), msg, keysAndValues))
+	fmt.Fprintf(s.buffer, "%s %v %s %v\n", s.name, err.Error(), msg, keysAndValues)
 }
 
 func (s bufferSink) Info(level int, msg string, keysAndValues ...interface{}) {
-	s.buffer.WriteString(fmt.Sprintf("%s %s %v\n", s.name, msg, keysAndValues))
+	fmt.Fprintf(s.buffer, "%s %s %v\n", s.name, msg, keysAndValues)
 }
 
 func (s bufferSink) Init(info logr.RuntimeInfo) {}

--- a/internal/policy/operator/required_annotations.go
+++ b/internal/policy/operator/required_annotations.go
@@ -62,6 +62,7 @@ func (h RequiredAnnotations) validate(ctx context.Context, bundledir string) (bo
 			continue
 		}
 		// the only string values allowed are lower case 'true' or 'false'
+		// nolint:staticcheck // the conditional is more readable with negation on the outside
 		if !(value == "true" || value == "false") {
 			incorrectValues[annotation] = value
 		}

--- a/internal/policy/operator/restricted_network_aware.go
+++ b/internal/policy/operator/restricted_network_aware.go
@@ -37,7 +37,10 @@ func (p FollowsRestrictedNetworkEnablementGuidelines) validate(ctx context.Conte
 		return false, err
 	}
 
+	// in this case, it is more readable to declare the variable first and have subsequent conditional assignments
+	// nolint:staticcheck
 	restrictedNetworkSupport := false
+
 	// If the CSV does not claim to support disconnected environments, there's no reason to check that it followed guidelines.
 	if libcsv.HasDisconnectedAnnotation(csv) && libcsv.SupportsDisconnected(csv.Annotations[libcsv.DisconnectedAnnotation]) {
 		restrictedNetworkSupport = true

--- a/internal/pyxis/builder_test.go
+++ b/internal/pyxis/builder_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Pyxis Builder tests", func() {
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(input.TestResults.ID).To(Equal(results.ID))
-				Expect(input.TestResults.UserResponse.Image).To(Equal(results.UserResponse.Image))
+				Expect(input.TestResults.Image).To(Equal(results.Image))
 			})
 
 			It("should not bind an invalid preflight results from file", func() {


### PR DESCRIPTION
- Update `Makefile` to get and use golangci-lint v2
- Update `.golangci-lint.yaml` file to match v2 config file format
- Update `nolint:gosimple` comments to `nolint:staticcheck` comments 
- Address/ignore some findings raised by `staticcheck`

Configuration file migration was performed using the [`golangci-lint migrate` command](https://golangci-lint.run/product/migration-guide/).