### PR TITLE
Restrict permissions in go build workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,10 +6,10 @@ on:
     - main
     - release-*
 
+permissions: {}
+
 jobs:
   build:
-    # TODO: Set explicit permissions for this job.
-    # zizmor: ignore[excessive-permissions]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -46,8 +46,6 @@ jobs:
         file: coverage.out
 
   build-linux-binaries:
-    # TODO: Set explicit permissions for this job.
-    # zizmor: ignore[excessive-permissions]
     name: Build Multi-arch-linux
     runs-on: ubuntu-latest
     strategy:
@@ -67,8 +65,6 @@ jobs:
         run: make build-linux-${{ matrix.architecture }}
 
   build-mac-binaries:
-    # TODO: Set explicit permissions for this job.
-    # zizmor: ignore[excessive-permissions]
     name: Build Multi-arch-mac
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Now that we have `zizmor` audits in place, we can proceed with further securing workflows by limiting the `GITHUB_TOKEN` only to permissions which are needed.

This PR starts with the `go.yml` workflow which is easy to validate (since it ran on even this PR).