### PR TITLE
runtime: add test for ResultWriterFile.OpenFile error path

### DIFF
--- a/internal/runtime/result_writer.go
+++ b/internal/runtime/result_writer.go
@@ -17,7 +17,6 @@ func (f *ResultWriterFile) OpenFile(name string) (io.WriteCloser, error) {
 		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 		0o600)
 	if err != nil {
-		//coverage:ignore
 		return nil, err
 	}
 

--- a/internal/runtime/result_writer_test.go
+++ b/internal/runtime/result_writer_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"os"
 	"path"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,15 @@ var _ = Describe("Result Writers", func() {
 
 		BeforeEach(func() {
 			rw = &ResultWriterFile{}
+		})
+
+		Context("When OpenFile fails due to a non-existent directory", func() {
+			It("should return nil and an error", func() {
+				p := filepath.Join(resultWriterTestDir, "nonexistent", "subdir", "foo.txt")
+				f, err := rw.OpenFile(p)
+				Expect(err).To(HaveOccurred())
+				Expect(f).To(BeNil())
+			})
 		})
 
 		Context("When using the file-based result writer", func() {


### PR DESCRIPTION
Remove `//coverage:ignore` from the `OpenFile` error path in `result_writer.go` and add a test triggering the error with a non-existent directory.

Refs: #1413