### PR TITLE
check: remove coverage exclusions from RequiredFilePatterns() accessors

### DIFF
--- a/internal/check/generic_check.go
+++ b/internal/check/generic_check.go
@@ -35,7 +35,6 @@ func (pd *genericCheckDefinition) Help() HelpText {
 }
 
 func (pd *genericCheckDefinition) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return pd.requiredFilePatterns
 }
 

--- a/internal/check/generic_check_test.go
+++ b/internal/check/generic_check_test.go
@@ -49,6 +49,9 @@ var _ = Describe("Generic check tests", func() {
 		It("should return the correct helpText", func() {
 			Expect(testCheck.Help().Message).To(Equal("test message"))
 		})
+		It("should return nil for RequiredFilePatterns when constructed with nil", func() {
+			Expect(testCheck.RequiredFilePatterns()).To(BeNil())
+		})
 		It("should execute the validator successfully", func() {
 			result, err := testCheck.Validate(context.TODO(), imgRef)
 			Expect(err).ToNot(HaveOccurred())
@@ -69,6 +72,19 @@ var _ = Describe("Generic check tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
+		})
+	})
+	When("A generic check is created with RequiredFilePatterns", func() {
+		It("should return the provided patterns", func() {
+			patterns := []string{"/manifests/*", "/metadata/*"}
+			checkWithPatterns := NewGenericCheck(
+				"testname",
+				validatorFn,
+				metadata,
+				helpText,
+				patterns,
+			)
+			Expect(checkWithPatterns.RequiredFilePatterns()).To(Equal(patterns))
 		})
 	})
 })

--- a/internal/policy/container/base_on_ubi.go
+++ b/internal/policy/container/base_on_ubi.go
@@ -93,6 +93,5 @@ func (p *BasedOnUBICheck) Help() check.HelpText {
 }
 
 func (p *BasedOnUBICheck) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return nil
 }

--- a/internal/policy/container/base_on_ubi_test.go
+++ b/internal/policy/container/base_on_ubi_test.go
@@ -95,5 +95,9 @@ var _ = Describe("BaseOnUBI", func() {
 		})
 
 		AssertMetaData(&basedOnUbiCheck)
+
+		It("should return nil for RequiredFilePatterns", func() {
+			Expect(basedOnUbiCheck.RequiredFilePatterns()).To(BeNil())
+		})
 	})
 })

--- a/internal/policy/container/has_prohibited_container_name.go
+++ b/internal/policy/container/has_prohibited_container_name.go
@@ -67,6 +67,5 @@ func (p HasProhibitedContainerName) Help() check.HelpText {
 }
 
 func (p HasProhibitedContainerName) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return nil
 }

--- a/internal/policy/container/has_prohibited_container_name_test.go
+++ b/internal/policy/container/has_prohibited_container_name_test.go
@@ -63,4 +63,8 @@ var _ = Describe("HasProhibitedContainerName", func() {
 	})
 
 	AssertMetaData(&hasProhibitedContainerName)
+
+	It("should return nil for RequiredFilePatterns", func() {
+		Expect(hasProhibitedContainerName.RequiredFilePatterns()).To(BeNil())
+	})
 })

--- a/internal/policy/container/has_required_labels.go
+++ b/internal/policy/container/has_required_labels.go
@@ -68,6 +68,5 @@ func (p *HasRequiredLabelsCheck) Help() check.HelpText {
 }
 
 func (p *HasRequiredLabelsCheck) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return nil
 }

--- a/internal/policy/container/has_required_labels_test.go
+++ b/internal/policy/container/has_required_labels_test.go
@@ -82,4 +82,8 @@ var _ = Describe("HasRequiredLabels", func() {
 	})
 
 	AssertMetaData(&hasRequiredLabelsCheck)
+
+	It("should return nil for RequiredFilePatterns", func() {
+		Expect(hasRequiredLabelsCheck.RequiredFilePatterns()).To(BeNil())
+	})
 })

--- a/internal/policy/container/has_unique_tag.go
+++ b/internal/policy/container/has_unique_tag.go
@@ -141,6 +141,5 @@ func (p *hasUniqueTagCheck) Help() check.HelpText {
 }
 
 func (p *hasUniqueTagCheck) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return nil
 }

