### PR TITLE
fix: HasLicense test for invalid path would sometimes fail

### DIFF
--- a/internal/policy/container/has_license_test.go
+++ b/internal/policy/container/has_license_test.go
@@ -42,11 +42,10 @@ var _ = Describe("HasLicense", func() {
 			})
 		})
 		Context("When licenses directory is not found", func() {
-			JustBeforeEach(func() {
-				imgRef.ImageFSPath = "/invalid"
-			})
 			It("Should not pass Validate", func() {
-				ok, err := hasLicense.Validate(context.TODO(), imgRef)
+				badImgRef := imgRef
+				badImgRef.ImageFSPath = "/invalid"
+				ok, err := hasLicense.Validate(context.TODO(), badImgRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})


### PR DESCRIPTION
Locally, this test would sometimes fail because upon cleanup, it couldn't find "//invalid". This saves of the original temporary directory value from imgRef.ImageFSPath, then restores it before any cleanup occurs.