### PR TITLE
Use maps and slices functions instead of loops where possible

### DIFF
--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -40,7 +40,7 @@ func createPlatformImage(arch string, addlLayers int) cranev1.Image {
 	img, err := random.Image(1024, 5)
 	Expect(err).ToNot(HaveOccurred())
 
-	for i := 0; i < addlLayers; i++ {
+	for range addlLayers {
 		newLayer, err := random.Layer(1024, cranev1types.OCILayer)
 		Expect(err).ToNot(HaveOccurred())
 		img, err = mutate.AppendLayers(img, newLayer)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"os"
 	"os/exec"
@@ -16,7 +17,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -335,12 +335,9 @@ func generateBundleHash(ctx context.Context, bundlePath string) (string, error) 
 		return nil
 	})
 
-	keys := make([]string, 0, len(files))
-	for k := range files {
-		keys = append(keys, k)
-	}
+	keys := slices.Collect(maps.Keys(files))
+	slices.Sort(keys)
 
-	sort.Strings(keys)
 	for _, k := range keys {
 		hashBuffer.WriteString(fmt.Sprintf("%s  %s\n", k, files[k]))
 	}

--- a/internal/policy/operator/deployable_by_olm.go
+++ b/internal/policy/operator/deployable_by_olm.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -234,10 +236,7 @@ func checkImageSource(ctx context.Context, operatorImages []string) bool {
 
 	logger.V(log.DBG).Info("checking that images are from approved sources")
 
-	registries := make([]string, 0, len(approvedRegistries))
-	for registry := range approvedRegistries {
-		registries = append(registries, registry)
-	}
+	registries := slices.Collect(maps.Keys(approvedRegistries))
 
 	logger.V(log.DBG).Info("list of approved registries", "registries", registries)
 	allApproved := true


### PR DESCRIPTION
Replace loops with uses of `maps` and `slices` functions where possible, while still preserving readability and intent. There are some other places that could similarly be changed but the result is not as readable.