### PR TITLE
fix(engine,runtime): add support for configurable temporary directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ image-push:
 
 .PHONY: test
 test:
-	go test -v $$(go list ./... | grep -v e2e) \
+	go test -v -tags testing $$(go list ./... | grep -v e2e) \
 	-ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo"
 
 .PHONY: cover
 cover: go-ignore-cov
-	go test -v \
+	go test -v -tags testing \
 	 -ldflags "-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=bar -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=foo" \
 	 $$(go list ./... | grep -v e2e) \
 	 -race \
@@ -73,11 +73,11 @@ cover: go-ignore-cov
 
 .PHONY: vet
 vet:
-	go vet ./...
+	go vet -tags testing ./...
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter checks.
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run --build-tags testing
 	
 .PHONY: test-e2e
 test-e2e:

--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -92,6 +92,7 @@ func checkContainerCmd(runpreflight runPreflight) *cobra.Command {
 
 	_ = viper.BindEnv("cpuprofile")
 	_ = viper.BindEnv("memprofile")
+	_ = viper.BindEnv("tempDir")
 
 	return checkContainerCmd
 }
@@ -306,6 +307,7 @@ func generateContainerCheckOptions(cfg *runtime.Config) []container.Option {
 		container.WithPyxisHost(cfg.PyxisHost),
 		container.WithPlatform(cfg.Platform),
 		container.WithManifestListDigest(cfg.ManifestListDigest),
+		container.WithTempDir(cfg.TempDir),
 	}
 
 	// set auth information if both are present in config.

--- a/container/check_container.go
+++ b/container/check_container.go
@@ -55,6 +55,7 @@ func (c *containerCheck) Run(ctx context.Context) (certification.Results, error)
 		Insecure:           c.insecure,
 		Platform:           c.platform,
 		ManifestListDigest: c.manifestListDigest,
+		TempDir:            c.tempDir,
 	}
 	eng, err := engine.New(ctx, c.checks, nil, cfg)
 	if err != nil {
@@ -222,6 +223,13 @@ func WithKonflux() Option {
 	}
 }
 
+// WithTempDir sets the temporary directory for cache and filesystem
+func WithTempDir(tempDir string) Option {
+	return func(cc *containerCheck) {
+		cc.tempDir = tempDir
+	}
+}
+
 type containerCheck struct {
 	image                  string
 	dockerconfigjson       string
@@ -236,4 +244,5 @@ type containerCheck struct {
 	policy                 policy.Policy
 	konflux                bool
 	pyxisClient            lib.PyxisClient // for testing purposes
+	tempDir                string
 }

--- a/container/check_container_test.go
+++ b/container/check_container_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 var _ = Describe("Container Check initialization", func() {
@@ -89,7 +90,7 @@ var _ = Describe("Container Check Execution", func() {
 		})
 
 		It("Should run without issue", func() {
-			ctx := context.TODO()
+			ctx := test.NewTestLoggerContext(context.TODO())
 			results, err := chk.Run(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).ToNot(Equal(certification.Results{}))

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -19,6 +20,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -34,10 +38,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/rpm"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
-	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/cache"
 )
 
 // New creates a new CraneEngine from the passed params
@@ -56,6 +56,7 @@ func New(ctx context.Context,
 		platform:           cfg.Platform,
 		insecure:           cfg.Insecure,
 		manifestListDigest: cfg.ManifestListDigest,
+		tempDir:            cfg.TempDir,
 	}, nil
 }
 
@@ -89,6 +90,9 @@ type craneEngine struct {
 	// ManifestListDigest is the sha256 digest for the manifest list
 	manifestListDigest string
 
+	// tempDir is optional. If empty, will use an OS tmp dir.
+	tempDir string
+
 	imageRef image.ImageReference
 	results  certification.Results
 }
@@ -111,35 +115,40 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info("target image", "image", c.image)
 
-	// pull the image and save to fs
+	logger.V(log.TRC).Info("temp directory", "dir", c.tempDir)
+	tempdir := c.tempDir
+	if tempdir == "" {
+		var err error
+
+		// create tmpdir to receive extracted fs
+		tempdir, err = os.MkdirTemp(os.TempDir(), "preflight-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temporary directory: %v", err)
+		}
+		logger.V(log.DBG).Info("created temporary directory", "path", tempdir)
+		defer func() {
+			if err := os.RemoveAll(tempdir); err != nil {
+				logger.Error(err, "unable to clean up tmpdir", "tempDir", tempdir)
+			}
+		}()
+	}
+
+	imageTarPath := path.Join(tempdir, "cache")
+	if err := os.MkdirAll(imageTarPath, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
+		return fmt.Errorf("failed to create cache directory: %s: %v", imageTarPath, err)
+	}
+
+	// pull the image manifest
 	logger.V(log.DBG).Info("pulling image from target registry")
 	options := option.GenerateCraneOptions(ctx, c)
 	img, err := crane.Pull(c.image, options...)
 	if err != nil {
 		return fmt.Errorf("failed to pull remote container: %v", err)
 	}
-
-	// create tmpdir to receive extracted fs
-	tmpdir, err := os.MkdirTemp(os.TempDir(), "preflight-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temporary directory: %v", err)
-	}
-	logger.V(log.DBG).Info("created temporary directory", "path", tmpdir)
-	defer func() {
-		if err := os.RemoveAll(tmpdir); err != nil {
-			logger.Error(err, "unable to clean up tmpdir", "tempDir", tmpdir)
-		}
-	}()
-
-	imageTarPath := path.Join(tmpdir, "cache")
-	if err := os.Mkdir(imageTarPath, 0o755); err != nil {
-		return fmt.Errorf("failed to create cache directory: %s: %v", imageTarPath, err)
-	}
-
 	img = cache.Image(img, cache.NewFilesystemCache(imageTarPath))
 
-	containerFSPath := path.Join(tmpdir, "fs")
-	if err := os.Mkdir(containerFSPath, 0o755); err != nil {
+	containerFSPath := path.Join(tempdir, "fs")
+	if err := os.MkdirAll(containerFSPath, 0o755); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to create container expansion directory: %s: %v", containerFSPath, err)
 	}
 

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/option"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
-
-	"github.com/spf13/viper"
 )
 
 // Config contains configuration details for running preflight.
