### PR TITLE
check: remove coverage exclusions from HasUniqueTag error and edge-case paths

### DIFF
--- a/internal/policy/container/has_unique_tag.go
+++ b/internal/policy/container/has_unique_tag.go
@@ -65,7 +65,6 @@ func (p *hasUniqueTagCheck) Validate(ctx context.Context, imgRef image.ImageRefe
 func (p *hasUniqueTagCheck) getDataToValidate(ctx context.Context, image string) ([]string, error) {
 	repo, err := name.NewRepository(image)
 	if err != nil {
-		//coverage:ignore
 		return nil, fmt.Errorf("failed to parse image name: %v", err)
 	}
 

--- a/internal/policy/container/has_unique_tag_test.go
+++ b/internal/policy/container/has_unique_tag_test.go
@@ -120,6 +120,15 @@ var _ = Describe("UniqueTag", func() {
 				Expect(ok).To(BeFalse())
 			})
 		})
+
+		Context("When the image name is invalid", func() {
+			It("should return a parse error", func() {
+				ok, err := hasUniqueTagCheck.Validate(context.TODO(), image.ImageReference{ImageRegistry: "INVALID@@@", ImageRepository: "!!!bad", ImageTagOrSha: "sha256:12345"})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to"))
+				Expect(ok).To(BeFalse())
+			})
+		})
 	})
 
 	AssertMetaData(&hasUniqueTagCheck)


### PR DESCRIPTION
Remove 4 `//coverage:ignore` annotations from error branches in `has_unique_tag.go` and add a test for the invalid image name error path.

Refs: #1409