### PR TITLE
cmd: remove coverage exclusions from conditional option appending in check_container.go and check_operator.go

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -325,12 +325,10 @@ func generateContainerCheckOptions(cfg *runtime.Config) []container.Option {
 
 	// set auth information if both are present in config.
 	if cfg.PyxisAPIToken != "" && cfg.CertificationComponentID != "" {
-		//coverage:ignore
 		o = append(o, container.WithCertificationComponent(cfg.CertificationComponentID, cfg.PyxisAPIToken))
 	}
 
 	if cfg.Insecure {
-		//coverage:ignore
 		// Do not allow for submission if Insecure is set.
 		// This is a secondary check to be safe.
 		cfg.Submit = false

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
+	goruntime "runtime"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
@@ -19,6 +19,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
+	preruntime "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 
 	"github.com/go-logr/logr"
@@ -285,7 +286,7 @@ var _ = Describe("Check Container Command", func() {
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(os.RemoveAll, tmpDir)
 
-				platformDir := filepath.Join(tmpDir, runtime.GOARCH)
+				platformDir := filepath.Join(tmpDir, goruntime.GOARCH)
 				Expect(os.Mkdir(platformDir, 0o755)).Should(Succeed())
 
 				// creating test files on in the tmpDir so the tar function has files to tar
@@ -315,7 +316,7 @@ var _ = Describe("Check Container Command", func() {
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(os.RemoveAll, tmpDir)
 
-				platformDir := filepath.Join(tmpDir, runtime.GOARCH)
+				platformDir := filepath.Join(tmpDir, goruntime.GOARCH)
 				Expect(os.Mkdir(platformDir, 0o755)).Should(Succeed())
 
 				// creating test files on in the tmpDir so the tar function has files to tar
@@ -446,6 +447,47 @@ var _ = Describe("Check Container Command", func() {
 			info, err := os.Stat(f.Name())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(info.Size()).ToNot(BeZero())
+		})
+	})
+
+	Context("when generating container check options", func() {
+		It("should include the certification component option when PyxisAPIToken and CertificationComponentID are set", func() {
+			cfg := &preruntime.Config{
+				PyxisAPIToken:            "mytoken",
+				CertificationComponentID: "myid",
+			}
+			baseOpts := generateContainerCheckOptions(&preruntime.Config{})
+			opts := generateContainerCheckOptions(cfg)
+			Expect(opts).To(HaveLen(len(baseOpts) + 1))
+		})
+
+		It("should include the insecure option when Insecure is true", func() {
+			cfg := &preruntime.Config{
+				Insecure: true,
+			}
+			baseOpts := generateContainerCheckOptions(&preruntime.Config{})
+			opts := generateContainerCheckOptions(cfg)
+			Expect(opts).To(HaveLen(len(baseOpts) + 1))
+		})
+
+		It("should set Submit to false when Insecure is true", func() {
+			cfg := &preruntime.Config{
+				Insecure: true,
+				Submit:   true,
+			}
+			generateContainerCheckOptions(cfg)
+			Expect(cfg.Submit).To(BeFalse())
+		})
+
+		It("should include both certification component and insecure options when both are set", func() {
+			cfg := &preruntime.Config{
+				PyxisAPIToken:            "mytoken",
+				CertificationComponentID: "myid",
+				Insecure:                 true,
+			}
+			baseOpts := generateContainerCheckOptions(&preruntime.Config{})
+			opts := generateContainerCheckOptions(cfg)
+			Expect(opts).To(HaveLen(len(baseOpts) + 2))
 		})
 	})
 })

--- a/cmd/preflight/cmd/check_operator.go
+++ b/cmd/preflight/cmd/check_operator.go
@@ -177,12 +177,10 @@ func generateOperatorCheckOptions(cfg *runtime.Config) []operator.Option {
 	}
 
 	if cfg.Channel != "" {
-		//coverage:ignore
 		opts = append(opts, operator.WithOperatorChannel(cfg.Channel))
 	}
 
 	if cfg.Insecure {
-		//coverage:ignore
 		opts = append(opts, operator.WithInsecureConnection())
 	}
 

--- a/cmd/preflight/cmd/check_operator_test.go
+++ b/cmd/preflight/cmd/check_operator_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 )
 
@@ -187,6 +188,36 @@ var _ = Describe("Check Operator", func() {
 		It("should succeed when all positional arg constraints and environment constraints are correct", func() {
 			err := checkOperatorPositionalArgs(checkOperatorCmd(mockRunPreflightReturnNil), posArgs)
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("when generating operator check options", func() {
+		It("should include the channel option when Channel is set", func() {
+			cfg := &runtime.Config{
+				Channel: "stable",
+			}
+			baseOpts := generateOperatorCheckOptions(&runtime.Config{})
+			opts := generateOperatorCheckOptions(cfg)
+			Expect(opts).To(HaveLen(len(baseOpts) + 1))
+		})
+
+		It("should include the insecure option when Insecure is true", func() {
+			cfg := &runtime.Config{
+				Insecure: true,
+			}
+			baseOpts := generateOperatorCheckOptions(&runtime.Config{})
+			opts := generateOperatorCheckOptions(cfg)
+			Expect(opts).To(HaveLen(len(baseOpts) + 1))
+		})
+
+		It("should include both channel and insecure options when both are set", func() {
+			cfg := &runtime.Config{
+				Channel:  "stable",
+				Insecure: true,
+			}
+			baseOpts := generateOperatorCheckOptions(&runtime.Config{})
+			opts := generateOperatorCheckOptions(cfg)
+			Expect(opts).To(HaveLen(len(baseOpts) + 2))
 		})
 	})
 })


### PR DESCRIPTION
Remove 4 `//coverage:ignore` annotations from conditional option-appending branches and add 7 unit tests exercising the feature toggles.

**Container tests:** WithCertificationComponent, WithInsecureConnection, Submit override, both combined
**Operator tests:** WithOperatorChannel, WithInsecureConnection, both combined

Refs: #1421