### PR TITLE
Use skopeo already present in VM for mirroring images to RHISV

### DIFF
--- a/.github/workflows/copy-to-rhisv.yml
+++ b/.github/workflows/copy-to-rhisv.yml
@@ -27,17 +27,6 @@ jobs:
     name: Mirror Images
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.19
-
-    - name: Install Skopeo
-      run: |
-        sudo apt-get update && sudo apt-get install libgpgme-dev libdevmapper-dev libbtrfs-dev -y
-        go install github.com/containers/skopeo/cmd/skopeo@v1.7.0
-        skopeo -v
-
     - name: Podman Login
       uses: redhat-actions/podman-login@v1
       with:


### PR DESCRIPTION
As pointed out in [runner documentation](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), skopeo is already provided inside the VM in which GitHub Actions are executed.