### PR TITLE
operator: remove coverage exclusion from operatorCheck.resolve() early-return

### DIFF
--- a/operator/check_operator.go
+++ b/operator/check_operator.go
@@ -75,7 +75,6 @@ func (c operatorCheck) Run(ctx context.Context) (certification.Results, error) {
 
 func (c *operatorCheck) resolve(ctx context.Context) error {
 	if c.resolved {
-		//coverage:ignore
 		return nil
 	}
 

--- a/operator/check_operator_test.go
+++ b/operator/check_operator_test.go
@@ -64,6 +64,17 @@ var _ = Describe("Operator Check Execution", func() {
 			Expect(len(chk.checks)).To(Equal(9))
 		})
 
+		It("Should return nil on second resolve (already resolved)", func() {
+			ctx := context.TODO()
+			err := chk.resolve(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(chk.resolved).To(BeTrue())
+
+			// Second call should hit the early-return path
+			err = chk.resolve(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Should list checks without issue", func() {
 			ctx := context.TODO()
 			policy, checks, err := chk.List(ctx)


### PR DESCRIPTION
Remove `//coverage:ignore` from the `if c.resolved { return nil }` early-return path and add a test that calls `resolve()` twice to exercise the already-resolved branch.

Refs: #1424