### PR TITLE
Add test cases to improve test coverage

### DIFF
--- a/artifacts/filesystem_writer_test.go
+++ b/artifacts/filesystem_writer_test.go
@@ -45,6 +45,17 @@ var _ = Describe("Filesystem Artifact Writer", func() {
 			readin, err := os.ReadFile(fullpath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(readin).To(Equal(contents))
+
+			exist, err := aw.Exists(filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exist).To(BeTrue())
+
+			err = aw.Remove(filename)
+			Expect(err).ToNot(HaveOccurred())
+
+			exist, err = aw.Exists(filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exist).To(BeFalse())
 		})
 	})
 })

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -444,6 +444,50 @@ var _ = Describe("Check Container Command", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("when PFLT_CPUPROFILE env is set", func() {
+		var f *os.File
+		var err error
+		BeforeEach(func() {
+			viper.Reset()
+			initConfig(viper.Instance())
+			f, err = os.CreateTemp("", "preflight-cpuprofile-")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(f.Name())
+			os.Setenv("PFLT_CPUPROFILE", f.Name())
+			DeferCleanup(os.Unsetenv, "PFLT_CPUPROFILE")
+		})
+		It("should generate a CPU profile", func() {
+			_, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnNil), logr.Discard(), src)
+			Expect(err).ToNot(HaveOccurred())
+
+			info, err := os.Stat(f.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Size()).ToNot(BeZero())
+		})
+	})
+
+	Context("when PFLT_MEMPROFILE env is set", func() {
+		var f *os.File
+		var err error
+		BeforeEach(func() {
+			viper.Reset()
+			initConfig(viper.Instance())
+			f, err = os.CreateTemp("", "preflight-memprofile-")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(f.Name())
+			os.Setenv("PFLT_MEMPROFILE", f.Name())
+			DeferCleanup(os.Unsetenv, "PFLT_MEMPROFILE")
+		})
+		It("should generate a memory profile", func() {
+			_, err := executeCommandWithLogger(checkContainerCmd(mockRunPreflightReturnNil), logr.Discard(), src)
+			Expect(err).ToNot(HaveOccurred())
+
+			info, err := os.Stat(f.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(info.Size()).ToNot(BeZero())
+		})
+	})
 })
 
 func mockRunPreflightReturnNil(context.Context, func(ctx context.Context) (certification.Results, error), cli.CheckConfig, formatters.ResponseFormatter, lib.ResultWriter, lib.ResultSubmitter) error {


### PR DESCRIPTION
~~This change also sets the test image `src` in `cmd/preflight/cmd/check_container_test.go` to have architecture `runtime.GOOS` instead of hardcoded to `amd64`. Tests which use this image expect the image to be the same architecture as the machine where tests are running (usually amd64 in CI, but could be arm64 if running tests locally).~~

Some test fixtures are only available for amd64, so leaving it as-is.