### PR TITLE
HasLicense: use resolved FileInfo for license walk entries

### DIFF
--- a/internal/policy/container/has_license.go
+++ b/internal/policy/container/has_license.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
@@ -22,6 +23,42 @@ const (
 )
 
 var errLicensesNotADir = errors.New("licenses is not a directory")
+
+// canonicalMountRoot returns a path comparable to filepath.EvalSymlinks results
+// (e.g. /var/... on macOS resolves to /private/var/...).
+func canonicalMountRoot(mountedPath string) string {
+	c := filepath.Clean(mountedPath)
+	if r, err := filepath.EvalSymlinks(c); err == nil && r != "" {
+		return filepath.Clean(r)
+	}
+	return c
+}
+
+// pathWithinMount reports whether resolved is the mount root or a path strictly
+// beneath it (prefix boundary safe, e.g. /tmp/img does not contain /tmp/image).
+func pathWithinMount(mount, resolved string) bool {
+	mount = filepath.Clean(mount)
+	resolved = filepath.Clean(resolved)
+	if resolved == mount {
+		return true
+	}
+	rel, err := filepath.Rel(mount, resolved)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// resolvedDirEntry wraps a WalkDir DirEntry so Info() returns metadata from
+// os.Stat (the followed target) instead of the symlink's DirEntry metadata.
+type resolvedDirEntry struct {
+	fs.DirEntry
+	fi fs.FileInfo
+}
+
+func (r resolvedDirEntry) Info() (fs.FileInfo, error) {
+	return r.fi, nil
+}
 
 var _ check.Check = &HasLicenseCheck{}
 
@@ -45,6 +82,8 @@ func (p *HasLicenseCheck) Validate(ctx context.Context, imgRef image.ImageRefere
 
 //nolint:unparam // ctx is unused. Keep for future use.
 func (p *HasLicenseCheck) getDataToValidate(ctx context.Context, mountedPath string) ([]fs.DirEntry, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	mountRoot := canonicalMountRoot(mountedPath)
 	fullPath := filepath.Join(mountedPath, licensePath)
 	fileinfo, err := os.Stat(fullPath)
 	if err != nil {
@@ -55,16 +94,34 @@ func (p *HasLicenseCheck) getDataToValidate(ctx context.Context, mountedPath str
 		return nil, fmt.Errorf("%s is not a directory: %w", licensePath, errLicensesNotADir)
 	}
 
+	// WalkDir does not follow a symlink at the root; if /licenses is a symlink to a directory,
+	// Stat above follows it and IsDir is true, but the walk would otherwise treat the symlink
+	// itself as a non-directory "file". Resolve before walking.
+	walkRoot := fullPath
+	if rp, errSy := filepath.EvalSymlinks(fullPath); errSy == nil && rp != "" && pathWithinMount(mountRoot, rp) {
+		walkRoot = rp
+	}
+
 	var files []fs.DirEntry
-	err = filepath.WalkDir(fullPath, func(p string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			//coverage:ignore
 			return err
 		}
-		// Only include regular files, not directories
-		if !d.IsDir() {
-			files = append(files, d)
+		if d.IsDir() {
+			return nil
 		}
+		resolved, errEv := filepath.EvalSymlinks(p)
+		if errEv != nil || resolved == "" || !pathWithinMount(mountRoot, resolved) {
+			logger.V(log.DBG).Info("skipping broken or escaped link", "path", p, "error", errEv)
+			return nil
+		}
+		// Stat the same path we validated (resolved), not p, to avoid a symlink TOCTOU.
+		fi, errSt := os.Stat(resolved)
+		if errSt != nil || !fi.Mode().IsRegular() {
+			return nil
+		}
+		files = append(files, resolvedDirEntry{DirEntry: d, fi: fi})
 		return nil
 	})
 	if err != nil {

--- a/internal/policy/container/has_license_test.go
+++ b/internal/policy/container/has_license_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -122,6 +123,130 @@ var _ = Describe("HasLicense", func() {
 			})
 		})
 
+		Context("When /licenses is a symlink to a directory that contains license files", func() {
+			It("Should pass Validate and count each regular file, not the symlink alone", func() {
+				if runtime.GOOS == "windows" {
+					Skip("symlink fixture not portable on Windows")
+				}
+				tmpDir := setupTmpDir()
+				targetDir := filepath.Join(tmpDir, "licenses-target")
+				Expect(os.Mkdir(targetDir, 0o755)).To(Succeed())
+				licenseNames := []string{validLicense, "second-license.txt", "third-license.txt"}
+				for _, name := range licenseNames {
+					Expect(os.WriteFile(filepath.Join(targetDir, name), []byte("This is a license"), 0o644)).To(Succeed())
+				}
+				Expect(os.Symlink(targetDir, filepath.Join(tmpDir, licenses))).To(Succeed())
+
+				entries, err := hasLicense.getDataToValidate(context.TODO(), tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(len(licenseNames)), "buggy walk counted the /licenses symlink as one file instead of walking the target directory")
+
+				ok, err := hasLicense.Validate(context.TODO(), image.ImageReference{ImageFSPath: tmpDir})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		Context("When a license path is a symlink to an empty regular file", func() {
+			It("Should not pass Validate based on the target file size, not the symlink", func() {
+				if runtime.GOOS == "windows" {
+					Skip("symlink fixture not portable on Windows")
+				}
+				tmpDir := setupTmpDir()
+				createLicenseDir(tmpDir)
+				target := filepath.Join(tmpDir, "empty-target.txt")
+				f, err := os.Create(target)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f.Close()).To(Succeed())
+				Expect(os.Symlink(target, filepath.Join(tmpDir, licenses, validLicense))).To(Succeed())
+
+				ok, err := hasLicense.Validate(context.TODO(), image.ImageReference{ImageFSPath: tmpDir})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When a license path is a symlink to an empty directory", func() {
+			It("Should not pass Validate", func() {
+				if runtime.GOOS == "windows" {
+					Skip("symlink fixture not portable on Windows")
+				}
+				tmpDir := setupTmpDir()
+				emptyTarget := filepath.Join(tmpDir, "empty-license-target")
+				Expect(os.Mkdir(emptyTarget, 0o755)).To(Succeed())
+				Expect(os.Symlink(emptyTarget, filepath.Join(tmpDir, licenses))).To(Succeed())
+
+				entries, err := hasLicense.getDataToValidate(context.TODO(), tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(BeEmpty())
+
+				ok, err := hasLicense.Validate(context.TODO(), image.ImageReference{ImageFSPath: tmpDir})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When a license file is a symlink pointing outside the image root", func() {
+			It("Should not count the external target", func() {
+				if runtime.GOOS == "windows" {
+					Skip("symlink fixture not portable on Windows")
+				}
+				tmpDir := setupTmpDir()
+				createLicenseDir(tmpDir)
+				outside := filepath.Join(tmpDir, "..", "outside-license-"+filepath.Base(tmpDir)+".txt")
+				Expect(os.WriteFile(outside, []byte("This is a license"), 0o644)).To(Succeed())
+				DeferCleanup(func() { _ = os.Remove(outside) })
+				Expect(os.Symlink(outside, filepath.Join(tmpDir, licenses, validLicense))).To(Succeed())
+
+				entries, err := hasLicense.getDataToValidate(context.TODO(), tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(BeEmpty())
+
+				ok, err := hasLicense.Validate(context.TODO(), image.ImageReference{ImageFSPath: tmpDir})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		Context("When a license path is a symlink to a directory containing only directories (no files)", func() {
+			It("Should not pass Validate", func() {
+				if runtime.GOOS == "windows" {
+					Skip("symlink fixture not portable on Windows")
+				}
+				tmpDir := setupTmpDir()
+				createLicenseDir(tmpDir)
+				nestedOnly := filepath.Join(tmpDir, "nested-only-target")
+				Expect(os.MkdirAll(filepath.Join(nestedOnly, "inner", "deep"), 0o755)).To(Succeed())
+				Expect(os.Symlink(nestedOnly, filepath.Join(tmpDir, licenses, "license-link-dirs-only"))).To(Succeed())
+
+				entries, err := hasLicense.getDataToValidate(context.TODO(), tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(BeEmpty())
+
+				ok, err := hasLicense.Validate(context.TODO(), image.ImageReference{ImageFSPath: tmpDir})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+
 		AssertMetaData(&hasLicense)
+	})
+})
+
+var _ = Describe("pathWithinMount", func() {
+	It("returns true when resolved equals the mount root after filepath.Clean", func() {
+		mount := filepath.Join("scratch", "image-root")
+		Expect(pathWithinMount(mount, mount)).To(BeTrue())
+
+		withTrailing := mount + string(filepath.Separator)
+		Expect(pathWithinMount(mount, withTrailing)).To(BeTrue())
+		Expect(pathWithinMount(withTrailing, mount)).To(BeTrue())
+	})
+
+	It("returns false when filepath.Rel cannot relate mount to resolved", func() {
+		// filepath.Rel errors when base is relative and target is absolute (or vice versa),
+		// which exercises the err != nil branch in pathWithinMount.
+		tmpDir := setupTmpDir()
+		Expect(pathWithinMount("image-root", filepath.Join(tmpDir, "any"))).To(BeFalse())
 	})
 })


### PR DESCRIPTION
Wrap WalkDir DirEntry with resolvedDirEntry so validate()'s Info() reflects os.Stat after following symlinks, not symlink inode metadata.

Add tests: symlink to empty file, symlink to empty dir, symlink to dirs-only tree; keep existing /licenses -> directory with files coverage.

Made-with: Cursor

---

This is a follow-up for some corner cases missed in #1453 (and includes tests which should guard against regression). You can confirm the difference by turning on trace logging and noticing the `licenseCount` on `quay.io/rh-ee-caxu/test-licenses-symlink:latest` (should be 168, not 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license discovery to correctly handle symlinked license directories, resolve mount roots, and prevent symlink-based path traversal so only valid regular files are considered.

* **Tests**
  * Added comprehensive tests covering symlink edge cases in license validation (including symlinked license dirs, escaped symlinks, empty targets and directory-only trees); symlink scenarios are platform-aware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->