### PR TITLE
move to go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-FROM docker.io/golang:1.23 AS builder
+FROM docker.io/golang:1.24 AS builder
 ARG quay_expiration
 ARG release_tag
 ARG ARCH

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,9 +23,9 @@ Vagrant.configure("2") do |config|
     containers-common \
     openscap-containers
 
-    curl -L https://go.dev/dl/go1.23.2.linux-amd64.tar.gz --output go1.23.2.linux-amd64.tar.gz
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
-    rm go1.23.2.linux-amd64.tar.gz
+    curl -L https://go.dev/dl/go1.24.1.linux-amd64.tar.gz --output go1.24.1.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.1.linux-amd64.tar.gz
+    rm go1.24.1.linux-amd64.tar.gz
 
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz --output oc.tar.gz
     tar -C /usr/local/bin -xzf oc.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-openshift-ecosystem/openshift-preflight
 
-go 1.23.2
+go 1.24.1
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
- Moving to the highest version of go 1.24 that our CI supports