### PR TITLE
adding openstack directory to HMF excluded directory list

### DIFF
--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -370,11 +370,12 @@ func findRPMDB(ctx context.Context, layer v1.Layer) (found bool, pkglist []*rpmd
 // directoryIsExcluded excludes a directory and any file contained in that directory.
 func directoryIsExcluded(ctx context.Context, s string) bool {
 	excl := map[string]struct{}{
-		"etc":               {},
-		"var":               {},
-		"run":               {},
-		"usr/lib/.build-id": {},
-		"usr/tmp":           {},
+		"etc":                           {},
+		"var":                           {},
+		"run":                           {},
+		"usr/lib/.build-id":             {},
+		"usr/tmp":                       {},
+		"usr/share/openstack-dashboard": {},
 	}
 
 	for k := range excl {


### PR DESCRIPTION
## Motivation
When OpenStack plugin authors use the default UBI build container, all of these files are included in the base image. They are also rebuilt when the plugin is added and the final container, causing HMF failure. This adds unnecessary burden to CertOps to approve exceptions for these containers, this also adds delays in publication for partners.

## Testing

**Before**
```
{
    "image": "quay.io/redhat-isv-containers/5e7e4d681359693eb9793743:6.1.7-rhosp17.1",
    "passed": false,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.16.0",
        "commit": "b4a231cf9d50c5471eed598b3b48906eb5b9f3f7"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 85,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata"
            },
            {
                "name": "HasNoProhibitedLabels",
                "elapsed_time": 0,
                "description": "Checking if the labels (name, vendor, maintainer) violate Red Hat trademark."
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1201,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            },
            {
                "name": "HasProhibitedContainerName",
                "elapsed_time": 0,
                "description": "Checking if the container-name violates Red Hat trademark."
            }
        ],
        "failed": [
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 14033,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified",
                "help": "Check HasModifiedFiles encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Do not modify any files installed by RPM in the base Red Hat layer",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
        "errors": []
    }
}
```

**After**
```
{
    "image": "quay.io/redhat-isv-containers/5e7e4d681359693eb9793743:6.1.7-rhosp17.1",
    "passed": false,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "unknown",
        "commit": "unknown"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 78,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata"
            },
            {
                "name": "HasNoProhibitedLabels",
                "elapsed_time": 0,
                "description": "Checking if the labels (name, vendor, maintainer) violate Red Hat trademark."
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 13421,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 999,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            },
            {
                "name": "HasProhibitedContainerName",
                "elapsed_time": 0,
                "description": "Checking if the container-name violates Red Hat trademark."
            }
        ],
        "failed": [
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
        "errors": []
    }
```