### PR TITLE
fix(workflows): Check out PR merge ref in code review

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Gemini AI Code Review


### PR DESCRIPTION
The code review workflow was failing on pull requests from forks because it was not checking out the correct ref. This change modifies the checkout step to fetch the PR's merge ref, which will allow the workflow to access the PR's code.


Assisted-by: Gemini