### PR TITLE
add logic to check container policy to block operator bundle projects

### DIFF
--- a/container/check_container.go
+++ b/container/check_container.go
@@ -2,16 +2,20 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	goruntime "runtime"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/engine"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
@@ -65,6 +69,7 @@ func (c *containerCheck) Run(ctx context.Context) (certification.Results, error)
 }
 
 func (c *containerCheck) resolve(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
 	if c.resolved {
 		return nil
 	}
@@ -76,18 +81,31 @@ func (c *containerCheck) resolve(ctx context.Context) error {
 	c.policy = policy.PolicyContainer
 
 	// If we have enough Pyxis information, resolve the policy.
-	if c.hasPyxisData() {
-		p := pyxis.NewPyxisClient(
-			c.pyxisHost,
-			c.pyxisToken,
-			c.certificationProjectID,
-			&http.Client{Timeout: 60 * time.Second},
-		)
-
-		override, err := lib.GetContainerPolicyExceptions(ctx, p)
-		if err != nil {
-			return fmt.Errorf("%w: %s", preflighterr.ErrCannotResolvePolicyException, err)
+	if c.pyxisClient != nil || c.hasPyxisData() {
+		// Use injected client for testing, otherwise create a new one
+		p := c.pyxisClient
+		if p == nil {
+			p = pyxis.NewPyxisClient(
+				c.pyxisHost,
+				c.pyxisToken,
+				c.certificationProjectID,
+				&http.Client{Timeout: 60 * time.Second},
+			)
 		}
+
+		certProject, err := p.GetProject(ctx)
+		if err != nil {
+			return fmt.Errorf("%w: could not retrieve project: %s", preflighterr.ErrCannotResolvePolicyException, err)
+		}
+		logger.V(log.DBG).Info("certification project", "name", certProject.Name)
+
+		// checking to see if project is an operator bundle, to safeguard against users submitting containers to bundle projects
+		if certProject.BundleProject() {
+			return errors.New("bundle project detected: container submissions are not valid for bundle projects, please run the operator certification workflow instead")
+		}
+
+		// checking for policy exceptions
+		override := lib.GetContainerPolicyExceptions(certProject)
 
 		c.policy = override
 	}
@@ -217,4 +235,5 @@ type containerCheck struct {
 	resolved               bool
 	policy                 policy.Policy
 	konflux                bool
+	pyxisClient            lib.PyxisClient // for testing purposes
 }

--- a/container/check_container_test.go
+++ b/container/check_container_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
@@ -147,4 +149,37 @@ var _ = Describe("Container Check Execution", func() {
 			Expect(err).To(MatchError(preflighterr.ErrCannotResolvePolicyException))
 		})
 	})
+
+	When("checking for bundle projects", func() {
+		It("should fail if the project is an operator bundle image", func() {
+			fakeClient := &fakePyxisClient{
+				getProjectFunc: returnBundleProject,
+			}
+			chk := NewCheck("placeholder", withPyxisClient(fakeClient))
+			_, err := chk.Run(context.TODO())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("bundle project detected"))
+			Expect(err.Error()).To(ContainSubstring("operator certification workflow"))
+		})
+
+		It("should succeed if the project is a container project", func() {
+			fakeClient := &fakePyxisClient{
+				getProjectFunc: returnContainerProject,
+			}
+			goodImage := "quay.io/opdev/simple-demo-operator:latest"
+			chk := NewCheck(goodImage, withPyxisClient(fakeClient))
+			results, err := chk.Run(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).ToNot(Equal(certification.Results{}))
+			Expect(results.TestedImage).To(Equal(goodImage))
+		})
+	})
 })
+
+// withPyxisClient injects a pyxis client for testing purposes.
+// This is not exported and should only be used in tests.
+func withPyxisClient(client lib.PyxisClient) Option {
+	return func(cc *containerCheck) {
+		cc.pyxisClient = client
+	}
+}

