### PR TITLE
Hoist regexp compilation out of loops

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -628,19 +628,21 @@ func writeRPMManifest(ctx context.Context, containerFSPath string) error {
 
 	// covert rpm struct to pxyis struct
 	rpms := make([]pyxis.RPM, 0, len(pkgList))
+	rpmSuffixRegexp := regexp.MustCompile("(-[0-9].*)")
+	pgpKeyIdRegexp := regexp.MustCompile(".*, Key ID (.*)")
 	for _, packageInfo := range pkgList {
 		var bgName, endChop, srpmNevra, pgpKeyID string
 
 		// accounting for the fact that not all packages have a source rpm
 		if len(packageInfo.SourceRpm) > 0 {
 			bgName = getBgName(packageInfo.SourceRpm)
-			endChop = strings.TrimPrefix(strings.TrimSuffix(regexp.MustCompile("(-[0-9].*)").FindString(packageInfo.SourceRpm), ".rpm"), "-")
+			endChop = strings.TrimPrefix(strings.TrimSuffix(rpmSuffixRegexp.FindString(packageInfo.SourceRpm), ".rpm"), "-")
 
 			srpmNevra = fmt.Sprintf("%s-%d:%s", bgName, packageInfo.Epoch, endChop)
 		}
 
 		if len(packageInfo.PGP) > 0 {
-			matches := regexp.MustCompile(".*, Key ID (.*)").FindStringSubmatch(packageInfo.PGP)
+			matches := pgpKeyIdRegexp.FindStringSubmatch(packageInfo.PGP)
 			if matches != nil {
 				pgpKeyID = matches[1]
 			} else {

--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -84,9 +84,9 @@ func (p *HasModifiedFilesCheck) parsePackageDist(_ context.Context, extractedIma
 	defer osRelease.Close()
 	scanner := bufio.NewScanner(osRelease)
 	packageDist := "unknown"
+	r := regexp.MustCompile(`PLATFORM_ID="platform:([[:alnum:]]+)"`)
 	for scanner.Scan() {
 		line := scanner.Text()
-		r, _ := regexp.Compile(`PLATFORM_ID="platform:([[:alnum:]]+)"`)
 		m := r.FindStringSubmatch(line)
 		if m == nil {
 			continue


### PR DESCRIPTION
Where possible, avoid needless re-compilation of const regexps by moving them out of loops.