### PR TITLE
Revert "Add new flag to use non-zero exit code when checks fail"

### DIFF
--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -3,13 +3,11 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
@@ -47,9 +45,6 @@ func rootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().String("loglevel", "", "The verbosity of the preflight tool itself. Ex. warn, debug, trace, info, error. (env: PFLT_LOGLEVEL)")
 	_ = viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel"))
 
-	rootCmd.PersistentFlags().Bool("exit-with-failure", false, "Exit with exit code 1 if any checks encounter an error or exit code 2 if any checks fail. (env: PFLT_EXIT_WITH_FAILURE)")
-	_ = viper.BindPFlag("exit_with_failure", rootCmd.PersistentFlags().Lookup("exit-with-failure"))
-
 	rootCmd.AddCommand(checkCmd())
 	rootCmd.AddCommand(listChecksCmd())
 	rootCmd.AddCommand(runtimeAssetsCmd())
@@ -58,24 +53,8 @@ func rootCmd() *cobra.Command {
 	return rootCmd
 }
 
-type ChecksFailedError = cli.ChecksFailedError
-
-type ChecksErroredError = cli.ChecksErroredError
-
 func Execute() error {
-	exit_with_failure := viper.Instance().GetBool("exit_with_failure")
-	err := rootCmd().ExecuteContext(context.Background())
-	if errors.Is(err, &cli.ChecksErroredError{}) && exit_with_failure {
-		return err
-	}
-	if errors.Is(err, &cli.ChecksFailedError{}) && exit_with_failure {
-		return err
-	}
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return rootCmd().ExecuteContext(context.Background())
 }
 
 func initConfig(viper *spfviper.Viper) {

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -1,26 +1,13 @@
 package main
 
 import (
-	"errors"
 	"log"
-	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cmd/preflight/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		if errors.Is(err, &cmd.ChecksErroredError{}) {
-			log.Println(err)
-			os.Exit(1)
-		}
-
-		if errors.Is(err, &cmd.ChecksFailedError{}) {
-			log.Println(err)
-			os.Exit(2)
-		}
-
-		// Default, original behaviour
 		log.Fatal(err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,18 +23,6 @@ type CheckConfig struct {
 	SubmitResults       bool
 }
 
-type ChecksFailedError struct{}
-
-func (e *ChecksFailedError) Error() string {
-	return "one or more checks failed"
-}
-
-type ChecksErroredError struct{}
-
-func (e *ChecksErroredError) Error() string {
-	return "one or more checks encountered an error"
-}
-
 // RunPreflight executes checks, writes logs, results, and submits results if requested.
 func RunPreflight(
 	ctx context.Context,
@@ -95,14 +83,6 @@ func RunPreflight(
 	}
 
 	logger.Info(fmt.Sprintf("Preflight result: %s", convertPassedOverall(results.PassedOverall)))
-
-	if len(results.Errors) > 0 {
-		return &ChecksErroredError{}
-	}
-
-	if len(results.Failed) > 0 {
-		return &ChecksFailedError{}
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Motivation
The original PR was causing CI failures due to the default flow exiting with code `2` example
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-openshift-ecosystem-certified-operators-prod-ocp-4.20-preflight-prod-claim/1991109411849900032

Reverts redhat-openshift-ecosystem/openshift-preflight#1316 (c15728f5609b4e262ca2d951633f0db91bb59273), which introduced several regressions including:
- New exit code behavior occurs regardless of whether the exit-with-failure flag is set
- When errors are encountered in checks while checking a multi-arch image, subsequent archs in the image are not checked

We need more time to work through these issues and test, so it's safest to revert this change for now to unblock users.