### PR TITLE
removing the deprecated certification-project-id flag

### DIFF
--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -168,14 +168,8 @@ var _ = Describe("Check Container Command", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(out).To(ContainSubstring(errString))
 			},
-			Entry("certification-project-id or certification-component-id and pyxis-api-token are not supplied", "certification component ID must be specified when --submit is present", []string{"--submit", "foo"}),
-			Entry("certification-project-id is supplied and pyxis-api-token is not supplied", "pyxis API Token must be specified when --submit is present", []string{"foo", "--submit", "--certification-project-id=fooid"}),
-			Entry("certification-project-id or certification-component-id is not supplied", "certification component ID must be specified when --submit is present", []string{"--submit", "foo", "--pyxis-api-token=footoken"}),
-			Entry("certification-project-id and pyxis-api-token flag is present but empty because of '='", "cannot be empty when --submit is present", []string{"foo", "--submit", "--certification-project-id=fooid", "--pyxis-api-token="}),
-			Entry("certification-project-id flag is present but empty because of '='", "cannot be empty when --submit is present", []string{"foo", "--submit", "--certification-project-id=", "--pyxis-api-token=footoken"}),
-			Entry("submit is passed after empty api token with certification-project-id", "pyxis API token and certification component ID are required when --submit is present", []string{"foo", "--certification-project-id=fooid", "--pyxis-api-token", "--submit"}),
-			Entry("certification-project-id and submit is passed with explicit value after empty api token", "pyxis API token and certification component ID are required when --submit is present", []string{"foo", "--certification-project-id=fooid", "--pyxis-api-token", "--submit=true"}),
-			Entry("certification-project-id and submit is passed and insecure is specified", "if any flags in the group [submit insecure] are set", []string{"foo", "--submit", "--insecure", "--certification-project-id=fooid", "--pyxis-api-token=footoken"}),
+			Entry("certification-component-id and pyxis-api-token are not supplied", "certification component ID must be specified when --submit is present", []string{"--submit", "foo"}),
+			Entry("certification-component-id is not supplied", "certification component ID must be specified when --submit is present", []string{"--submit", "foo", "--pyxis-api-token=footoken"}),
 			Entry("certification-component-id is supplied and pyxis-api-token is not supplied", "pyxis API Token must be specified when --submit is present", []string{"foo", "--submit", "--certification-component-id=fooid"}),
 			Entry("certification-component-id and pyxis-api-token flag is present but empty because of '='", "cannot be empty when --submit is present", []string{"foo", "--submit", "--certification-component-id=fooid", "--pyxis-api-token="}),
 			Entry("certification-component-id flag is present but empty because of '='", "cannot be empty when --submit is present", []string{"foo", "--submit", "--certification-component-id=", "--pyxis-api-token=footoken"}),