--- a/internal/policy/container/has_unique_tag_test.go
+++ b/internal/policy/container/has_unique_tag_test.go
@@ -123,6 +123,10 @@ var _ = Describe("UniqueTag", func() {
 	})
 
 	AssertMetaData(&hasUniqueTagCheck)
+
+	It("should return nil for RequiredFilePatterns", func() {
+		Expect(hasUniqueTagCheck.RequiredFilePatterns()).To(BeNil())
+	})
 })
 
 func emptyImageTags() []string {

--- a/internal/policy/operator/certified_images.go
+++ b/internal/policy/operator/certified_images.go
@@ -129,6 +129,5 @@ func (p *certifiedImagesCheck) Help() check.HelpText {
 }
 
 func (p *certifiedImagesCheck) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return []string{"/manifests/*"}
 }

--- a/internal/policy/operator/certified_images_test.go
+++ b/internal/policy/operator/certified_images_test.go
@@ -242,4 +242,8 @@ spec:
 		})
 	})
 	AssertMetaData(certifiedImagesCheck)
+
+	It("should return the expected RequiredFilePatterns", func() {
+		Expect(certifiedImagesCheck.RequiredFilePatterns()).To(Equal([]string{"/manifests/*"}))
+	})
 })

--- a/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/internal/policy/operator/scorecard_basic_check_spec.go
@@ -79,6 +79,5 @@ func (p *ScorecardBasicSpecCheck) Help() check.HelpText {
 }
 
 func (p *ScorecardBasicSpecCheck) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return bundle.BundleFiles
 }

--- a/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
 
@@ -86,6 +87,10 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	})
 
 	AssertMetaData(&scorecardBasicCheck)
+
+	It("should return the expected RequiredFilePatterns", func() {
+		Expect(scorecardBasicCheck.RequiredFilePatterns()).To(Equal(bundle.BundleFiles))
+	})
 
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard Basic Check has a pass", func() {

--- a/internal/policy/operator/scorecard_olm_suite.go
+++ b/internal/policy/operator/scorecard_olm_suite.go
@@ -79,6 +79,5 @@ func (p *ScorecardOlmSuiteCheck) Help() check.HelpText {
 }
 
 func (p *ScorecardOlmSuiteCheck) RequiredFilePatterns() []string {
-	//coverage:ignore
 	return bundle.BundleFiles
 }

--- a/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/internal/policy/operator/scorecard_olm_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
 
@@ -86,6 +87,10 @@ var _ = Describe("ScorecardBasicCheck", func() {
 	})
 
 	AssertMetaData(&scorecardOlmSuiteCheck)
+
+	It("should return the expected RequiredFilePatterns", func() {
+		Expect(scorecardOlmSuiteCheck.RequiredFilePatterns()).To(Equal(bundle.BundleFiles))
+	})
 
 	Describe("Operator Bundle Scorecard", func() {
 		Context("When Operator Bundle Scorecard OLM Suite Check has a pass", func() {


### PR DESCRIPTION
## Summary

Remove `//coverage:ignore` comments from all `RequiredFilePatterns()` methods and add unit tests to cover each accessor, making the coverage report honest without exclusion annotations.

## Changes

### Source files (8) — removed `//coverage:ignore` from `RequiredFilePatterns()`:
- `internal/check/generic_check.go`
- `internal/policy/container/base_on_ubi.go`
- `internal/policy/container/has_unique_tag.go`
- `internal/policy/container/has_required_labels.go`
- `internal/policy/container/has_prohibited_container_name.go`
- `internal/policy/operator/certified_images.go`
- `internal/policy/operator/scorecard_basic_check_spec.go`
- `internal/policy/operator/scorecard_olm_suite.go`

### Test files (8) — added `RequiredFilePatterns()` assertions:
- Container checks: assert returns `nil`
- `certifiedImagesCheck`: assert returns `[]string{"/manifests/*"}`
- Scorecard checks: assert returns `bundle.BundleFiles`
- `genericCheckDefinition`: assert round-trips both `nil` and provided patterns

## Validation
- All tests pass across `internal/check/`, `internal/policy/container/`, `internal/policy/operator/`
- `make lint` — 0 issues
- `make fmt` — clean

Closes #1404