### PR TITLE
check: remove coverage exclusions from constructors, wrappers, and option returns

### DIFF
--- a/container/check_container.go
+++ b/container/check_container.go
@@ -173,7 +173,6 @@ func WithCertificationProject(id, token string) Option {
 // An example might be the Scratch or Privileged flags on a project allowing for
 // the corresponding policy to be executed.
 func WithCertificationComponent(id, token string) Option {
-	//coverage:ignore
 	return withCertificationComponent(id, token)
 }
 

--- a/container/check_container_test.go
+++ b/container/check_container_test.go
@@ -45,6 +45,15 @@ var _ = Describe("Container Check initialization", func() {
 			Expect(c.insecure).To(Equal(insecure))
 			Expect(c.konflux).To(Equal(konflux))
 		})
+		Context("with the WithCertificationComponent option", func() {
+			It("should set the project ID and token", func() {
+				c := NewCheck("placeholder",
+					WithCertificationComponent("mycomponent", "mytoken"),
+				)
+				Expect(c.certificationProjectID).To(Equal("mycomponent"))
+				Expect(c.pyxisToken).To(Equal("mytoken"))
+			})
+		})
 		Context("with the pyxisenv option", func() {
 			var env string
 			It("should resolve the env if valid", func() {

--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -1,4 +1,3 @@
-//coverage:ignore file
 package option
 
 import (
@@ -60,15 +59,12 @@ func GenerateCraneOptions(ctx context.Context, craneConfig CraneConfig) []crane.
 		options = append(options, crane.Insecure, crane.WithTransport(rt))
 	}
 
-	//coverage:ignore
 	return options
 }
 
 // RetryOnceAfter is a crane option that retries once after t duration.
 func RetryOnceAfter(t time.Duration) crane.Option {
-	//coverage:ignore
 	return func(o *crane.Options) {
-		//coverage:ignore
 		o.Remote = append(o.Remote, remote.WithRetryBackoff(remote.Backoff{
 			Duration: t,
 			Factor:   1.0,

--- a/internal/option/option_suite_test.go
+++ b/internal/option/option_suite_test.go
@@ -1,0 +1,13 @@
+package option
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOption(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Option Suite")
+}

--- a/internal/option/option_test.go
+++ b/internal/option/option_test.go
@@ -1,0 +1,26 @@
+package option
+
+import (
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Option", func() {
+	Describe("RetryOnceAfter", func() {
+		It("should return a non-nil crane.Option", func() {
+			opt := RetryOnceAfter(5 * time.Second)
+			Expect(opt).ToNot(BeNil())
+		})
+
+		It("should apply remote options to crane.Options when called", func() {
+			opt := RetryOnceAfter(5 * time.Second)
+			o := &crane.Options{}
+			opt(o)
+			Expect(o.Remote).ToNot(BeEmpty())
+		})
+	})
+})

--- a/internal/policy/container/base_on_ubi.go
+++ b/internal/policy/container/base_on_ubi.go
@@ -23,7 +23,6 @@ type layerHashChecker interface {
 }
 
 func NewBasedOnUbiCheck(layerHashChecker layerHashChecker) *BasedOnUBICheck {
-	//coverage:ignore
 	return &BasedOnUBICheck{LayerHashCheckEngine: layerHashChecker}
 }
 

--- a/internal/policy/container/base_on_ubi_test.go
+++ b/internal/policy/container/base_on_ubi_test.go
@@ -96,4 +96,13 @@ var _ = Describe("BaseOnUBI", func() {
 
 		AssertMetaData(&basedOnUbiCheck)
 	})
+
+	Describe("NewBasedOnUbiCheck", func() {
+		It("should return a non-nil check with the engine wired correctly", func() {
+			engine := &fakeLayerHashChecker{}
+			chk := NewBasedOnUbiCheck(engine)
+			Expect(chk).ToNot(BeNil())
+			Expect(chk.LayerHashCheckEngine).To(Equal(engine))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Remove `//coverage:ignore` annotations from trivially testable constructors, wrappers, and return statements, and add corresponding unit tests.

## Changes

### Source files
- **`internal/policy/container/base_on_ubi.go`** — Remove coverage exclusion from `NewBasedOnUbiCheck` constructor
- **`container/check_container.go`** — Remove coverage exclusion from `WithCertificationComponent` wrapper
- **`internal/option/option.go`** — Remove file-level `//coverage:ignore file` directive and per-line exclusions from `GenerateCraneOptions` return, `RetryOnceAfter` function, and its closure body

### Test files
- **`internal/policy/container/base_on_ubi_test.go`** — Verify constructor returns non-nil check with `LayerHashCheckEngine` wired correctly
- **`container/check_container_test.go`** — Verify `WithCertificationComponent` sets `certificationProjectID` and `pyxisToken`
- **`internal/option/option_suite_test.go`** (new) — Ginkgo suite bootstrap for option package
- **`internal/option/option_test.go`** (new) — Verify `RetryOnceAfter` returns non-nil `crane.Option` and appends remote options

## Verification
- All affected package tests pass
- `make lint` — 0 issues
- `make fmt` — clean

Refs: #1405