### PR TITLE
Filter test image layer hashes to remove irrelevant layers

### DIFF
--- a/internal/pyxis/layers.go
+++ b/internal/pyxis/layers.go
@@ -10,12 +10,46 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
+// filterExcludedLayers removes layer hashes that are known to be common or
+// problematic when matching up against a base image.
+func filterExcludedLayers(uncompressedLayerHashes []cranev1.Hash) []cranev1.Hash {
+	excludedHashes := map[string]struct{}{
+		// This hash represents an empty layer, where the contents is only the
+		// tar end-of-stream marker 1kb of zeros (dd if=/dev/zero bs=1024
+		// count=1 2>/dev/null | sha256sum).
+		//
+		// Legacy build tools would add this before "empty_layer" became an
+		// option for operations like LABEL, ENV, etc. that did not modify the
+		// filesystem. There are also more modern cases where we see this behavior
+		// e.g. https://github.com/containers/buildah/issues/6860
+		//
+		// Because it is effectively an empty layer, we do not want to match
+		// against base images that also have an empty base layer as their final
+		// layer diff (any image can have an empty layer).
+		//
+		// For this reason, we will not send this to the backend to find an
+		// image that contains this layer
+		"sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef": {},
+	}
+
+	filtered := make([]cranev1.Hash, 0, len(uncompressedLayerHashes))
+	for _, layer := range uncompressedLayerHashes {
+		if _, isExcluded := excludedHashes[layer.String()]; !isExcluded {
+			filtered = append(filtered, layer)
+		}
+	}
+
+	return filtered
+}
+
 // CertifiedImagesContainingLayers takes uncompressedLayerHashes and queries to a Red Hat Pyxis,
 // returning existing certified images from registry.access.redhat.com that contain any of the
 // IDs as its uncompressed top layer id.
 func (p *pyxisClient) CertifiedImagesContainingLayers(ctx context.Context, uncompressedLayerHashes []cranev1.Hash) ([]CertImage, error) {
-	layerIds := make([]graphql.String, 0, len(uncompressedLayerHashes))
-	for _, layer := range uncompressedLayerHashes {
+	filteredHashes := filterExcludedLayers(uncompressedLayerHashes)
+
+	layerIds := make([]graphql.String, 0, len(filteredHashes))
+	for _, layer := range filteredHashes {
 		layerIds = append(layerIds, graphql.String(layer.String()))
 	}
 

--- a/internal/pyxis/layers_test.go
+++ b/internal/pyxis/layers_test.go
@@ -9,6 +9,72 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("filterExcludedLayers", func() {
+	var (
+		excludedHash cranev1.Hash
+		validHash1   cranev1.Hash
+		validHash2   cranev1.Hash
+	)
+
+	BeforeEach(func() {
+		var err error
+		excludedHash, err = cranev1.NewHash("sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef")
+		Expect(err).ToNot(HaveOccurred())
+		validHash1, err = cranev1.NewHash("sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+		Expect(err).ToNot(HaveOccurred())
+		validHash2, err = cranev1.NewHash("sha256:fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when the input contains the excluded hash", func() {
+		It("should filter out the excluded hash", func() {
+			input := []cranev1.Hash{validHash1, excludedHash, validHash2}
+			result := filterExcludedLayers(input)
+			Expect(result).To(HaveLen(2), "result should contain only the two valid hashes after filtering")
+			Expect(result).To(ContainElement(validHash1), "validHash1 should be present in the filtered result")
+			Expect(result).To(ContainElement(validHash2), "validHash2 should be present in the filtered result")
+			Expect(result).ToNot(ContainElement(excludedHash), "excludedHash should be removed from the result")
+		})
+	})
+
+	Context("when the input does not contain the excluded hash", func() {
+		It("should return all hashes", func() {
+			input := []cranev1.Hash{validHash1, validHash2}
+			result := filterExcludedLayers(input)
+			Expect(result).To(HaveLen(2), "result should contain all input hashes when no excluded hash is present")
+			Expect(result).To(ContainElement(validHash1), "validHash1 should be present in the result")
+			Expect(result).To(ContainElement(validHash2), "validHash2 should be present in the result")
+		})
+	})
+
+	Context("when the input is empty", func() {
+		It("should return an empty slice", func() {
+			input := []cranev1.Hash{}
+			result := filterExcludedLayers(input)
+			Expect(result).To(BeEmpty(), "result should be empty when input is empty")
+		})
+	})
+
+	Context("when the input contains only the excluded hash", func() {
+		It("should return an empty slice", func() {
+			input := []cranev1.Hash{excludedHash}
+			result := filterExcludedLayers(input)
+			Expect(result).To(BeEmpty(), "result should be empty when input contains only the excluded hash")
+		})
+	})
+
+	Context("when the input contains multiple instances of the excluded hash", func() {
+		It("should filter out all instances", func() {
+			input := []cranev1.Hash{validHash1, excludedHash, validHash2, excludedHash}
+			result := filterExcludedLayers(input)
+			Expect(result).To(HaveLen(2), "result should contain only the two valid hashes after filtering all excluded instances")
+			Expect(result).To(ContainElement(validHash1), "validHash1 should be present in the filtered result")
+			Expect(result).To(ContainElement(validHash2), "validHash2 should be present in the filtered result")
+			Expect(result).ToNot(ContainElement(excludedHash), "all instances of excludedHash should be removed from the result")
+		})
+	})
+})
+
 var _ = Describe("Pyxis CheckRedHatLayers", func() {
 	ctx := context.Background()
 	var pyxisClient *pyxisClient
@@ -22,9 +88,9 @@ var _ = Describe("Pyxis CheckRedHatLayers", func() {
 		Context("and a layer is a known good layer", func() {
 			It("should be a good layer", func() {
 				certImages, err := pyxisClient.CertifiedImagesContainingLayers(ctx, []cranev1.Hash{{}})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(certImages).ToNot(BeNil())
-				Expect(certImages).ToNot(BeZero())
+				Expect(err).ToNot(HaveOccurred(), "CertifiedImagesContainingLayers should not return an error")
+				Expect(certImages).ToNot(BeNil(), "certImages should not be nil")
+				Expect(certImages).ToNot(BeZero(), "certImages should contain certified image data")
 			})
 		})
 	})


### PR DESCRIPTION
The RootFS.Layer hash `sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef` effectively means "no content", and if found in a test image, could match with base images that also incorrectly have this layer hash as their final hash.

This PR adds a function to filter layers we want to exclude from the test image. It only excludes one layer for the moment, but it's been built to potentially exclude more if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve certified image layer filtering to exclude a known empty layer before building filter lists, preventing empty layers from affecting results.

* **Tests**
  * Added tests for layer filtering: excluded-layer removal, absent excluded layer, empty input, input of only excluded layers, and multiple occurrences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-openshift-ecosystem/openshift-preflight/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->