### PR TITLE
Fix podman login in copy-to-rhisv workflow

### DIFF
--- a/.github/workflows/copy-to-rhisv.yml
+++ b/.github/workflows/copy-to-rhisv.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Podman Login
       uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
       with:
-        registry: ${DEST_IMAGE_REGISTRY}
+        registry: ${{ secrets.destImageRegistry }}
         username: ${{ secrets.destRegistryUser }}
         password: ${{ secrets.destRegistryPassword }}
 


### PR DESCRIPTION
- `with` values in a GHA still need to come from a `secret` not a defined `env`
- https://github.com/redhat-openshift-ecosystem/openshift-preflight/actions/runs/19442717907/job/55632032156