@@ -20,6 +20,7 @@ type Config struct {
 	LogFile        string
 	Artifacts      string
 	WriteJUnit     bool
+	TempDir        string
 	// Container-Specific Fields
 	CertificationComponentID string
 	PyxisHost                string
@@ -60,6 +61,7 @@ func NewConfigFrom(vcfg viper.Viper) (*Config, error) {
 	cfg.DockerConfig = vcfg.GetString("dockerConfig")
 	cfg.Artifacts = vcfg.GetString("artifacts")
 	cfg.WriteJUnit = vcfg.GetBool("junit")
+	cfg.TempDir = vcfg.GetString("tempDir")
 	cfg.storeContainerPolicyConfiguration(vcfg)
 	cfg.storeOperatorPolicyConfiguration(vcfg)
 	return &cfg, nil

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -74,6 +74,6 @@ var _ = Describe("Viper to Runtime Config", func() {
 		// accurate in confirming that the derived configuration from viper
 		// matches.
 		keys := reflect.TypeOf(Config{}).NumField()
-		Expect(keys).To(Equal(27))
+		Expect(keys).To(Equal(28))
 	})
 })

--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -1,0 +1,19 @@
+//go:build testing
+
+package test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+func NewTestLoggerContext(ctx context.Context) context.Context {
+	log := funcr.New(func(prefix, args string) {
+		GinkgoWriter.Println(prefix, args)
+	}, funcr.Options{})
+	return logr.NewContext(ctx, log)
+}


### PR DESCRIPTION
Add TmpDir configuration option to allow users to specify a custom
temporary directory for image extraction and caching. This enables
better control over disk usage location, particularly useful when the
default OS temp directory has limited space.

When TmpDir is configured, the directory is reused across runs,
preserving the filesystem cache between executions. When empty,
falls back to creating an ephemeral directory in the OS temp location
that is cleaned up after execution.

Adds a simple logging function for use in tests. Will use the
GinkgoWriter.Println that will only show if there is a problem in the
test.

Also includes minor whitespace formatting improvements in the untar
function and adds os.IsExist checks when creating directories.

Signed-off-by: Brad P. Crochet <brad@redhat.com>
