### PR TITLE
check: add tests for scorecard check Help() fatal error branches

### DIFF
--- a/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/internal/policy/operator/scorecard_basic_check_spec.go
@@ -65,7 +65,6 @@ func (p *ScorecardBasicSpecCheck) Metadata() check.Metadata {
 
 func (p *ScorecardBasicSpecCheck) Help() check.HelpText {
 	if p.fatalError {
-		//coverage:ignore
 		return check.HelpText{
 			Message: "There was a fatal error while running operator-sdk scorecard tests. " +
 				"Please see the preflight log for details. If necessary, set logging to be more verbose.",

--- a/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -133,6 +133,16 @@ var _ = Describe("ScorecardBasicCheck", func() {
 			})
 		})
 	})
+	Describe("Help", func() {
+		Context("When fatalError is true", func() {
+			It("should return fatal error help text", func() {
+				scorecardBasicCheck.fatalError = true
+				help := scorecardBasicCheck.Help()
+				Expect(help.Message).To(ContainSubstring("fatal error"))
+				Expect(help.Suggestion).To(ContainSubstring("wait time"))
+			})
+		})
+	})
 	Describe("Checking that OperatorSdk errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdk{}

--- a/internal/policy/operator/scorecard_olm_suite.go
+++ b/internal/policy/operator/scorecard_olm_suite.go
@@ -65,7 +65,6 @@ func (p *ScorecardOlmSuiteCheck) Metadata() check.Metadata {
 
 func (p *ScorecardOlmSuiteCheck) Help() check.HelpText {
 	if p.fatalError {
-		//coverage:ignore
 		return check.HelpText{
 			Message: "There was a fatal error while running operator-sdk scorecard tests. " +
 				"Please see the preflight log for details. If necessary, set logging to be more verbose.",

--- a/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/internal/policy/operator/scorecard_olm_suite_test.go
@@ -114,6 +114,16 @@ var _ = Describe("ScorecardBasicCheck", func() {
 			})
 		})
 	})
+	Describe("Help", func() {
+		Context("When fatalError is true", func() {
+			It("should return fatal error help text", func() {
+				scorecardOlmSuiteCheck.fatalError = true
+				help := scorecardOlmSuiteCheck.Help()
+				Expect(help.Message).To(ContainSubstring("fatal error"))
+				Expect(help.Suggestion).To(ContainSubstring("wait time"))
+			})
+		})
+	})
 	Describe("Checking that OperatorSdk errors are handled correctly", func() {
 		BeforeEach(func() {
 			fakeEngine = BadOperatorSdk{}


### PR DESCRIPTION
Remove `//coverage:ignore` from fatal error branches in `Help()` for both `ScorecardBasicSpecCheck` and `ScorecardOlmSuiteCheck`, and add tests asserting the fatal help text.

Refs: #1411