### PR TITLE
addressing import format missmatch by updating golangci lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,9 +65,15 @@ linters:
       - examples$
 formatters:
   enable:
+    - gci
     - gofumpt
     - goimports
   settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/redhat-openshift-ecosystem/openshift-preflight)
     goimports:
       local-prefixes:
         - github.com/redhat-openshift-ecosystem/openshift-preflight

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ The `-run` value must match the `TestXxx` suite function name defined in the `*_
 
 ```bash
 make lint   # golangci-lint run --build-tags testing
-make fmt    # gofumpt -l -w . (must produce no diff)
+make fmt    # gofumpt -l -w . && golangci-lint fmt (must produce no diff)
 make vet    # go vet -tags testing ./...
 make tidy   # go mod tidy (must produce no diff)
 ```
@@ -72,12 +72,13 @@ All PRs must pass lint, fmt, vet, and tidy with no diffs.
 
 ### Formatting
 
-- Formatter: **gofumpt** (stricter than `gofmt`). Run `make fmt` before committing.
-- Do not manually format; let `gofumpt` handle it.
+- Formatters: **gofumpt** (stricter than `gofmt`) and **golangci-lint fmt**. Run `make fmt` before committing.
+- `make fmt` runs both `gofumpt -l -w .` and `golangci-lint fmt` to ensure consistent formatting and import organization.
+- Do not manually format; let the tooling handle it.
 
 ### Import Organization
 
-Three groups, separated by blank lines, enforced by `goimports` with local prefix:
+Three groups, separated by blank lines, enforced by `golangci-lint` (via the `goimports` linter with local prefix):
 
 ```go
 import (

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,9 @@ endef
 $(foreach arch,$(ARCHITECTURES_MAC),$(eval $(call MAC_ARCHITECTURE_template,$(arch))))
 
 .PHONY: fmt
-fmt: gofumpt
+fmt: gofumpt golangci-lint
 	${GOFUMPT} -l -w .
+	$(GOLANGCI_LINT) fmt
 	git diff --exit-code
 
 .PHONY: tidy
@@ -120,7 +121,7 @@ clean:
 	$(shell if [ -f "$(BINARY)-$(GOOS)-$(GOARCH)" ]; then rm -f $(BINARY)-$(GOOS)-$(GOARCH); fi)))
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.1.6
+GOLANGCI_LINT_VERSION ?= v2.8.0
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))

