### PR TITLE
pyxis: reduce per-line coverage exclusions in createArtifact

### DIFF
--- a/internal/pyxis/pyxis.go
+++ b/internal/pyxis/pyxis.go
@@ -540,7 +540,6 @@ func (p *pyxisClient) updateTestResults(ctx context.Context, testResults *TestRe
 }
 
 func (p *pyxisClient) createArtifact(ctx context.Context, artifact *Artifact) (*Artifact, error) {
-	//coverage:ignore
 	logger := logr.FromContextOrDiscard(ctx)
 
 	b, err := json.Marshal(artifact)
@@ -548,14 +547,12 @@ func (p *pyxisClient) createArtifact(ctx context.Context, artifact *Artifact) (*
 		//coverage:ignore
 		return nil, fmt.Errorf("could not marshal artifact: %w", err)
 	}
-	//coverage:ignore
 	req, err := p.newRequestWithAPIToken(ctx, http.MethodPost, p.getPyxisURL(fmt.Sprintf("projects/certification/id/%s/artifacts", p.ProjectID)), bytes.NewReader(b))
 	if err != nil {
 		//coverage:ignore
 		return nil, fmt.Errorf("could not create new request: %w", err)
 	}
 
-	//coverage:ignore
 	logger.V(log.TRC).Info("pyxis URL", "url", req.URL)
 
 	resp, err := p.Client.Do(req)
@@ -564,7 +561,6 @@ func (p *pyxisClient) createArtifact(ctx context.Context, artifact *Artifact) (*
 		return nil, fmt.Errorf("could not create artifact in pyxis: %w", err)
 	}
 
-	//coverage:ignore
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
@@ -573,7 +569,6 @@ func (p *pyxisClient) createArtifact(ctx context.Context, artifact *Artifact) (*
 		return nil, fmt.Errorf("could not read body: %w", err)
 	}
 
-	//coverage:ignore
 	if ok := checkStatus(resp.StatusCode); !ok {
 		//coverage:ignore
 		return nil, fmt.Errorf(
@@ -582,14 +577,12 @@ func (p *pyxisClient) createArtifact(ctx context.Context, artifact *Artifact) (*
 			string(body))
 	}
 
-	//coverage:ignore
 	var newArtifact Artifact
 	if err := json.Unmarshal(body, &newArtifact); err != nil {
 		//coverage:ignore
 		return nil, fmt.Errorf("could not unmarshal body: %s: %w", string(body), err)
 	}
 
-	//coverage:ignore
 	return &newArtifact, nil
 }
 

--- a/internal/pyxis/pyxis_test.go
+++ b/internal/pyxis/pyxis_test.go
@@ -2,6 +2,8 @@ package pyxis
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -37,6 +39,59 @@ var _ = Describe("Pyxis", func() {
 			AfterEach(func() {
 				pyxisClient.Client = &http.Client{Transport: localRoundTripper{handler: mux}}
 			})
+		})
+	})
+
+	Context("createArtifact", func() {
+		It("should return the created artifact on success", func() {
+			artifactMux := http.NewServeMux()
+			artifactMux.HandleFunc("/api/v1/projects/certification/id/test-project-id/artifacts", func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodPost))
+				defer r.Body.Close()
+				body, err := io.ReadAll(r.Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				var incoming Artifact
+				Expect(json.Unmarshal(body, &incoming)).To(Succeed())
+
+				resp := Artifact{
+					ID:          "artifact-123",
+					CertProject: incoming.CertProject,
+					Content:     incoming.Content,
+					ContentType: incoming.ContentType,
+					FileSize:    incoming.FileSize,
+					Filename:    incoming.Filename,
+					ImageID:     incoming.ImageID,
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				Expect(json.NewEncoder(w).Encode(resp)).To(Succeed())
+			})
+
+			client := NewPyxisClient(
+				"my.pyxis.host/api",
+				"my-spiffy-api-token",
+				"test-project-id",
+				&http.Client{Transport: localRoundTripper{handler: artifactMux}},
+			)
+
+			input := &Artifact{
+				CertProject: "test-project-id",
+				Content:     "dGVzdC1jb250ZW50",
+				ContentType: "application/json",
+				FileSize:    42,
+				Filename:    "test-artifact.json",
+				ImageID:     "image-abc",
+			}
+
+			result, err := client.createArtifact(ctx, input)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.ID).To(Equal("artifact-123"))
+			Expect(result.Filename).To(Equal("test-artifact.json"))
+			Expect(result.CertProject).To(Equal("test-project-id"))
+			Expect(result.FileSize).To(Equal(int64(42)))
 		})
 	})
 })


### PR DESCRIPTION
Remove 7 `//coverage:ignore` annotations from happy-path lines in `createArtifact` (logger init, defer, variable declarations, return). Keep annotations only on the 6 error-return branches. Verified 100% coverage maintained.

Refs: #1419