### PR TITLE
check: remove coverage exclusions from error-return paths in container policy checks

### DIFF
--- a/internal/policy/container/has_prohibited_container_name.go
+++ b/internal/policy/container/has_prohibited_container_name.go
@@ -34,7 +34,6 @@ func (p HasProhibitedContainerName) validate(ctx context.Context, containerName 
 
 	result, err := violatesRedHatTrademark(containerName)
 	if err != nil {
-		//coverage:ignore
 		return false, fmt.Errorf("error while validating container name: %w", err)
 	}
 

--- a/internal/policy/container/has_prohibited_container_name_test.go
+++ b/internal/policy/container/has_prohibited_container_name_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/ginkgo/v2"
@@ -57,6 +58,26 @@ var _ = Describe("HasProhibitedContainerName", func() {
 			It("should not pass Validate", func() {
 				ok, err := hasProhibitedContainerName.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When violatesRedHatTrademark returns an error", func() {
+			var origValidator func(string) (bool, error)
+			BeforeEach(func() {
+				origValidator = violatesRedHatTrademark
+				violatesRedHatTrademark = func(_ string) (bool, error) {
+					return false, errors.New("trademark error")
+				}
+				imageRef.ImageRepository = "opdev/simple-demo-operator"
+			})
+			AfterEach(func() {
+				violatesRedHatTrademark = origValidator
+			})
+			It("should return an error", func() {
+				ok, err := hasProhibitedContainerName.Validate(context.TODO(), imageRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("error while validating container name"))
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/internal/policy/container/has_prohibited_labels.go
+++ b/internal/policy/container/has_prohibited_labels.go
@@ -20,7 +20,6 @@ type HasNoProhibitedLabelsCheck struct{}
 func (p *HasNoProhibitedLabelsCheck) Validate(ctx context.Context, imgRef image.ImageReference) (result bool, err error) {
 	labels, err := getContainerLabels(imgRef.ImageInfo)
 	if err != nil {
-		//coverage:ignore
 		return false, fmt.Errorf("could not retrieve image labels: %v", err)
 	}
 
@@ -34,7 +33,6 @@ func (p *HasNoProhibitedLabelsCheck) validate(ctx context.Context, labels map[st
 	for _, label := range trademarkLabels {
 		result, err := violatesRedHatTrademark(labels[label])
 		if err != nil {
-			//coverage:ignore
 			return false, fmt.Errorf("error while validating label: %w", err)
 		}
 

--- a/internal/policy/container/has_prohibited_labels_test.go
+++ b/internal/policy/container/has_prohibited_labels_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
@@ -72,6 +73,41 @@ var _ = Describe("HasNoProhibitedLabelsCheck", func() {
 			It("should not pass Validate", func() {
 				ok, err := hasProhibitedLabelsCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When ConfigFile returns an error", func() {
+			BeforeEach(func() {
+				fakeImage := fakecranev1.FakeImage{
+					ConfigFileStub: func() (*cranev1.ConfigFile, error) {
+						return &cranev1.ConfigFile{}, errors.New("config error")
+					},
+				}
+				imageRef.ImageInfo = &fakeImage
+			})
+			It("should return an error", func() {
+				ok, err := hasProhibitedLabelsCheck.Validate(context.TODO(), imageRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not retrieve image labels"))
+				Expect(ok).To(BeFalse())
+			})
+		})
+		Context("When violatesRedHatTrademark returns an error", func() {
+			var origValidator func(string) (bool, error)
+			BeforeEach(func() {
+				origValidator = violatesRedHatTrademark
+				violatesRedHatTrademark = func(_ string) (bool, error) {
+					return false, errors.New("trademark error")
+				}
+			})
+			AfterEach(func() {
+				violatesRedHatTrademark = origValidator
+			})
+			It("should return an error", func() {
+				ok, err := hasProhibitedLabelsCheck.Validate(context.TODO(), imageRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("error while validating label"))
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/internal/policy/container/has_required_labels.go
+++ b/internal/policy/container/has_required_labels.go
@@ -22,7 +22,6 @@ type HasRequiredLabelsCheck struct{}
 func (p *HasRequiredLabelsCheck) Validate(ctx context.Context, imgRef image.ImageReference) (bool, error) {
 	labels, err := getContainerLabels(imgRef.ImageInfo)
 	if err != nil {
-		//coverage:ignore
 		return false, fmt.Errorf("could not retrieve image labels: %v", err)
 	}
 

--- a/internal/policy/container/has_required_labels_test.go
+++ b/internal/policy/container/has_required_labels_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
@@ -76,6 +77,23 @@ var _ = Describe("HasRequiredLabels", func() {
 			It("should not succeed the check", func() {
 				ok, err := hasRequiredLabelsCheck.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When ConfigFile returns an error", func() {
+			BeforeEach(func() {
+				fakeImage := fakecranev1.FakeImage{
+					ConfigFileStub: func() (*cranev1.ConfigFile, error) {
+						return &cranev1.ConfigFile{}, errors.New("config error")
+					},
+				}
+				imageRef.ImageInfo = &fakeImage
+			})
+			It("should return an error", func() {
+				ok, err := hasRequiredLabelsCheck.Validate(context.TODO(), imageRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not retrieve image labels"))
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/internal/policy/container/max_layers.go
+++ b/internal/policy/container/max_layers.go
@@ -24,7 +24,6 @@ type MaxLayersCheck struct{}
 func (p *MaxLayersCheck) Validate(ctx context.Context, imgRef image.ImageReference) (bool, error) {
 	layers, err := p.getDataToValidate(imgRef.ImageInfo)
 	if err != nil {
-		//coverage:ignore
 		return false, fmt.Errorf("could not get image layers: %v", err)
 	}
 

--- a/internal/policy/container/max_layers_test.go
+++ b/internal/policy/container/max_layers_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
@@ -58,6 +59,22 @@ var _ = Describe("LessThanMaxLayers", func() {
 			It("should not succeed the check", func() {
 				ok, err := maxLayersCheck.Validate(context.TODO(), imgRef)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+		Context("When Layers returns an error", func() {
+			BeforeEach(func() {
+				fakeImage := fakecranev1.FakeImage{
+					LayersStub: func() ([]cranev1.Layer, error) {
+						return nil, errors.New("layers error")
+					},
+				}
+				imgRef.ImageInfo = &fakeImage
+			})
+			It("should return an error", func() {
+				ok, err := maxLayersCheck.Validate(context.TODO(), imgRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not get image layers"))
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/internal/policy/container/runs_as_nonroot.go
+++ b/internal/policy/container/runs_as_nonroot.go
@@ -20,8 +20,7 @@ type RunAsNonRootCheck struct{}
 func (p *RunAsNonRootCheck) Validate(ctx context.Context, imgRef image.ImageReference) (bool, error) {
 	user, err := p.getDataToValidate(imgRef.ImageInfo)
 	if err != nil {
-		//coverage:ignore
-		return false, fmt.Errorf("could not get validation data: %v", err)
+		return false, fmt.Errorf("could not get validation data: %w", err)
 	}
 
 	return p.validate(ctx, user)
@@ -30,7 +29,6 @@ func (p *RunAsNonRootCheck) Validate(ctx context.Context, imgRef image.ImageRefe
 func (p *RunAsNonRootCheck) getDataToValidate(image cranev1.Image) (string, error) {
 	configFile, err := image.ConfigFile()
 	if err != nil {
-		//coverage:ignore
 		return "", fmt.Errorf("could not retrieve ConfigFile from Image: %w", err)
 	}
 	return configFile.Config.User, nil

--- a/internal/policy/container/runs_as_nonroot_test.go
+++ b/internal/policy/container/runs_as_nonroot_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
@@ -94,6 +95,23 @@ var _ = Describe("RunAsNonRoot", func() {
 			It("should not pass Validate", func() {
 				ok, err := runAsNonRoot.Validate(context.TODO(), imageRef)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When ConfigFile returns an error", func() {
+			BeforeEach(func() {
+				fakeImage := fakecranev1.FakeImage{
+					ConfigFileStub: func() (*cranev1.ConfigFile, error) {
+						return nil, errors.New("config error")
+					},
+				}
+				imageRef.ImageInfo = &fakeImage
+			})
+			It("should return an error", func() {
+				ok, err := runAsNonRoot.Validate(context.TODO(), imageRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not get validation data"))
 				Expect(ok).To(BeFalse())
 			})
 		})

--- a/internal/policy/container/trademark_validator.go
+++ b/internal/policy/container/trademark_validator.go
@@ -7,7 +7,7 @@ import (
 )
 
 // violatesRedHatTrademark validates if a string meets specific "Red Hat" naming criteria
-func violatesRedHatTrademark(s string) (bool, error) {
+var violatesRedHatTrademark = func(s string) (bool, error) {
 	// string starts with Red Hat variant
 	startingWithRedHatRegexp, err := regexp.Compile("^[^a-z0-9]*red[^a-z0-9]*hat")
 	if err != nil {


### PR DESCRIPTION
Remove `//coverage:ignore` annotations from error-return paths in container policy checks and add unit tests covering those paths.

**Changes:**
- Remove coverage exclusions from `max_layers.go`, `has_required_labels.go`, `runs_as_nonroot.go`, `has_prohibited_labels.go`, `has_prohibited_container_name.go`
- Fix `%v` to `%w` error wrapping in `runs_as_nonroot.go`
- Make `violatesRedHatTrademark` injectable for testing
- Add error-path tests for ConfigFile failures and trademark validation errors

Refs: #1407