### PR TITLE
operatorsdk: remove coverage exclusions from OperatorSDK default output format

### DIFF
--- a/internal/operatorsdk/operatorsdk.go
+++ b/internal/operatorsdk/operatorsdk.go
@@ -43,7 +43,6 @@ func (o operatorSdk) Scorecard(ctx context.Context, image string, opts OperatorS
 
 	cmdArgs := []string{"scorecard"}
 	if opts.OutputFormat == "" {
-		//coverage:ignore
 		opts.OutputFormat = "json"
 	}
 	cmdArgs = append(cmdArgs, "--output", opts.OutputFormat)

--- a/internal/operatorsdk/operatorsdk_test.go
+++ b/internal/operatorsdk/operatorsdk_test.go
@@ -55,6 +55,17 @@ var _ = Describe("OperatorSdk", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+	When("The Scorecard OutputFormat is empty", func() {
+		It("should default to json and succeed", func() {
+			operatorSdk := New("foo.image", fakeExecCommandSuccess)
+			opts := OperatorSdkScorecardOptions{
+				ResultFile:   "default-format.txt",
+				OutputFormat: "",
+			}
+			_, err := operatorSdk.Scorecard(testcontext, "foo.image", opts)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 	When("The Scorecard result is a failure", func() {
 		It("should fail", func() {
 			operatorSdk := New("foo.image", fakeExecCommandFailure)


### PR DESCRIPTION
Remove `//coverage:ignore` from the `OutputFormat` default-to-json branch and add a test exercising the empty `OutputFormat` path.

Refs: #1423