### PR TITLE
bundle: remove per-line coverage exclusions from SCC functions

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -189,52 +189,37 @@ func LoadAnnotations(ctx context.Context, r io.Reader) (*Annotations, error) {
 // GetSecurityContextConstraints returns an string array of SCC resource names requested by the operator as specified
 // in the csv
 func GetSecurityContextConstraints(ctx context.Context, bundlePath string) ([]string, error) {
-	//coverage:ignore
 	bundle, err := manifests.GetBundleFromDir(bundlePath)
 	if err != nil {
-		//coverage:ignore
 		return nil, fmt.Errorf("could not get bundle from dir: %s: %v", bundlePath, err)
 	}
-	//coverage:ignore
 	for _, cp := range bundle.CSV.Spec.InstallStrategy.StrategySpec.ClusterPermissions {
-		//coverage:ignore
 		for _, rule := range cp.Rules {
-			//coverage:ignore
 			if hasSCCApiGroup(rule) && hasSCCResource(rule) {
-				//coverage:ignore
 				return rule.ResourceNames, nil
 			}
 		}
 	}
-	//coverage:ignore
 	return nil, nil
 }
 
 // hasSCCApiGroup returns a bool indicating if security.openshift.io is in the list of apigroups referenced in a policy
 // rule
 func hasSCCApiGroup(rule rbacv1.PolicyRule) bool {
-	//coverage:ignore
 	for _, apiGroup := range rule.APIGroups {
-		//coverage:ignore
 		if apiGroup == "security.openshift.io" {
-			//coverage:ignore
 			return true
 		}
 	}
-	//coverage:ignore
 	return false
 }
 
 // hasSCCResource returns a bool indicating if any securitycontextconstraints resources are referenced in a policy rule
 func hasSCCResource(rule rbacv1.PolicyRule) bool {
-	//coverage:ignore
 	for _, resource := range rule.Resources {
-		//coverage:ignore
 		if resource == "securitycontextconstraints" {
-			//coverage:ignore
 			return true
 		}
 	}
-	//coverage:ignore
 	return false
 }

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 )
 
@@ -85,6 +87,90 @@ var _ = Describe("BundleValidateCheck", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(annotations).To(BeNil())
 				})
+			})
+		})
+	})
+
+	Describe("hasSCCApiGroup", func() {
+		Context("when the rule contains security.openshift.io", func() {
+			It("should return true", func() {
+				rule := rbacv1.PolicyRule{
+					APIGroups: []string{"", "security.openshift.io"},
+				}
+				Expect(hasSCCApiGroup(rule)).To(BeTrue())
+			})
+		})
+
+		Context("when the rule does not contain security.openshift.io", func() {
+			It("should return false", func() {
+				rule := rbacv1.PolicyRule{
+					APIGroups: []string{"apps", ""},
+				}
+				Expect(hasSCCApiGroup(rule)).To(BeFalse())
+			})
+		})
+
+		Context("when the rule has no API groups", func() {
+			It("should return false", func() {
+				rule := rbacv1.PolicyRule{
+					APIGroups: []string{},
+				}
+				Expect(hasSCCApiGroup(rule)).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("hasSCCResource", func() {
+		Context("when the rule contains securitycontextconstraints", func() {
+			It("should return true", func() {
+				rule := rbacv1.PolicyRule{
+					Resources: []string{"pods", "securitycontextconstraints"},
+				}
+				Expect(hasSCCResource(rule)).To(BeTrue())
+			})
+		})
+
+		Context("when the rule does not contain securitycontextconstraints", func() {
+			It("should return false", func() {
+				rule := rbacv1.PolicyRule{
+					Resources: []string{"pods", "deployments"},
+				}
+				Expect(hasSCCResource(rule)).To(BeFalse())
+			})
+		})
+
+		Context("when the rule has no resources", func() {
+			It("should return false", func() {
+				rule := rbacv1.PolicyRule{
+					Resources: []string{},
+				}
+				Expect(hasSCCResource(rule)).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("GetSecurityContextConstraints", func() {
+		Context("when the bundle path is invalid", func() {
+			It("should return an error", func() {
+				sccs, err := GetSecurityContextConstraints(context.TODO(), "/nonexistent/path")
+				Expect(err).To(HaveOccurred())
+				Expect(sccs).To(BeNil())
+			})
+		})
+
+		Context("when the bundle has no SCC rules", func() {
+			It("should return nil", func() {
+				sccs, err := GetSecurityContextConstraints(context.TODO(), "./testdata/valid_bundle")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sccs).To(BeNil())
+			})
+		})
+
+		Context("when the bundle has SCC rules", func() {
+			It("should return the SCC resource names", func() {
+				sccs, err := GetSecurityContextConstraints(context.TODO(), "./testdata/scc_bundle")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sccs).To(ConsistOf("my-scc", "another-scc"))
 			})
 		})
 	})

--- a/internal/bundle/testdata/scc_bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/bundle/testdata/scc_bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -1,0 +1,234 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+  name: memcached-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  description: Memcached Operator description. TODO.
+  displayName: Memcached Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - my-scc
+          - another-scc
+          verbs:
+          - use
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cache.example.com
+          resources:
+          - memcacheds
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cache.example.com
+          resources:
+          - memcacheds/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - cache.example.com
+          resources:
+          - memcacheds/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: memcached-operator-controller-manager
+      deployments:
+      - name: memcached-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                image: quay.io/example/memcached-operator:v0.0.1
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 30Mi
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: memcached-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: memcached-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - memcached-operator
+  links:
+  - name: Memcached Operator
+    url: https://memcached-operator.domain
+  maintainers:
+  - email: your@email.com
+    name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
+  version: 0.0.1
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: memcached-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vmemcached.kb.io
+    rules:
+    - apiGroups:
+      - cache.example.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - memcacheds
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-cache-example-com-v1alpha1-memcached
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: memcached-operator-controller-manager
+    failurePolicy: Fail
+    generateName: mmemcached.kb.io
+    rules:
+    - apiGroups:
+      - cache.example.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - memcacheds
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-cache-example-com-v1alpha1-memcached

--- a/internal/bundle/testdata/scc_bundle/metadata/annotations.yaml
+++ b/internal/bundle/testdata/scc_bundle/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  com.redhat.openshift.versions: "v4.6-v4.9"
+  operators.operatorframework.io.bundle.package.v1: testPackage
+  operators.operatorframework.io.bundle.channel.default.v1: testChannel


### PR DESCRIPTION
Remove 15 `//coverage:ignore` annotations from `GetSecurityContextConstraints`, `hasSCCApiGroup`, and `hasSCCResource` in `bundle.go`. Add 6 tests covering positive/negative paths and error handling.

Refs: #1418