### PR TITLE
adding maintainer label to test docker files

### DIFF
--- a/test/containerfiles/container-passes-multiple-arch-rpm.Dockerfile
+++ b/test/containerfiles/container-passes-multiple-arch-rpm.Dockerfile
@@ -6,6 +6,7 @@ COPY --chown=preflightuser:preflightuser example-license.txt /licenses/
 
 LABEL name="preflight test image container-policy" \
       vendor="preflight test vendor" \
+      maintainer="preflight test maintainer" \
       version="1" \
       release="1" \
       summary="testing the preflight tool" \

--- a/test/containerfiles/container-passes.Dockerfile
+++ b/test/containerfiles/container-passes.Dockerfile
@@ -6,6 +6,7 @@ COPY --chown=preflightuser:preflightuser example-license.txt /licenses/
 
 LABEL name="preflight test image container-policy" \
       vendor="preflight test vendor" \
+      maintainer="preflight test maintainer" \
       version="1" \
       release="1" \
       summary="testing the preflight tool" \


### PR DESCRIPTION
- Adding `maintainer` label so that developers that build with these files for their own testing, can pass preflights checks.