### PR TITLE
engine: fix globbing inside directory symlinks

### DIFF
--- a/internal/engine/untar.go
+++ b/internal/engine/untar.go
@@ -20,6 +20,60 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 )
 
+// expandLiteralPatternsWithDescendantGlob adds a "path/**" pattern for each pattern that has no
+// glob metacharacters, so a follow-up pass that only lists a symlink's target directory (e.g.
+// usr/share/licenses) still matches nested files in the tarball.
+//
+// Patterns containing `[` are skipped: we treat * ? [ as glob syntax; literal `[` in a path is rare.
+func expandLiteralPatternsWithDescendantGlob(patterns []string) []string {
+	if len(patterns) == 0 {
+		return patterns
+	}
+	out := slices.Clone(patterns)
+	for _, p := range patterns {
+		if p == "" || strings.ContainsAny(p, "*?[") {
+			continue
+		}
+		child := p + "/**"
+		if !slices.Contains(out, child) {
+			out = append(out, child)
+		}
+	}
+	return out
+}
+
+// clearUnresolvedLinkTargetsForExtractedPath removes entries from unresolved when an extracted
+// path satisfies them: either an exact key match, or the longest key that is a strict parent
+// directory prefix of extractedPath (directory symlink targets such as usr/share/licenses).
+func clearUnresolvedLinkTargetsForExtractedPath(unresolved map[string]struct{}, extractedPath string) {
+	var longestKey string
+	for k := range unresolved {
+		if extractedPath == k || strings.HasPrefix(extractedPath, k+"/") {
+			if len(k) > len(longestKey) {
+				longestKey = k
+			}
+		}
+	}
+	if longestKey != "" {
+		delete(unresolved, longestKey)
+	}
+}
+
+// appendSymlinkTargetPatterns appends the resolved symlink target and target/** to filterPatterns
+// when missing, so layer paths under the real directory (e.g. usr/share/licenses/...) match.
+func appendSymlinkTargetPatterns(filterPatterns []string, logger logr.Logger, resolvedTargetName string) []string {
+	nestedGlob := resolvedTargetName + "/**"
+	if !slices.Contains(filterPatterns, resolvedTargetName) {
+		logger.V(log.TRC).Info("adding symlink target path to filter patterns", "target", resolvedTargetName)
+		filterPatterns = append(filterPatterns, resolvedTargetName)
+	}
+	if !slices.Contains(filterPatterns, nestedGlob) {
+		logger.V(log.TRC).Info("adding symlink target descendant glob to filter patterns", "targetGlob", nestedGlob)
+		filterPatterns = append(filterPatterns, nestedGlob)
+	}
+	return filterPatterns
+}
+
 // untar takes a destination path, a container image, and a list of files or match patterns
 // which should be extracted out of the image.
 func untar(ctx context.Context, dst string, img v1.Image, requiredFilePatterns []string) error {
@@ -59,6 +113,7 @@ func untar(ctx context.Context, dst string, img v1.Image, requiredFilePatterns [
 // Uses os.Root to restrict extraction to dst.
 func untarOnce(ctx context.Context, dst string, img v1.Image, filterPatterns []string, state map[string]struct{}) (remaining []string, err error) {
 	logger := logr.FromContextOrDiscard(ctx)
+	filterPatterns = expandLiteralPatternsWithDescendantGlob(filterPatterns)
 	logger.V(log.TRC).Info("extracting from tar stream with filter patterns", "patterns", filterPatterns)
 
 	fs := mutate.Extract(img)
@@ -153,10 +208,8 @@ func untarOnce(ctx context.Context, dst string, img v1.Image, filterPatterns []s
 			filesProcessedInThisPass[header.Name] = struct{}{}
 			state[header.Name] = struct{}{}
 
-			// If the file being processed is the target of a symlink we encountered earlier in
-			// this pass, it will also be in unresolvedLinkTargets. Now that we've found it,
-			// remove it from the list.
-			delete(unresolvedLinkTargets, header.Name)
+			// Drop satisfied unresolved symlink targets (exact path or longest parent-directory key).
+			clearUnresolvedLinkTargetsForExtractedPath(unresolvedLinkTargets, header.Name)
 
 			// manually close here after each file operation; defering would cause each file close
 			// to wait until all operations have completed.
@@ -200,10 +253,7 @@ func untarOnce(ctx context.Context, dst string, img v1.Image, filterPatterns []s
 			filesProcessedInThisPass[header.Name] = struct{}{}
 			state[header.Name] = struct{}{}
 
-			// If the file being processed is the target of a symlink we encountered earlier in
-			// this pass, it will also be in unresolvedLinkTargets. Now that we've found it,
-			// remove it from the list.
-			delete(unresolvedLinkTargets, header.Name)
+			clearUnresolvedLinkTargetsForExtractedPath(unresolvedLinkTargets, header.Name)
 
 			resolvedTargetName := filepath.Clean(filepath.Join(filepath.Dir(header.Name), header.Linkname))
 
@@ -213,12 +263,9 @@ func untarOnce(ctx context.Context, dst string, img v1.Image, filterPatterns []s
 				continue
 			}
 
-			// If the target of the symlink is not already in the list of search patterns,
-			// add it to the list. We might get lucky and encounter it later in this pass.
-			if !slices.Contains(filterPatterns, resolvedTargetName) {
-				logger.V(log.TRC).Info("adding to the filter patterns for the current pass", "target", resolvedTargetName)
-				filterPatterns = append(filterPatterns, resolvedTargetName)
-			}
+			// Add the resolved target and target/** so nested layer paths match (e.g. /licenses ->
+			// /usr/share/licenses with files stored as usr/share/licenses/...).
+			filterPatterns = appendSymlinkTargetPatterns(filterPatterns, logger, resolvedTargetName)
 
 			// Also add the target of this symlink to the list of unresolved link targets,
 			// if not already present. It's possible that we've already passed the target

--- a/internal/engine/untar_test.go
+++ b/internal/engine/untar_test.go
@@ -39,6 +39,72 @@ var _ = Describe("Link Path Resolution", func() {
 	)
 })
 
+var _ = Describe("untar pattern helpers", func() {
+	DescribeTable("expandLiteralPatternsWithDescendantGlob",
+		func(in, want []string) {
+			Expect(expandLiteralPatternsWithDescendantGlob(in)).To(Equal(want))
+		},
+		Entry("nil", nil, nil),
+		Entry("empty", []string{}, []string{}),
+		Entry("literal gets descendant glob", []string{"usr/share/licenses"}, []string{"usr/share/licenses", "usr/share/licenses/**"}),
+		Entry("glob patterns unchanged except clone order", []string{"licenses/**"}, []string{"licenses/**"}),
+		Entry("mixed literals and globs", []string{"a/**", "b"}, []string{"a/**", "b", "b/**"}),
+		Entry("does not duplicate child glob", []string{"x", "x/**"}, []string{"x", "x/**"}),
+		Entry("preserves empty string", []string{"", "y"}, []string{"", "y", "y/**"}),
+	)
+
+	DescribeTable("clearUnresolvedLinkTargetsForExtractedPath",
+		func(initial map[string]struct{}, extracted string, wantKeys []string) {
+			u := mapsCloneKeys(initial)
+			clearUnresolvedLinkTargetsForExtractedPath(u, extracted)
+			keys := mapsKeys(u)
+			slices.Sort(keys)
+			Expect(keys).To(Equal(wantKeys))
+		},
+		Entry("exact match removes key",
+			map[string]struct{}{"a/b": {}},
+			"a/b",
+			[]string{},
+		),
+		Entry("child path removes longest parent prefix",
+			map[string]struct{}{"usr/share/licenses": {}},
+			"usr/share/licenses/pkg/COPYING",
+			[]string{},
+		),
+		Entry("longest prefix wins when multiple match",
+			map[string]struct{}{"usr": {}, "usr/share/licenses": {}},
+			"usr/share/licenses/foo",
+			[]string{"usr"},
+		),
+		Entry("unrelated keys preserved",
+			map[string]struct{}{"other": {}, "usr/share/licenses": {}},
+			"usr/share/licenses/x",
+			[]string{"other"},
+		),
+		Entry("no-op when nothing matches",
+			map[string]struct{}{"only/here": {}},
+			"elsewhere/file",
+			[]string{"only/here"},
+		),
+	)
+})
+
+func mapsCloneKeys(m map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(m))
+	for k := range m {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+func mapsKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 var _ = Describe("Untar Directory Traversal Protection", func() {
 	var tmpDir string
 
@@ -88,6 +154,47 @@ var _ = Describe("Untar Directory Traversal Protection", func() {
 		fileContent, err := os.ReadFile(legitimateFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fileContent).To(Equal(content))
+	})
+
+	It("should extract nested files when /licenses is a symlink to usr/share/licenses (tar paths under usr/share/licenses)", func() {
+		// Mirrors UBI/RHEL images: layer stores license files under usr/share/licenses/... while
+		// /licenses is a symlink to /usr/share/licenses. Nested paths must match after resolving
+		// the symlink target (including follow-up passes when the symlink appears after paths).
+		content := []byte("license text")
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+
+		nestedPath := "usr/share/licenses/demo/LICENSE"
+		err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     nestedPath,
+			Size:     int64(len(content)),
+			Mode:     0o644,
+			Format:   tar.FormatPAX,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = tw.Write(content)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeSymlink,
+			Name:     "licenses",
+			Linkname: "/usr/share/licenses",
+			Mode:     0o777,
+			Format:   tar.FormatPAX,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(tw.Close()).To(Succeed())
+
+		img, err := createImageWithLayer(buf.Bytes())
+		Expect(err).ToNot(HaveOccurred())
+
+		err = untar(context.Background(), tmpDir, img, []string{"licenses/**"})
+		Expect(err).ToNot(HaveOccurred())
+
+		got, err := os.ReadFile(filepath.Join(tmpDir, nestedPath))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(content))
 	})
 
 	It("should extract files in nested subdirectories when pattern ends with /**", func() {


### PR DESCRIPTION
## Context
Checks only pull matching paths out of the image tar (e.g. `licenses/**`). In some images, /licenses is a symlink to /usr/share/licenses, but the tar still lists files as usr/share/licenses/..., not licenses/..., so `licenses/**` never matched those files.

When the extractor followed the symlink, it only added the bare target path (usr/share/licenses) as the next filter. Glob matching treats that as that path only, not everything under it, so usr/share/licenses/pkg/LICENSE did not match and nested license files were never extracted (including on a second pass that still only had the bare path).

## Changes
- After resolving a symlink target, add both usr/share/licenses and `usr/share/licenses/**` so descendants in the tar match.
- At the start of each untarOnce pass, for patterns without glob characters, automatically add `path/**` next to each literal path. That way a follow-up pass whose list is only usr/share/licenses still expands to include `usr/share/licenses/**`.
- When clearing “pending symlink targets”, treat a target like usr/share/licenses as satisfied once any extracted path is that path or under it (longest-prefix match), not only an exact name hit.
- Test cases for the above