### PR TITLE
build: set GOAMD64=v2 and GOPPC64=power8 for backward compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ ARG OS
 # which prohibits copying from `/tmp` during make build cmd
 USER root
 
+# Override UBI10 Go toolset microarchitecture defaults to maintain backward
+# compatibility with the same hardware baseline as UBI9-built releases.
+# See https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/1339
+ENV GOAMD64=v2
+ENV GOPPC64=power8
+
 # Build the preflight binary
 COPY . /go/src/preflight
 WORKDIR /go/src/preflight

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,16 @@ PLATFORMS=linux darwin
 ARCHITECTURES_LINUX=amd64 arm64 ppc64le s390x
 ARCHITECTURES_MAC=amd64 arm64
 
+# Microarchitecture levels: match UBI9 baseline for backward compatibility.
+# UBI10 defaults to GOAMD64=v3 and GOPPC64=power9, which produce binaries
+# incompatible with older processors. These can be overridden at build time
+# (e.g. make build GOAMD64=v3) if a higher baseline is desired.
+GOAMD64 ?= v2
+GOPPC64 ?= power8
+
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -o $(BINARY) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
+	CGO_ENABLED=0 GOAMD64=$(GOAMD64) GOPPC64=$(GOPPC64) go build -o $(BINARY) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 	@ls | grep -e '^preflight$$' &> /dev/null
 
 .PHONY: build-multi-arch-linux
@@ -21,7 +28,7 @@ build-multi-arch-linux: $(addprefix build-linux-,$(ARCHITECTURES_LINUX))
 define LINUX_ARCHITECTURE_template
 .PHONY: build-linux-$(1)
 build-linux-$(1):
-	GOOS=linux GOARCH=$(1) CGO_ENABLED=0 go build -o $(BINARY)-linux-$(1) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
+	GOOS=linux GOARCH=$(1) CGO_ENABLED=0 GOAMD64=$(GOAMD64) GOPPC64=$(GOPPC64) go build -o $(BINARY)-linux-$(1) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
 				-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 endef
 
@@ -33,7 +40,7 @@ build-multi-arch-mac: $(addprefix build-mac-,$(ARCHITECTURES_MAC))
 define MAC_ARCHITECTURE_template
 .PHONY: build-mac-$(1)
 build-mac-$(1):
-	GOOS=darwin GOARCH=$(1) CGO_ENABLED=0 go build -o $(BINARY)-darwin-$(1) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
+	GOOS=darwin GOARCH=$(1) CGO_ENABLED=0 GOAMD64=$(GOAMD64) go build -o $(BINARY)-darwin-$(1) -trimpath -ldflags "-s -w -X github.com/redhat-openshift-ecosystem/openshift-preflight/version.commit=$(VERSION) \
 				-X github.com/redhat-openshift-ecosystem/openshift-preflight/version.version=$(RELEASE_TAG)" cmd/preflight/main.go
 endef
 


### PR DESCRIPTION
UBI10 go-toolset defaults to GOAMD64=v3 and GOPPC64=power9, which produces binaries that crash at startup on older processors that only support the v2 (amd64) or power8 (ppc64le) microarchitecture level.

Explicitly pin GOAMD64=v2 and GOPPC64=power8 in both the Dockerfile and the Makefile to restore the same hardware compatibility baseline that UBI9-built releases provided.

Fixes #1339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced compatibility with older processor architectures by configuring appropriate baseline defaults during the build process, ensuring the software runs reliably on older hardware.
  * Standardized microarchitecture configurations consistently across all build environments and platforms.
  * Maintained build flexibility by allowing compile-time customization of processor settings for different deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-openshift-ecosystem/openshift-preflight/pull/1467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->