### PR TITLE
check: add test for scorecard empty-results warning

### DIFF
--- a/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -109,6 +109,25 @@ var _ = Describe("ScorecardBasicCheck", func() {
 			})
 		})
 	})
+	Describe("When Operator Bundle Scorecard returns empty items", func() {
+		BeforeEach(func() {
+			fakeEngine = FakeOperatorSdk{
+				OperatorSdkReport: operatorsdk.OperatorSdkScorecardReport{
+					Stdout: "",
+					Stderr: "",
+					Items:  []operatorsdk.OperatorSdkScorecardItem{},
+				},
+			}
+			scorecardBasicCheck = *NewScorecardBasicSpecCheck(fakeEngine, "myns", "mysa", []byte("fake kubeconfig contents"), "20")
+		})
+		Context("When scorecard output has no test results", func() {
+			It("Should pass Validate and not return an error", func() {
+				ok, err := scorecardBasicCheck.Validate(testcontext, image.ImageReference{ImageURI: "dummy/image"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+	})
 	Describe("Checking that OperatorSdk errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdk{}

--- a/internal/policy/operator/scorecard_check.go
+++ b/internal/policy/operator/scorecard_check.go
@@ -27,7 +27,6 @@ func (p *scorecardCheck) validate(ctx context.Context, items []operatorsdk.Opera
 	var err error
 
 	if len(items) == 0 {
-		//coverage:ignore
 		logger.Info("warning: did not receive any test result information from scorecard output")
 	}
 	for _, item := range items {


### PR DESCRIPTION
Remove `//coverage:ignore` from the empty scorecard results warning path in `scorecard_check.go` and add a test exercising the empty-items branch.

Refs: #1410