@@ -200,44 +194,10 @@ var _ = Describe("Check Container Command", func() {
 					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(viper.Instance().GetString("pyxis_api_token")).To(Equal("tokenid"))
-					Expect(viper.Instance().GetString("certification_project_id")).To(Equal("certcompenvid"))
-				})
-			})
-			When("old environment variable is used for certification ID", func() {
-				BeforeEach(func() {
-					viper.Reset()
-					initConfig(viper.Instance())
-					os.Setenv("PFLT_CERTIFICATION_PROJECT_ID", "certprojenvid")
-					os.Setenv("PFLT_PYXIS_API_TOKEN", "tokenid")
-					DeferCleanup(os.Unsetenv, "PFLT_CERTIFICATION_PROJECT_ID")
-					DeferCleanup(os.Unsetenv, "PFLT_PYXIS_API_TOKEN")
-				})
-				It("should still execute with no error", func() {
-					submit = true
-
-					err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(viper.Instance().GetString("pyxis_api_token")).To(Equal("tokenid"))
-					Expect(viper.Instance().GetString("certification_project_id")).To(Equal("certprojenvid"))
+					Expect(viper.Instance().GetString("certification_component_id")).To(Equal("certcompenvid"))
 				})
 			})
 			When("a config file is used", func() {
-				When("the deprecated certification_project_id config file is used", func() {
-					JustBeforeEach(func() {
-						viper.Reset()
-						viper.Instance().AddConfigPath("testdata/project/")
-					})
-					It("should still execute with no error", func() {
-						// Make sure that we've read the config file
-						initConfig(viper.Instance())
-						submit = true
-
-						err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
-						Expect(err).ToNot(HaveOccurred())
-						Expect(viper.Instance().GetString("pyxis_api_token")).To(Equal("mytoken"))
-						Expect(viper.Instance().GetString("certification_project_id")).To(Equal("myprojectid"))
-					})
-				})
 				When("certification_component_id config file is used", func() {
 					JustBeforeEach(func() {
 						viper.Reset()
@@ -251,7 +211,7 @@ var _ = Describe("Check Container Command", func() {
 						err := checkContainerPositionalArgs(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 						Expect(err).ToNot(HaveOccurred())
 						Expect(viper.Instance().GetString("pyxis_api_token")).To(Equal("mytoken"))
-						Expect(viper.Instance().GetString("certification_project_id")).To(Equal("mycomponentcertid"))
+						Expect(viper.Instance().GetString("certification_component_id")).To(Equal("mycomponentcertid"))
 					})
 				})
 			})
@@ -261,43 +221,43 @@ var _ = Describe("Check Container Command", func() {
 	Context("When validating the certification-component-id flag", func() {
 		Context("and the flag is set properly", func() {
 			BeforeEach(func() {
-				viper.Instance().Set("certification_project_id", "123456789")
-				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
+				viper.Instance().Set("certification_component_id", "123456789")
+				DeferCleanup(viper.Instance().Set, "certification_component_id", "")
 			})
 			It("should not change the flag value", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
+				err := validateCertificationComponentID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(viper.Instance().GetString("certification_project_id")).To(Equal("123456789"))
+				Expect(viper.Instance().GetString("certification_component_id")).To(Equal("123456789"))
 			})
 		})
 		Context("and a valid ospid format is provided", func() {
 			BeforeEach(func() {
-				viper.Instance().Set("certification_project_id", "ospid-123456789")
-				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
+				viper.Instance().Set("certification_component_id", "ospid-123456789")
+				DeferCleanup(viper.Instance().Set, "certification_component_id", "")
 			})
 			It("should strip ospid- from the flag value", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
+				err := validateCertificationComponentID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(viper.Instance().GetString("certification_project_id")).To(Equal("123456789"))
+				Expect(viper.Instance().GetString("certification_component_id")).To(Equal("123456789"))
 			})
 		})
 		Context("and a legacy format with ospid is provided", func() {
 			BeforeEach(func() {
-				viper.Instance().Set("certification_project_id", "ospid-62423-f26c346-6cc1dc7fae92")
-				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
+				viper.Instance().Set("certification_component_id", "ospid-62423-f26c346-6cc1dc7fae92")
+				DeferCleanup(viper.Instance().Set, "certification_component_id", "")
 			})
 			It("should throw an error", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
+				err := validateCertificationComponentID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).To(HaveOccurred())
 			})
 		})
 		Context("and a legacy format without ospid is provided", func() {
 			BeforeEach(func() {
-				viper.Instance().Set("certification_project_id", "62423-f26c346-6cc1dc7fae92")
-				DeferCleanup(viper.Instance().Set, "certification_project_id", "")
+				viper.Instance().Set("certification_component_id", "62423-f26c346-6cc1dc7fae92")
+				DeferCleanup(viper.Instance().Set, "certification_component_id", "")
 			})
 			It("should throw an error", func() {
-				err := validateCertificationProjectID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
+				err := validateCertificationComponentID(checkContainerCmd(mockRunPreflightReturnNil), []string{"foo"})
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/cmd/preflight/cmd/testdata/project/config.yaml
+++ b/cmd/preflight/cmd/testdata/project/config.yaml
@@ -1,2 +1,0 @@
-pyxis_api_token: mytoken
-certification_project_id: myprojectid

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,9 +35,9 @@ For information on how to build an index image, see [BUILDING_AN_INDEX.md](BUILD
 These configurables are specific to cases where `preflight check container ...`
 is called.
 
-|Variable|Kind|Doc|Required or Optional|Default|
-|--|--|--|--|--|
-|`PFLT_PYXIS_HOST`|env|The Pyxis host to connect to. Must contain any additional path information leading up to the API version|optional|catalog.redhat.com/api/containers|
-|`PFLT_PYXIS_API_TOKEN`|env|The API Token to be used when connecting to Pyxis. Used for authenticated calls only.|optional?|-|
-|`PFLT_CERTIFICATION_PROJECT_ID`|env|Certification Project ID from connect.redhat.com. Should be supplied without the ospid- prefix.|optional?|-|
-|`PFLT_DOCKERCONFIG`|env|The full path to a dockerconfigjson file, that has access to the container under test.|required|-|
+| Variable                       |Kind| Doc                                                                                                      |Required or Optional|Default|
+|--------------------------------|--|----------------------------------------------------------------------------------------------------------|--|--|
+| `PFLT_PYXIS_HOST`              |env| The Pyxis host to connect to. Must contain any additional path information leading up to the API version |optional|catalog.redhat.com/api/containers|
+| `PFLT_PYXIS_API_TOKEN`         |env| The API Token to be used when connecting to Pyxis. Used for authenticated calls only.                    |optional?|-|
+| `PFLT_CERTIFICATION_COMPONENT_ID` |env| Certification Component ID from connect.redhat.com. Should be supplied without the ospid- prefix.        |optional?|-|
+| `PFLT_DOCKERCONFIG`            |env| The full path to a dockerconfigjson file, that has access to the container under test.                   |required|-|

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,7 @@ type commonConfig interface {
 // container certification.
 type containerConfig interface {
 	IsScratch() bool
-	CertificationProjectID() string
+	CertificationComponentID() string
 	PyxisHost() string
 	PyxisAPIToken() string
 	Submit() bool

--- a/internal/lib/types.go
+++ b/internal/lib/types.go
@@ -40,7 +40,7 @@ type PyxisClient interface {
 }
 
 // NewPyxisClient initializes a pyxisClient with relevant information from cfg.
-// If the the CertificationProjectID, PyxisAPIToken, or PyxisHost are empty, then nil is returned.
+// If the the CertificationComponentID, PyxisAPIToken, or PyxisHost are empty, then nil is returned.
 // Callers should treat a nil pyxis client as an indicator that pyxis calls should not be made.
 func NewPyxisClient(ctx context.Context, projectID, token, host string) PyxisClient {
 	if projectID == "" || token == "" || host == "" {

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -21,16 +21,16 @@ type Config struct {
 	Artifacts      string
 	WriteJUnit     bool
 	// Container-Specific Fields
-	CertificationProjectID string
-	PyxisHost              string
-	PyxisAPIToken          string
-	DockerConfig           string
-	Submit                 bool
-	Platform               string
-	Insecure               bool
-	Offline                bool
-	ManifestListDigest     string
-	Konflux                bool
+	CertificationComponentID string
+	PyxisHost                string
+	PyxisAPIToken            string
+	DockerConfig             string
+	Submit                   bool
+	Platform                 string
+	Insecure                 bool
+	Offline                  bool
+	ManifestListDigest       string
+	Konflux                  bool
 	// Operator-Specific Fields
 	Namespace           string
 	ServiceAccount      string
@@ -71,7 +71,7 @@ func (c *Config) storeContainerPolicyConfiguration(vcfg viper.Viper) {
 	c.PyxisAPIToken = vcfg.GetString("pyxis_api_token")
 	c.Submit = vcfg.GetBool("submit")
 	c.PyxisHost = PyxisHostLookup(vcfg.GetString("pyxis_env"), vcfg.GetString("pyxis_host"))
-	c.CertificationProjectID = vcfg.GetString("certification_project_id")
+	c.CertificationComponentID = vcfg.GetString("certification_component_id")
 	c.Platform = vcfg.GetString("platform")
 	c.Insecure = vcfg.GetBool("insecure")
 	c.Offline = vcfg.GetBool("offline")

--- a/internal/runtime/config_read.go
+++ b/internal/runtime/config_read.go
@@ -40,8 +40,8 @@ func (ro *ReadOnlyConfig) LogFile() string {
 	return ro.cfg.LogFile
 }
 
-func (ro *ReadOnlyConfig) CertificationProjectID() string {
-	return ro.cfg.CertificationProjectID
+func (ro *ReadOnlyConfig) CertificationComponentID() string {
+	return ro.cfg.CertificationComponentID
 }
 
 func (ro *ReadOnlyConfig) PyxisHost() string {

--- a/internal/runtime/config_read_test.go
+++ b/internal/runtime/config_read_test.go
@@ -10,29 +10,29 @@ import (
 var _ = Describe("Runtime ReadOnlyConfig test", func() {
 	Context("When calling ReadOnly on a config", func() {
 		c := &Config{
-			Image:                  "image",
-			Policy:                 "policy",
-			ResponseFormat:         "format",
-			Bundle:                 true,
-			Scratch:                true,
-			LogFile:                "logfile",
-			Artifacts:              "artifacts",
-			WriteJUnit:             true,
-			CertificationProjectID: "certprojid",
-			PyxisHost:              "pyxishost",
-			PyxisAPIToken:          "pyxisapitoken",
-			DockerConfig:           "dockercfg",
-			Submit:                 true,
-			Platform:               "s390x",
-			Insecure:               true,
-			Namespace:              "ns",
-			ServiceAccount:         "sa",
-			ScorecardImage:         "scorecardimg",
-			ScorecardWaitTime:      "waittime",
-			Channel:                "channel",
-			IndexImage:             "indeximg",
-			Kubeconfig:             "kubeconfig",
-			CSVTimeout:             180 * time.Second,
+			Image:                    "image",
+			Policy:                   "policy",
+			ResponseFormat:           "format",
+			Bundle:                   true,
+			Scratch:                  true,
+			LogFile:                  "logfile",
+			Artifacts:                "artifacts",
+			WriteJUnit:               true,
+			CertificationComponentID: "certprojid",
+			PyxisHost:                "pyxishost",
+			PyxisAPIToken:            "pyxisapitoken",
+			DockerConfig:             "dockercfg",
+			Submit:                   true,
+			Platform:                 "s390x",
+			Insecure:                 true,
+			Namespace:                "ns",
+			ServiceAccount:           "sa",
+			ScorecardImage:           "scorecardimg",
+			ScorecardWaitTime:        "waittime",
+			Channel:                  "channel",
+			IndexImage:               "indeximg",
+			Kubeconfig:               "kubeconfig",
+			CSVTimeout:               180 * time.Second,
 		}
 		cro := c.ReadOnly()
 		It("should return values assigned to corresponding struct fields", func() {
@@ -44,7 +44,7 @@ var _ = Describe("Runtime ReadOnlyConfig test", func() {
 			Expect(cro.LogFile()).To(Equal("logfile"))
 			Expect(cro.Artifacts()).To(Equal("artifacts"))
 			Expect(cro.WriteJUnit()).To(Equal(true))
-			Expect(cro.CertificationProjectID()).To(Equal("certprojid"))
+			Expect(cro.CertificationComponentID()).To(Equal("certprojid"))
 			Expect(cro.PyxisHost()).To(Equal("pyxishost"))
 			Expect(cro.PyxisAPIToken()).To(Equal("pyxisapitoken"))
 			Expect(cro.DockerConfig()).To(Equal("dockercfg"))

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -35,8 +35,8 @@ var _ = Describe("Viper to Runtime Config", func() {
 		expectedRuntimeCfg.Submit = true
 		baseViperCfg.Set("pyxis_env", "prod")
 		expectedRuntimeCfg.PyxisHost = "catalog.redhat.com/api/containers"
-		baseViperCfg.Set("certification_project_id", "000000000000")
-		expectedRuntimeCfg.CertificationProjectID = "000000000000"
+		baseViperCfg.Set("certification_component_id", "000000000000")
+		expectedRuntimeCfg.CertificationComponentID = "000000000000"
 		baseViperCfg.Set("platform", "s390x")
 		expectedRuntimeCfg.Platform = "s390x"
 		baseViperCfg.Set("insecure", true)


### PR DESCRIPTION
## Motivation
The flag has been deprecated from sometime now, and it was found out that we were overriding precedences of `flags`, `env`, and `configs` with taking `envs` over `flags`. Since there is a bug in the custom logic, that goes against cobra's order, it makes sense to just remove this flag.

## Changes

- Removes the `certification-project-id` flag
- Update supporting vars to reference `component` flag 

Build-depends: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/810