### PR TITLE
Add -trimpath flag and -s -w ldflags on builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ARCHITECTURES_MAC=amd64 arm64
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -o $(BINARY) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
+	CGO_ENABLED=0 go build -o $(BINARY) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 	@ls | grep -e '^preflight$$' &> /dev/null
 
 .PHONY: build-multi-arch-linux
@@ -21,7 +21,7 @@ build-multi-arch-linux: $(addprefix build-linux-,$(ARCHITECTURES_LINUX))
 define LINUX_ARCHITECTURE_template
 .PHONY: build-linux-$(1)
 build-linux-$(1):
-	GOOS=linux GOARCH=$(1) CGO_ENABLED=0 go build -o $(BINARY)-linux-$(1) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
+	GOOS=linux GOARCH=$(1) CGO_ENABLED=0 go build -o $(BINARY)-linux-$(1) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
 				-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 endef
 
@@ -33,7 +33,7 @@ build-multi-arch-mac: $(addprefix build-mac-,$(ARCHITECTURES_MAC))
 define MAC_ARCHITECTURE_template
 .PHONY: build-mac-$(1)
 build-mac-$(1):
-	GOOS=darwin GOARCH=$(1) go build -o $(BINARY)-darwin-$(1) -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
+	GOOS=darwin GOARCH=$(1) go build -o $(BINARY)-darwin-$(1) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
 				-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 endef
 
@@ -60,12 +60,12 @@ image-push:
 .PHONY: test
 test:
 	go test -v $$(go list ./... | grep -v e2e) \
-	-ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo"
+	-trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo"
 
 .PHONY: cover
 cover:
 	go test -v \
-	 -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo" \
+	 -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo" \
 	 $$(go list ./... | grep -v e2e) \
 	 -race \
 	 -cover -coverprofile=coverage.out


### PR DESCRIPTION
This change adds `-trimpath` build flag and `-s` and `-w` linker flags in all `go build`/`go test` invocations.

```
	-trimpath
		remove all file system paths from the resulting executable.
		Instead of absolute file system paths, the recorded file names
		will begin either a module path@version (when using modules),
		or a plain import path (when using the standard library, or GOPATH).
```

```
  -s	disable symbol table
```

```
  -w	disable DWARF generation
```

The goals of this change are to:
- Avoid exposing info about the build environment in the resulting binaries (all paths recorded/embedded in resulting binaries become module-relative, rather than absolute paths)
- Reduce the binary size

The removal of the symbol table and DWARF debug information may impact the ability to debug these binaries in a debugger e.g. `dlv`, but from prior discussion it sounds like this is not currently a concern.

Binary size difference when built locally on `darwin/arm64`:
| File | Before | After |
| --- | --- | --- |
| preflight-darwin-amd64 | 83 MiB | 58 MiB |
| preflight-darwin-arm64 | 88 MiB | 55 MiB |
| preflight-linux-amd64 | 83 MiB | 57 MiB |
| preflight-linux-arm64 | 80 MiB | 54 MiB |
| preflight-linux-ppc64le | 82 MiB | 56 MiB |
| preflight-linux-s390x | 87 MiB | 62 MiB |