### PR TITLE
fix gofumpt issue and pinning version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,9 @@ $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 GOFUMPT = $(shell pwd)/bin/gofumpt
+GOFUMPT_VERSION ?= v0.9.0
 gofumpt: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(GOFUMPT),mvdan.cc/gofumpt@latest)
+	$(call go-install-tool,$(GOFUMPT),mvdan.cc/gofumpt@$(GOFUMPT_VERSION))
 
 COSIGN = $(shell pwd)/bin/cosign
 COSIGN_VERSION ?= v2.0.0

--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -359,7 +359,7 @@ func findRPMDB(ctx context.Context, layer v1.Layer) (found bool, pkglist []*rpmd
 		id, _ := layer.Digest()
 		logger.V(log.TRC).Info("findRPMDB found an RPM db", "layer", id.String())
 		found = true
-		return
+		return found, pkglist
 	}
 
 	return found, pkglist


### PR DESCRIPTION
## Motivation
Our main build started to fail, due to a change in gofumpt. 
- https://github.com/redhat-openshift-ecosystem/openshift-preflight/actions/runs/17495866311/job/49696413398

## Changes
- Fix the issue
- Pin the version so we know that when PR jobs pass, main will also pass.