### PR TITLE
pyxis: add tests for certificationInputBuilder.finalize() nil-guard validation

### DIFF
--- a/internal/pyxis/builder.go
+++ b/internal/pyxis/builder.go
@@ -47,11 +47,9 @@ func NewCertificationInput(ctx context.Context, project *CertProject, opts ...Ce
 func (b *certificationInputBuilder) finalize() (*CertificationInput, error) {
 	// safeguards, make sure things aren't nil for any reason.
 	if b.CertImage == nil {
-		//coverage:ignore
 		return nil, fmt.Errorf("a CertImage was not provided and is required")
 	}
 	if b.TestResults == nil {
-		//coverage:ignore
 		return nil, fmt.Errorf("test results were not provided and are required")
 	}
 

--- a/internal/pyxis/builder_test.go
+++ b/internal/pyxis/builder_test.go
@@ -29,6 +29,40 @@ var _ = Describe("Pyxis Builder tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	Context("When calling finalize on a certificationInputBuilder", func() {
+		Context("with a nil CertImage", func() {
+			It("should return an error", func() {
+				b := &certificationInputBuilder{
+					CertificationInput: CertificationInput{
+						CertProject: &CertProject{},
+						TestResults: &TestResults{},
+						CertImage:   nil,
+						RpmManifest: &RPMManifest{},
+					},
+				}
+				_, err := b.finalize()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("CertImage was not provided"))
+			})
+		})
+
+		Context("with a nil TestResults", func() {
+			It("should return an error", func() {
+				b := &certificationInputBuilder{
+					CertificationInput: CertificationInput{
+						CertProject: &CertProject{},
+						TestResults: nil,
+						CertImage:   &CertImage{},
+						RpmManifest: &RPMManifest{},
+					},
+				}
+				_, err := b.finalize()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("test results were not provided"))
+			})
+		})
+	})
+
 	Context("When preparing a new input builder", func() {
 		Context("with a nil CertProject value", func() {
 			It("should return an error", func() {


### PR DESCRIPTION
Remove `//coverage:ignore` from nil-guard checks in `finalize()` and add tests for nil `CertImage` and nil `TestResults` cases.

Refs: #1412