### PR TITLE
remove platformChanged logic from single arch logic

### DIFF
--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -457,9 +457,13 @@ func platformsToBeProcessed(cmd *cobra.Command, cfg *runtime.Config) ([]string, 
 			return nil, fmt.Errorf("could not retrieve image config: %w", err)
 		}
 
-		// A specific arch was specified. This image does not contain that arch.
-		if cfgFile.Architecture != cfg.Platform && !platformChanged {
-			return nil, fmt.Errorf("cannot process image manifest of different arch without platform override")
+		// Validate that the image architecture matches the requested platform.
+		// cfg.Platform is always set (either from --platform flag or defaults to runtime arch).
+		// crane.WithPlatform() only selects from manifest lists - for single-arch images, it's
+		// ignored and crane pulls whatever exists. This validation catches that mismatch before
+		// running checks against the wrong architecture.
+		if cfgFile.Architecture != cfg.Platform {
+			return nil, fmt.Errorf("platform mismatch: requested %s but image is %s architecture", cfg.Platform, cfgFile.Architecture)
 		}
 
 		// At this point, we know that the original containerImagePlatform is correct, so

--- a/cmd/preflight/cmd/check_container_test.go
+++ b/cmd/preflight/cmd/check_container_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Check Container Command", func() {
 			Expect(err).To(match)
 		},
 		Entry("image manifest, valid platform", "image", "amd64", Not(HaveOccurred()), true),
-		Entry("image manifest, different platform, modifier", "image", "none", Not(HaveOccurred()), true),
+		Entry("image manifest, different platform, modifier", "image", "none", HaveOccurred(), true),
 		Entry("image manifest, different platform, no modifier", "imageppc", "none", HaveOccurred(), false),
 		Entry("index manifest, valid platform", "index", "amd64", Not(HaveOccurred()), true),
 		Entry("index manifest, invalid platform", "index", "none", HaveOccurred(), true),


### PR DESCRIPTION
## Summary

Fixes #1463 - prevents silent platform mismatch when certifying single-architecture container images.

## Problem

When `--platform` is specified but the registry returns a single-arch manifest (not a manifest list), preflight silently certified the wrong architecture:

1. User requests `--platform=s390x`
2. Registry returns a single-arch `amd64` manifest
3. `crane.WithPlatform()` is **ignored** (it only works on manifest lists)
4. Preflight pulls `amd64`, runs all checks against `amd64`, but labels the report as `s390x`

This happened because `crane.WithPlatform()` is a manifest-list selector, not a platform validator. For single-arch images, the platform parameter is silently ignored.

**References:**
- [`crane.WithPlatform()` documentation](https://pkg.go.dev/github.com/google/go-containerregistry/pkg/v1/remote#WithPlatform)
- [How platform selection works in go-containerregistry](https://github.com/google/go-containerregistry/blob/main/pkg/v1/remote/descriptor.go#L105-L117)

## Solution

**Fixed the validation logic** in `platformsToBeProcessed()`:

**Before:** Only validated platform mismatch when user *didn't* specify `--platform`
```go
if cfgFile.Architecture != cfg.Platform && !platformChanged {
    return nil, fmt.Errorf("cannot process image manifest of different arch without platform override")
}
```

**After:** Always validate platform match for single-arch images
```go
if cfgFile.Architecture != cfg.Platform {
    return nil, fmt.Errorf("platform mismatch: requested %s but image is %s architecture", cfg.Platform, cfgFile.Architecture)
}
```

The original logic was backwards - it allowed mismatches when the user explicitly requested a specific platform, which is exactly when we should enforce it.

## Testing

Updated test expectations in `check_container_test.go` to expect errors on platform mismatch. All tests pass.
