### PR TITLE
cmd,internal: prefer any over interface{}

### DIFF
--- a/cmd/preflight/cmd/runtime_assets.go
+++ b/cmd/preflight/cmd/runtime_assets.go
@@ -44,7 +44,7 @@ func printAssets(ctx context.Context, w io.Writer) error {
 
 // prettyPrintJSON marhals v with standard pretty print spacing and returns
 // it in string form.
-func prettyPrintJSON(v interface{}) (string, error) {
+func prettyPrintJSON(v any) (string, error) {
 	json, err := json.MarshalIndent(v, "", "    ")
 	if err != nil {
 		return "", err

--- a/cmd/preflight/cmd/runtime_assets_test.go
+++ b/cmd/preflight/cmd/runtime_assets_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("runtime-assets test", func() {
 	Context("When formatting JSON data", func() {
 		It("should be formatted in a standard format", func() {
-			in := map[string]interface{}{
+			in := map[string]any{
 				"foo":  "bar",
 				"this": []string{"that", "theother"},
 			}

--- a/internal/formatters/generic_test.go
+++ b/internal/formatters/generic_test.go
@@ -58,7 +58,7 @@ func TestGenericJSONFormatter(t *testing.T) {
 	for _, tc := range testCases {
 		// Patch the function if we expect an error
 		if tc.marshalIndentFailure {
-			jsonMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
+			jsonMarshalIndent = func(v any, prefix, indent string) ([]byte, error) {
 				return nil, errors.New("this is an error")
 			}
 		} else {
@@ -134,7 +134,7 @@ func TestGenericXMLFormatter(t *testing.T) {
 	for _, tc := range testCases {
 		// Patch the function if we expect an error
 		if tc.marshalIndentFailure {
-			xmlMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
+			xmlMarshalIndent = func(v any, prefix, indent string) ([]byte, error) {
 				return nil, errors.New("this is an error")
 			}
 		} else {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -35,11 +35,11 @@ func (s bufferSink) Enabled(level int) bool {
 	return true
 }
 
-func (s bufferSink) Error(err error, msg string, keysAndValues ...interface{}) {
+func (s bufferSink) Error(err error, msg string, keysAndValues ...any) {
 	fmt.Fprintf(s.buffer, "%s %v %s %v\n", s.name, err.Error(), msg, keysAndValues)
 }
 
-func (s bufferSink) Info(level int, msg string, keysAndValues ...interface{}) {
+func (s bufferSink) Info(level int, msg string, keysAndValues ...any) {
 	fmt.Fprintf(s.buffer, "%s %s %v\n", s.name, msg, keysAndValues)
 }
 
@@ -53,6 +53,6 @@ func (s bufferSink) WithName(name string) logr.LogSink {
 	return newSink
 }
 
-func (s bufferSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+func (s bufferSink) WithValues(keysAndValues ...any) logr.LogSink {
 	return nil
 }

--- a/internal/policy/operator/deployable_by_olm.go
+++ b/internal/policy/operator/deployable_by_olm.go
@@ -718,7 +718,7 @@ func (p *DeployableByOlmCheck) cleanUp(ctx context.Context, operatorData operato
 	_ = p.openshiftClient.DeleteNamespace(ctx, operatorData.TargetNamespace)
 }
 
-func (p *DeployableByOlmCheck) writeToFile(ctx context.Context, data interface{}) error {
+func (p *DeployableByOlmCheck) writeToFile(ctx context.Context, data any) error {
 	obj, err := apiruntime.DefaultUnstructuredConverter.ToUnstructured(data)
 	if err != nil {
 		return fmt.Errorf("unable to convert the object to unstructured.Unstructured: %w", err)

--- a/internal/pyxis/builder.go
+++ b/internal/pyxis/builder.go
@@ -130,7 +130,7 @@ func WithArtifact(r io.Reader, filename string) CertificationInputOption {
 	}
 }
 
-func readAndUnmarshal(r io.Reader, submission interface{}) error {
+func readAndUnmarshal(r io.Reader, submission any) error {
 	bytes, err := io.ReadAll(r)
 	if err != nil {
 		return err

--- a/internal/pyxis/layers.go
+++ b/internal/pyxis/layers.go
@@ -42,7 +42,7 @@ func (p *pyxisClient) CertifiedImagesContainingLayers(ctx context.Context, uncom
 	}
 
 	// variables to feed to our graphql filter
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"contImageLayers": layerIds,
 		"registries":      []graphql.String{"registry.access.redhat.com"},
 	}

--- a/internal/pyxis/pyxis.go
+++ b/internal/pyxis/pyxis.go
@@ -210,7 +210,7 @@ func (p *pyxisClient) FindImagesByDigest(ctx context.Context, digests []string) 
 		graphqlDigests[idx] = graphql.String(digest)
 	}
 	// variables to feed to our graphql filter
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"digests": graphqlDigests,
 	}
 


### PR DESCRIPTION
`any` has been available since Go 1.18 and has clearer intent than `interface{}`. Internally, `any` is a type alias for `interface{}`, so there should be no difference in behavior in any of the usages here.