### PR TITLE
cmd: add test for operator pull request URL validation in support command

### DIFF
--- a/cmd/preflight/cmd/support.go
+++ b/cmd/preflight/cmd/support.go
@@ -94,7 +94,6 @@ func (g *supportTextGenerator) validate() error {
 
 	if g.ProjectType == "operator" {
 		if len(g.PullRequestURL) == 0 {
-			//coverage:ignore
 			return errors.New("a pull request URL is required for operator project support requests")
 		}
 

--- a/cmd/preflight/cmd/support_test.go
+++ b/cmd/preflight/cmd/support_test.go
@@ -16,6 +16,13 @@ var _ = Describe("support command tests", func() {
 			})
 		})
 	})
+	Context("When creating a support text generator for an operator project", func() {
+		It("should return an error when the pull request URL is empty", func() {
+			_, err := newSupportTextGenerator("operator", "000011112222", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("a pull request URL is required for operator project support requests"))
+		})
+	})
 	Context("When validating a pull request URL", func() {
 		urlNoScheme := "example.com"
 		urlNoHost := "https:///foo"


### PR DESCRIPTION
## Summary

Remove `//coverage:ignore` from the empty `PullRequestURL` validation branch in `supportTextGenerator.validate()` and add a corresponding unit test.

## Changes

### Source
- **`cmd/preflight/cmd/support.go`** — Remove `//coverage:ignore` from the `len(g.PullRequestURL) == 0` branch (line 97)

### Test
- **`cmd/preflight/cmd/support_test.go`** — Add test that calls `newSupportTextGenerator("operator", "000011112222", "")` and asserts the expected error message

## Verification
- All CMD suite tests pass (90 specs)
- `make lint` — 0 issues
- `make fmt` — clean

Refs: #1406