--- a/container/fakes_test.go
+++ b/container/fakes_test.go
@@ -1,0 +1,46 @@
+package container
+
+import (
+	"context"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
+)
+
+// fakePyxisClient implements lib.PyxisClient for testing
+type fakePyxisClient struct {
+	getProjectFunc func(ctx context.Context) (*pyxis.CertProject, error)
+}
+
+func (f *fakePyxisClient) GetProject(ctx context.Context) (*pyxis.CertProject, error) {
+	if f.getProjectFunc != nil {
+		return f.getProjectFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (f *fakePyxisClient) FindImagesByDigest(ctx context.Context, digests []string) ([]pyxis.CertImage, error) {
+	return nil, nil
+}
+
+func (f *fakePyxisClient) SubmitResults(ctx context.Context, certInput *pyxis.CertificationInput) (*pyxis.CertificationResults, error) {
+	return nil, nil
+}
+
+// Helper functions to return different project types
+func returnBundleProject(ctx context.Context) (*pyxis.CertProject, error) {
+	return &pyxis.CertProject{
+		Name: "test-bundle-project",
+		Container: pyxis.Container{
+			Type: "operator bundle image",
+		},
+	}, nil
+}
+
+func returnContainerProject(ctx context.Context) (*pyxis.CertProject, error) {
+	return &pyxis.CertProject{
+		Name: "test-container-project",
+		Container: pyxis.Container{
+			Type: "container",
+		},
+	}, nil
+}

--- a/internal/lib/fakes_test.go
+++ b/internal/lib/fakes_test.go
@@ -138,46 +138,6 @@ func gpFuncReturnScratchException(ctx context.Context) (*pyxis.CertProject, erro
 	}, nil
 }
 
-// gpFuncReturnScratchImageException implements gpFunc and returns a scratch image exception.
-func gpFuncReturnScratchImageException(ctx context.Context) (*pyxis.CertProject, error) {
-	return &pyxis.CertProject{
-		Container: pyxis.Container{
-			OsContentType: "Scratch Image",
-		},
-	}, nil
-}
-
-// gpFuncReturnRootException implements gpFunc and returns a root exception.
-func gpFuncReturnRootException(ctx context.Context) (*pyxis.CertProject, error) {
-	return &pyxis.CertProject{
-		Container: pyxis.Container{
-			DockerConfigJSON: "",
-			Privileged:       true,
-		},
-	}, nil
-}
-
-// gpFuncReturnScratchRootException implements gpFunc and returns a root exception.
-func gpFuncReturnScratchRootException(ctx context.Context) (*pyxis.CertProject, error) {
-	return &pyxis.CertProject{
-		Container: pyxis.Container{
-			DockerConfigJSON: "",
-			OsContentType:    "Scratch Image",
-			Privileged:       true,
-		},
-	}, nil
-}
-
-// gpFuncReturnNoException implements gpFunc and returns no exception indicators.
-func gpFuncReturnNoException(ctx context.Context) (*pyxis.CertProject, error) {
-	return &pyxis.CertProject{
-		Container: pyxis.Container{
-			Type:       "",
-			Privileged: false,
-		},
-	}, nil
-}
-
 // srFuncReturnError implements srFunc and returns a submission error.
 func srFuncReturnError(ctx context.Context, ci *pyxis.CertificationInput) (*pyxis.CertificationResults, error) {
 	return nil, errors.New("some submission error")

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1,13 +1,8 @@
 package lib
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/go-logr/logr"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 )
 
 // ResolveSubmitter will build out a ResultSubmitter if the provided pyxisClient, pc, is not nil.
@@ -25,36 +20,33 @@ func ResolveSubmitter(pc PyxisClient, projectID, dockerconfig, logfile string) R
 	return NewNoopSubmitter(true, nil)
 }
 
-// GetContainerPolicyExceptions will query Pyxis to determine if
-// a given project has a certification excemptions, such as root or scratch.
+// GetContainerPolicyExceptions accepts a CertProject to determine if
+// a given project has certification exemptions, such as root or scratch.
 // This will then return the corresponding policy.
 //
 // If no policy exception flags are found on the project, the standard
 // container policy is returned.
-func GetContainerPolicyExceptions(ctx context.Context, pc PyxisClient) (policy.Policy, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
-	certProject, err := pc.GetProject(ctx)
-	if err != nil {
-		return "", fmt.Errorf("could not retrieve project: %w", err)
+func GetContainerPolicyExceptions(certProject *pyxis.CertProject) policy.Policy {
+	// check for nil first so code doesn't panic later
+	if certProject == nil {
+		return policy.PolicyContainer
 	}
-	logger.V(log.DBG).Info("certification project", "name", certProject.Name)
 
 	// if the partner has gotten a scratch exception from the business and os_content_type == "Scratch Image"
 	// and a partner sets `Host Level Access` in connect to `Privileged`, enable ScratchRootContainerPolicy checks
 	if certProject.ScratchProject() && certProject.Container.Privileged {
-		return policy.PolicyScratchRoot, nil
+		return policy.PolicyScratchRoot
 	}
 
 	// if the partner has gotten a scratch exception from the business and os_content_type == "Scratch Image",
 	// enable ScratchNonRootContainerPolicy checks
 	if certProject.ScratchProject() {
-		return policy.PolicyScratchNonRoot, nil
+		return policy.PolicyScratchNonRoot
 	}
 
 	// if a partner sets `Host Level Access` in connect to `Privileged`, enable RootExceptionContainerPolicy checks
 	if certProject.Container.Privileged {
-		return policy.PolicyRoot, nil
+		return policy.PolicyRoot
 	}
-	return policy.PolicyContainer, nil
+	return policy.PolicyContainer
 }

--- a/internal/lib/types_test.go
+++ b/internal/lib/types_test.go
@@ -54,56 +54,63 @@ var _ = Describe("Pyxis Client Instantiation", func() {
 
 var _ = Describe("Policy Resolution", func() {
 	Context("When determining container policy exceptions", func() {
-		var fakePC *FakePyxisClient
-		BeforeEach(func() {
-			// reset the fake pyxis client before each execution
-			// as a precaution.
-			fakePC = &FakePyxisClient{
-				findImagesByDigestFunc: fidbFuncNoop,
-				getProjectsFunc:        gpFuncNoop,
-				submitResultsFunc:      srFuncNoop,
+		It("should return a scratch policy exception if the project has type flag", func() {
+			certProject := &pyxis.CertProject{
+				Container: pyxis.Container{
+					Type: "scratch",
+				},
 			}
-		})
-
-		It("should throw an error if unable to get the project from the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnError
-			_, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should return a scratch policy exception if the project has type flag in the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnScratchException
-			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+			p := GetContainerPolicyExceptions(certProject)
 			Expect(p).To(Equal(policy.PolicyScratchNonRoot))
-			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return a scratch policy exception if the project has os_content_type flag in the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnScratchImageException
-			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+		It("should return a scratch policy exception if the project has os_content_type flag", func() {
+			certProject := &pyxis.CertProject{
+				Container: pyxis.Container{
+					OsContentType: "Scratch Image",
+				},
+			}
+			p := GetContainerPolicyExceptions(certProject)
 			Expect(p).To(Equal(policy.PolicyScratchNonRoot))
-			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return a root policy exception if the project has the flag in the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnRootException
-			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+		It("should return a root policy exception if the project has the flag", func() {
+			certProject := &pyxis.CertProject{
+				Container: pyxis.Container{
+					DockerConfigJSON: "",
+					Privileged:       true,
+				},
+			}
+			p := GetContainerPolicyExceptions(certProject)
 			Expect(p).To(Equal(policy.PolicyRoot))
-			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return a scratch plus root policy exception if the project has the flag in the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnScratchRootException
-			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+		It("should return a scratch plus root policy exception if the project has the flag", func() {
+			certProject := &pyxis.CertProject{
+				Container: pyxis.Container{
+					DockerConfigJSON: "",
+					OsContentType:    "Scratch Image",
+					Privileged:       true,
+				},
+			}
+			p := GetContainerPolicyExceptions(certProject)
 			Expect(p).To(Equal(policy.PolicyScratchRoot))
-			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return a container policy exception if the project no exceptions in the API", func() {
-			fakePC.getProjectsFunc = gpFuncReturnNoException
-			p, err := GetContainerPolicyExceptions(context.TODO(), fakePC)
+		It("should return a container policy exception if the project has no exceptions", func() {
+			certProject := &pyxis.CertProject{
+				Container: pyxis.Container{
+					Type:       "",
+					Privileged: false,
+				},
+			}
+			p := GetContainerPolicyExceptions(certProject)
 			Expect(p).To(Equal(policy.PolicyContainer))
-			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return a container policy exception if called with nil container project", func() {
+			p := GetContainerPolicyExceptions(nil)
+			Expect(p).To(Equal(policy.PolicyContainer))
 		})
 	})
 })

--- a/internal/pyxis/types.go
+++ b/internal/pyxis/types.go
@@ -109,6 +109,11 @@ func (cp CertProject) ScratchProject() bool {
 	return cp.Container.Type == "scratch" || cp.Container.OsContentType == "Scratch Image"
 }
 
+func (cp CertProject) BundleProject() bool {
+	// BundleProject returns true if the CertProject is designated as a Bundle in Pyxis.
+	return cp.Container.Type == "operator bundle image"
+}
+
 type Container struct {
 	DockerConfigJSON string `json:"docker_config_json,omitempty"`
 	HostedRegistry   bool   `json:"hosted_registry,omitempty"`


### PR DESCRIPTION
## Motivation
Over the past few weeks, we've seen a few instances where the partner submits results of `preflight check container` to an `operator bundle` project. This has then caused hours (or days in some cases) of troubleshooting issues to find the route cause of the submission issue(s). It also causes our backend to have inconsistent data, since `check container` isn't designed for `operator bundle` information: i.e. `imageConfig`, `rpmInfo`, etc.

## Changes
- Move `GetProject` into `check_container` logic
   - This enables `certProject` to be used for multiple validations
- Refactor `GetContainerPolicyExceptions` to accept a `certProject` instead of a `pyxisClient`
- Updated United tests

## Image from Swagger for `certProject.Container.type` values
<img width="1089" height="69" alt="Screenshot From 2026-03-02 07-10-42" src="https://github.com/user-attachments/assets/49945828-60a2-4d6f-9e57-b0681ccf4295" />