--- a/cmd/preflight/cmd/check.go
+++ b/cmd/preflight/cmd/check.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
-
-	"github.com/spf13/cobra"
 )
 
 func checkCmd() *cobra.Command {

--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -13,6 +13,13 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/container"
@@ -25,13 +32,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
-
-	"github.com/go-logr/logr"
-	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var submit bool

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -13,15 +13,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
-	preruntime "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
-
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -34,6 +25,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
+	preruntime "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 )
 
 func createPlatformImage(arch string, addlLayers int) cranev1.Image {

--- a/cmd/preflight/cmd/check_operator.go
+++ b/cmd/preflight/cmd/check_operator.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
@@ -14,9 +17,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/operator"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
-
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
 )
 
 func checkOperatorCmd(runpreflight runPreflight) *cobra.Command {

--- a/cmd/preflight/cmd/check_test.go
+++ b/cmd/preflight/cmd/check_test.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"os"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 )
 
 var _ = Describe("cmd package check command", func() {

--- a/cmd/preflight/cmd/list_checks.go
+++ b/cmd/preflight/cmd/list_checks.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/engine"
-
 	"github.com/spf13/cobra"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/engine"
 )
 
 func listChecksCmd() *cobra.Command {

--- a/cmd/preflight/cmd/list_checks_test.go
+++ b/cmd/preflight/cmd/list_checks_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/engine"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/engine"
 )
 
 var _ = Describe("list checks subcommand", func() {

--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -7,17 +7,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
-
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	spfviper "github.com/spf13/viper"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 )
 
 var (

--- a/cmd/preflight/cmd/root_test.go
+++ b/cmd/preflight/cmd/root_test.go
@@ -6,16 +6,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
-
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	spfviper "github.com/spf13/viper"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 )
 
 // executeCommand is used for cobra command testing. It is effectively what's seen here:

--- a/cmd/preflight/cmd/runtime_assets.go
+++ b/cmd/preflight/cmd/runtime_assets.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
 	"github.com/spf13/cobra"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 )
 
 func runtimeAssetsCmd() *cobra.Command {

--- a/cmd/preflight/cmd/runtime_assets_test.go
+++ b/cmd/preflight/cmd/runtime_assets_test.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 )
 
 var _ = Describe("runtime-assets test", func() {

--- a/container/check_container_test.go
+++ b/container/check_container_test.go
@@ -6,10 +6,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
-
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	preflighterr "github.com/redhat-openshift-ecosystem/openshift-preflight/errors"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -8,15 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/operator-framework/api/pkg/validation"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 )
 
 // This table signifies what the NEXT release of OpenShift will

--- a/internal/bundle/bundle_test.go
+++ b/internal/bundle/bundle_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"

--- a/internal/check/generic_check_test.go
+++ b/internal/check/generic_check_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 )
 
 var _ = Describe("Generic check tests", func() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 type CheckConfig struct {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -8,6 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
@@ -16,12 +20,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/lib"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
-	// This file imports logrus instead of internal/log because a standalone logger is used
-	// for test specs defined here.
-	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CLI Library function", func() {

--- a/internal/csv/csv_test.go
+++ b/internal/csv/csv_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -19,12 +19,11 @@ import (
 	"strings"
 	"time"
 
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
-
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/cache"
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -12,14 +12,6 @@ import (
 	"net/url"
 	"os"
 
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -27,8 +19,15 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 )
 
 var _ = Describe("Execute Checks tests", func() {

--- a/internal/formatters/formatters_test.go
+++ b/internal/formatters/formatters_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/formatters"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Formatters", func() {

--- a/internal/formatters/generic_test.go
+++ b/internal/formatters/generic_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-
-	"gotest.tools/v3/assert"
 )
 
 func TestGenericJSONFormatter(t *testing.T) {

--- a/internal/formatters/junitxml_test.go
+++ b/internal/formatters/junitxml_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/certification"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("JUnitXML Formatter", func() {

--- a/internal/lib/types.go
+++ b/internal/lib/types.go
@@ -11,14 +11,14 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/policy"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
-
-	"github.com/go-logr/logr"
 )
 
 // ResultWriter defines methods associated with writing check results.

--- a/internal/openshift/openshift.go
+++ b/internal/openshift/openshift.go
@@ -8,9 +8,6 @@ import (
 	"maps"
 
 	"github.com/go-logr/logr"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
 	imagestreamv1 "github.com/openshift/api/image/v1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -22,6 +19,8 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 )
 
 type openshiftClient struct {

--- a/internal/openshift/openshift_error_test.go
+++ b/internal/openshift/openshift_error_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	imagestreamv1 "github.com/openshift/api/image/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/openshift/openshift_test.go
+++ b/internal/openshift/openshift_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	imagestreamv1 "github.com/openshift/api/image/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/internal/openshift/openshift_version.go
+++ b/internal/openshift/openshift_version.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
 	"github.com/go-logr/logr"
 	configv1Client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 )
 
 func GetOpenshiftClusterVersion(ctx context.Context, kubeconfig []byte) (runtime.OpenshiftClusterVersion, error) {

--- a/internal/openshift/openshift_version_test.go
+++ b/internal/openshift/openshift_version_test.go
@@ -3,10 +3,10 @@ package openshift
 import (
 	"context"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
 )
 
 var _ = Describe("OpenShift Version", func() {

--- a/internal/operatorsdk/operatorsdk.go
+++ b/internal/operatorsdk/operatorsdk.go
@@ -9,11 +9,11 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/runtime"
-
-	"github.com/go-logr/logr"
 )
 
 func New(userProvidedScorecardImage string, cmdContext execContext) *operatorSdk {

--- a/internal/operatorsdk/operatorsdk_test.go
+++ b/internal/operatorsdk/operatorsdk_test.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 )
 
 const (

--- a/internal/option/option_test.go
+++ b/internal/option/option_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/internal/policy/container/base_on_ubi.go
+++ b/internal/policy/container/base_on_ubi.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
-
-	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 var _ check.Check = &BasedOnUBICheck{}

--- a/internal/policy/container/base_on_ubi_test.go
+++ b/internal/policy/container/base_on_ubi_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
-
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 )
 
 func ConfigFile() (*cranev1.ConfigFile, error) {

--- a/internal/policy/container/container_suite_test.go
+++ b/internal/policy/container/container_suite_test.go
@@ -4,12 +4,12 @@ import (
 	"io"
 	"testing"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 )
 
 func TestContainer(t *testing.T) {

--- a/internal/policy/container/has_license.go
+++ b/internal/policy/container/has_license.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 const (

--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -13,15 +13,15 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/rpm"
-
 	"github.com/go-logr/logr"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	"github.com/spf13/afero"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/rpm"
 )
 
 var _ check.Check = &HasModifiedFilesCheck{}

--- a/internal/policy/container/has_modified_files_test.go
+++ b/internal/policy/container/has_modified_files_test.go
@@ -6,17 +6,16 @@ import (
 	"io/fs"
 	"path"
 
-	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/spf13/afero"
-
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/crane"
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 )
 
 const (

--- a/internal/policy/container/has_prohibited_labels.go
+++ b/internal/policy/container/has_prohibited_labels.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 var trademarkLabels = []string{"name", "vendor", "maintainer"}

--- a/internal/policy/container/has_prohibited_packages.go
+++ b/internal/policy/container/has_prohibited_packages.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/rpm"
-
-	"github.com/go-logr/logr"
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 )
 
 var _ check.Check = &HasNoProhibitedPackagesCheck{}

--- a/internal/policy/container/has_required_labels.go
+++ b/internal/policy/container/has_required_labels.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 var requiredLabels = []string{"name", "vendor", "version", "release", "summary", "description", "maintainer"}

--- a/internal/policy/container/has_unique_tag.go
+++ b/internal/policy/container/has_unique_tag.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/authn"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 var _ check.Check = &hasUniqueTagCheck{}

--- a/internal/policy/container/max_layers.go
+++ b/internal/policy/container/max_layers.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
-	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 const (

--- a/internal/policy/container/runs_as_nonroot.go
+++ b/internal/policy/container/runs_as_nonroot.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-
 	"github.com/go-logr/logr"
 	cranev1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 )
 
 var _ check.Check = &RunAsNonRootCheck{}

--- a/internal/policy/operator/certified_images.go
+++ b/internal/policy/operator/certified_images.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
-
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/name"
 	mimage "github.com/operator-framework/operator-manifest-tools/pkg/image"
 	"github.com/operator-framework/operator-manifest-tools/pkg/pullspec"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 )
 
 var _ check.Check = &certifiedImagesCheck{}

--- a/internal/policy/operator/certified_images_test.go
+++ b/internal/policy/operator/certified_images_test.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
 )
 
 type certifiedImageFinder struct{}

--- a/internal/policy/operator/deployable_by_olm.go
+++ b/internal/policy/operator/deployable_by_olm.go
@@ -14,13 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/openshift"
-
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/api/pkg/manifests"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -35,6 +28,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/openshift"
 )
 
 type Option func(*DeployableByOlmCheck)

--- a/internal/policy/operator/deployable_by_olm_test.go
+++ b/internal/policy/operator/deployable_by_olm_test.go
@@ -5,10 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/openshift"
-
 	fakecranev1 "github.com/google/go-containerregistry/pkg/v1/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,6 +14,10 @@ import (
 	fakecg "k8s.io/client-go/kubernetes/fake"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/openshift"
 )
 
 var _ = Describe("DeployableByOLMCheck", func() {

--- a/internal/policy/operator/operator_suite_test.go
+++ b/internal/policy/operator/operator_suite_test.go
@@ -5,18 +5,17 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	imagestreamv1 "github.com/openshift/api/image/v1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
 )
 
 func TestOperator(t *testing.T) {

--- a/internal/policy/operator/related_images.go
+++ b/internal/policy/operator/related_images.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-
 	"github.com/go-logr/logr"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	mimage "github.com/operator-framework/operator-manifest-tools/pkg/image"
 	"github.com/operator-framework/operator-manifest-tools/pkg/pullspec"
 	"sigs.k8s.io/yaml"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 )
 
 var _ check.Check = &RelatedImagesCheck{}

--- a/internal/policy/operator/scc_info.go
+++ b/internal/policy/operator/scc_info.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-
-	"github.com/go-logr/logr"
 )
 
 var _ check.Check = &securityContextConstraintsInCSV{}

--- a/internal/policy/operator/scorecard_basic_check_spec.go
+++ b/internal/policy/operator/scorecard_basic_check_spec.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 var _ check.Check = &ScorecardBasicSpecCheck{}

--- a/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"os"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ScorecardBasicCheck", func() {

--- a/internal/policy/operator/scorecard_check.go
+++ b/internal/policy/operator/scorecard_check.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
-
 	"github.com/go-logr/logr"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
 )
 
 type scorecardCheck struct {

--- a/internal/policy/operator/scorecard_olm_suite.go
+++ b/internal/policy/operator/scorecard_olm_suite.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/go-logr/logr"
 )
 
 var _ check.Check = &ScorecardOlmSuiteCheck{}

--- a/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/internal/policy/operator/scorecard_olm_suite_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"os"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ScorecardBasicCheck", func() {

--- a/internal/policy/operator/validate_operator_bundle.go
+++ b/internal/policy/operator/validate_operator_bundle.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/check"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
-
-	"github.com/go-logr/logr"
 )
 
 var _ check.Check = &ValidateOperatorBundleCheck{}

--- a/internal/pyxis/builder_test.go
+++ b/internal/pyxis/builder_test.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"path"
 
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
-	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
-
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/formatters"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/version"
 )
 
 var _ = Describe("Pyxis Builder tests", func() {

--- a/internal/runtime/assets.go
+++ b/internal/runtime/assets.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/crane"
+	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/authn"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
-
-	"github.com/google/go-containerregistry/pkg/crane"
-	cranev1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // images maps the images use by preflight with their purpose.

--- a/internal/test/logger.go
+++ b/internal/test/logger.go
@@ -5,10 +5,9 @@ package test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/ginkgo/v2"
 )
 
 func NewTestLoggerContext(ctx context.Context) context.Context {


### PR DESCRIPTION
## Description
This PR addresses the mismatch between the Agent.md (seen below), and our `make fmt` and `make lint` cmds. This makes the agent match our expectation(s) and vice/versa, and also makes the fmt/linting enforcable locally and in our CI.

https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/6a5cc3a7f4757bea563f3b823f192267a3bf5e00/AGENTS.md#L80

- Fixes: #1458 
- Relates: #1459 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled a new import formatter in linting and bumped golangci-lint from v2.1.6 to v2.8.0.
  * Updated formatting command to run both gofumpt and golangci-lint fmt.

* **Style**
  * Applied consistent import ordering across the codebase.

* **Documentation**
  * Updated contributor guidance to reflect the combined formatting tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->