### PR TITLE
pyxis: remove coverage exclusion from artifact ImageID assignment in submit.go

### DIFF
--- a/internal/pyxis/submit.go
+++ b/internal/pyxis/submit.go
@@ -109,7 +109,6 @@ func (p *pyxisClient) SubmitResults(ctx context.Context, certInput *Certificatio
 	// Create the artifacts in Pyxis.
 	artifacts := certInput.Artifacts
 	for _, artifact := range artifacts {
-		//coverage:ignore
 		artifact.ImageID = certImage.ID
 		if _, err := p.createArtifact(ctx, &artifact); err != nil {
 			//coverage:ignore


### PR DESCRIPTION
Remove stray `//coverage:ignore` from `artifact.ImageID = certImage.ID` assignment. The line is already exercised by existing tests. Verified 100% coverage maintained.

Refs: #1420