### PR TITLE
Reverse an order of layers for Pyxis

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -547,7 +548,10 @@ func writeCertImage(ctx context.Context, imageRef image.ImageReference) error {
 	}
 
 	manifestLayers := make([]string, 0, len(manifest.Layers))
-	for _, layer := range manifest.Layers {
+
+	// CertImage expects the layers to be stored in the order from base to top.
+	// Index 0 is the base layer, and the last index is the top layer.
+	for _, layer := range slices.Backward(manifest.Layers) {
 		manifestLayers = append(manifestLayers, layer.Digest.String())
 	}
 


### PR DESCRIPTION
Pyxis schema expects image layers to be sorted from base image to top layer. This commit reverts the order to align with Pyxis expected schema.

JIRA: ISV-6472