### PR TITLE
check: fix import group ordering in has_license.go

### DIFF
--- a/internal/policy/container/has_license.go
+++ b/internal/policy/container/has_license.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 const (


### PR DESCRIPTION
## Summary

- Move `github.com/go-logr/logr` to the third-party import group (above project-local imports) per `goimports` convention with the repo's local prefix.

Fixes: #1458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal import statements for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->