### PR TITLE
authn: remove coverage exclusions from keychain auth-file error and anonymous fallback paths

### DIFF
--- a/internal/authn/keychain.go
+++ b/internal/authn/keychain.go
@@ -73,11 +73,9 @@ func (k *preflightKeychain) Resolve(target craneauthn.Resource) (craneauthn.Auth
 
 	r, err := os.Open(k.dockercfg)
 	if os.IsNotExist(err) {
-		//coverage:ignore
 		return nil, fmt.Errorf("could not find authfile: %s: %w", k.dockercfg, err)
 	}
 	if err != nil {
-		//coverage:ignore
 		return nil, fmt.Errorf("could not open authfile: %s: %v", k.dockercfg, err)
 	}
 
@@ -119,7 +117,6 @@ func (k *preflightKeychain) Resolve(target craneauthn.Resource) (craneauthn.Auth
 		}
 	}
 	if cfg == empty {
-		//coverage:ignore
 		return craneauthn.Anonymous, nil
 	}
 

--- a/internal/authn/keychain_test.go
+++ b/internal/authn/keychain_test.go
@@ -17,10 +17,12 @@ package authn
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	craneauthn "github.com/google/go-containerregistry/pkg/authn"
@@ -69,6 +71,67 @@ func setupConfigFile(t *testing.T, content string) string {
 
 	// return the config dir so we can clean up
 	return cd
+}
+
+func TestAuthfileNotExist(t *testing.T) {
+	origCfg := keychain.dockercfg
+	defer func() { keychain.dockercfg = origCfg }()
+
+	keychain.dockercfg = "/does/not/exist/config.json"
+	keychain.ctx = context.TODO()
+
+	_, err := keychain.Resolve(testRegistry)
+	if err == nil {
+		t.Fatal("expected error for non-existent authfile, got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist in error chain, got: %v", err)
+	}
+}
+
+func TestAuthfileOpenError(t *testing.T) {
+	origCfg := keychain.dockercfg
+	defer func() { keychain.dockercfg = origCfg }()
+
+	// Create a file that cannot be read (permission denied).
+	tmpdir, err := os.MkdirTemp("", "keychain_open_error")
+	if err != nil {
+		t.Fatalf("creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	p := filepath.Join(tmpdir, "config.json")
+	if err := os.WriteFile(p, []byte(`{}`), 0o000); err != nil {
+		t.Fatalf("write %q: %v", p, err)
+	}
+
+	keychain.dockercfg = p
+	keychain.ctx = context.TODO()
+
+	_, err = keychain.Resolve(testRegistry)
+	if err == nil {
+		t.Fatal("expected error for unreadable authfile, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not open authfile") && !strings.Contains(err.Error(), "could not load authfile") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAnonymousFallbackNoMatchingCreds(t *testing.T) {
+	origCfg := keychain.dockercfg
+	defer func() { keychain.dockercfg = origCfg }()
+
+	// Config file has creds for a different registry; target registry should get Anonymous.
+	cd := setupConfigFile(t, fmt.Sprintf(`{"auths": {"other.io": {"auth": %q}}}`, encode("foo", "bar")))
+	defer os.RemoveAll(filepath.Dir(cd))
+
+	auth, err := keychain.Resolve(testRegistry)
+	if err != nil {
+		t.Fatalf("Resolve() = %v", err)
+	}
+	if auth != craneauthn.Anonymous {
+		t.Errorf("expected Anonymous for unmatched registry, got %v", auth)
+	}
 }
 
 func TestNoConfig(t *testing.T) {


### PR DESCRIPTION
Remove `//coverage:ignore` from auth-file error and anonymous fallback paths in `keychain.go` and add 3 tests covering file-not-exist, open-error, and anonymous fallback scenarios.

Refs: #1415