### PR TITLE
Add new flag to use non-zero exit code when checks fail

### DIFF
--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -45,6 +45,9 @@ func rootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().String("loglevel", "", "The verbosity of the preflight tool itself. Ex. warn, debug, trace, info, error. (env: PFLT_LOGLEVEL)")
 	_ = viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel"))
 
+	rootCmd.PersistentFlags().Bool("exit-with-failure", false, "Exit with a non-zero exit code if any checks do not pass. (env: PFLT_EXIT_WITH_FAILURE)")
+	_ = viper.BindPFlag("exit_with_failure", rootCmd.PersistentFlags().Lookup("exit-with-failure"))
+
 	rootCmd.AddCommand(checkCmd())
 	rootCmd.AddCommand(listChecksCmd())
 	rootCmd.AddCommand(runtimeAssetsCmd())

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 
 	"github.com/go-logr/logr"
 )
@@ -83,6 +84,10 @@ func RunPreflight(
 	}
 
 	logger.Info(fmt.Sprintf("Preflight result: %s", convertPassedOverall(results.PassedOverall)))
+
+	if !results.PassedOverall && viper.Instance().GetBool("exit_with_failure") {
+		return fmt.Errorf("one or more checks did not pass")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Open to feedback on how to structure/propagate the boolean flag. This approach introduces dependency on `viper` in `cli`; alternatively, we could add the flag into the `CheckConfig` struct (but this would require changing how `CheckConfig` structs are initialized/created in several places). Similarly, the flag could also be added as an additional parameter in `RunPreflight`, but this would require changing places which expect the existing function signature.