### PR TITLE
update release to run mac binary release to be parallel

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -57,10 +57,13 @@ jobs:
         tag: ${{ inputs.tag }}
         GH_TOKEN: ${{ secrets.token }}
 
-  # an ugly workaround to build binaries for mac.  builds locally and pushes to the release.
+  # builds mac binaries in parallel using matrix strategy
   add-darwin-bins:
     name: Release binaries for MacOS
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
       - name: Set Env Tags
@@ -72,12 +75,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Build Multi-arch-mac
-        run: make build-multi-arch-mac
+      - name: Build Mac binary for ${{ matrix.architecture }}
+        run: make build-mac-${{ matrix.architecture }}
 
-      - name: Upload binaries to the release
+      - name: Upload binary to the release
         run:
-          gh release upload --repo "${GITHUB_REPOSITORY}" "${tag}" preflight-darwin-*
+          gh release upload --repo "${GITHUB_REPOSITORY}" "${tag}" preflight-darwin-${{ matrix.architecture }}
         env:
           tag: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
## Motivation
- Fixes: #1295 

## Testing
The below release in my fork shows this running in parallel.
- [Action](https://github.com/acornett21/openshift-preflight/actions/runs/16921199869)
- [Release](https://github.com/acornett21/openshift-preflight/releases/tag/0.0.40)