### PR TITLE
test: redirect stdout/stderr through injectable writers and route log…

### DIFF
--- a/cmd/preflight/cmd/root.go
+++ b/cmd/preflight/cmd/root.go
@@ -23,6 +23,7 @@ import (
 var (
 	configFileUsed bool
 	logFiles       []*os.File
+	stderr         io.Writer = os.Stderr
 )
 
 func init() {
@@ -147,7 +148,7 @@ func preRunConfig(cmd *cobra.Command, args []string) {
 		artifactsLogFile, err := os.OpenFile(filepath.Join(artifacts, baseLogName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err == nil {
 			logFiles = append(logFiles, artifactsLogFile)
-			mw := io.MultiWriter(os.Stderr, logFile, artifactsLogFile)
+			mw := io.MultiWriter(stderr, logFile, artifactsLogFile)
 			l.SetOutput(mw)
 		}
 

--- a/cmd/preflight/cmd/root_test.go
+++ b/cmd/preflight/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -15,6 +16,7 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/viper"
 )
 
@@ -159,6 +161,7 @@ loglevel: configloglevel`
 		})
 		Context("with the offline flag", func() {
 			var tmpDir string
+			var oldStderr io.Writer
 			BeforeEach(func() {
 				var err error
 				tmpDir, err = os.MkdirTemp("", "prerun-artifacts-*")
@@ -177,9 +180,16 @@ loglevel: configloglevel`
 
 				viper.Instance().Set("offline", true)
 				DeferCleanup(viper.Instance().Set, "offline", false)
+
+				oldStderr = stderr
+				stderr = GinkgoWriter
+			})
+			AfterEach(func() {
+				stderr = oldStderr
 			})
 			It("should create the logfile in the artifacts directory", func() {
-				Expect(cmd.ExecuteContext(context.TODO())).To(Succeed())
+				ctx := test.NewTestLoggerContext(context.TODO())
+				Expect(cmd.ExecuteContext(ctx)).To(Succeed())
 				_, err := os.Stat(filepath.Join(tmpDir, "preflight.log"))
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,6 +23,8 @@ type CheckConfig struct {
 	SubmitResults       bool
 }
 
+var stdout io.Writer = os.Stdout
+
 // RunPreflight executes checks, writes logs, results, and submits results if requested.
 func RunPreflight(
 	ctx context.Context,
@@ -55,7 +57,7 @@ func RunPreflight(
 	}
 
 	defer resultsFile.Close()
-	resultsOutputTarget := io.MultiWriter(os.Stdout, resultsFile)
+	resultsOutputTarget := io.MultiWriter(stdout, resultsFile)
 
 	// Execute Checks.
 	results, err := runChecks(ctx)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -23,6 +23,14 @@ import (
 )
 
 var _ = Describe("CLI Library function", func() {
+	var oldStdout io.Writer
+	BeforeEach(func() {
+		oldStdout = stdout
+		stdout = GinkgoWriter
+	})
+	AfterEach(func() {
+		stdout = oldStdout
+	})
 	When("invoking preflight using the CLI library", func() {
 		Context("without passing in an artifact writer ", func() {
 			It("should throw an error", func() {

--- a/internal/policy/operator/certified_images_test.go
+++ b/internal/policy/operator/certified_images_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/pyxis"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 type certifiedImageFinder struct{}
@@ -96,6 +97,7 @@ var _ = Describe("CertifiedImages", func() {
 		clusterServiceVersionFilename = "myoperator.clusterserviceversion.yaml"
 	)
 	var (
+		ctx                  context.Context
 		certifiedImagesCheck *certifiedImagesCheck
 		imageRef             image.ImageReference
 		csvContents          = `kind: ClusterServiceVersion
@@ -119,6 +121,7 @@ spec:
 	)
 
 	BeforeEach(func() {
+		ctx = test.NewTestLoggerContext(context.TODO())
 		certifiedImagesCheck = NewCertifiedImagesCheck(&certifiedImageFinder{})
 		tmpDir, err := os.MkdirTemp("", "certified-images-bundle-*")
 		Expect(err).ToNot(HaveOccurred())
@@ -133,7 +136,7 @@ spec:
 	})
 	When("given a good CSV", func() {
 		It("should succeed", func() {
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(0))
@@ -145,7 +148,7 @@ spec:
 		})
 		It("should fail", func() {
 			certifiedImagesCheck.imageFinder = &uncertifiedImageFinder{}
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))
@@ -157,7 +160,7 @@ spec:
 		})
 		It("should fail", func() {
 			certifiedImagesCheck.imageFinder = &missingImageFinder{}
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))
@@ -166,7 +169,7 @@ spec:
 	When("there is no CSV", func() {
 		It("should fail", func() {
 			Expect(os.RemoveAll(imageRef.ImageFSPath)).To(Succeed())
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
@@ -178,7 +181,7 @@ apiVersion: operators.coreos.com/v1alpha1
 spec:
 `
 			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
@@ -198,7 +201,7 @@ spec:
               - image: registry.example.io/foo/bar:latest
                 name: the-operator`
 			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))
@@ -210,7 +213,7 @@ spec:
 		})
 		It("should fail", func() {
 			certifiedImagesCheck.imageFinder = &badCertifiedImageFinder{}
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
@@ -235,7 +238,7 @@ spec:
   - name: ''
     image: ''`
 			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
-			result, err := certifiedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := certifiedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeFalse())
 			Expect(certifiedImagesCheck.nonCertifiedImages).To(HaveLen(1))

--- a/internal/policy/operator/deployable_by_olm_test.go
+++ b/internal/policy/operator/deployable_by_olm_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/openshift"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 var _ = Describe("DeployableByOLMCheck", func() {
@@ -56,6 +57,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 		aw, err := artifacts.NewFilesystemWriter(artifacts.WithDirectory(tmpDir))
 		Expect(err).ToNot(HaveOccurred())
 		testcontext = artifacts.ContextWithWriter(context.Background(), aw)
+		testcontext = test.NewTestLoggerContext(testcontext)
 		DeferCleanup(os.RemoveAll, tmpDir)
 	})
 

--- a/internal/policy/operator/operator_suite_test.go
+++ b/internal/policy/operator/operator_suite_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"errors"
+	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,6 +20,8 @@ import (
 )
 
 func TestOperator(t *testing.T) {
+	// This is only necessary because OperatorSDK uses the std Log.
+	log.SetOutput(GinkgoWriter)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operator Suite")
 }

--- a/internal/policy/operator/related_images_test.go
+++ b/internal/policy/operator/related_images_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 var _ = Describe("RelatedImages", func() {
@@ -17,6 +18,7 @@ var _ = Describe("RelatedImages", func() {
 		clusterServiceVersionFilename = "myoperator.clusterserviceversion.yaml"
 	)
 	var (
+		ctx                context.Context
 		relatedImagesCheck *RelatedImagesCheck
 		imageRef           image.ImageReference
 		csvContents        = `kind: ClusterServiceVersion
@@ -39,6 +41,7 @@ spec:
 	)
 
 	BeforeEach(func() {
+		ctx = test.NewTestLoggerContext(context.TODO())
 		relatedImagesCheck = &RelatedImagesCheck{}
 		tmpDir, err := os.MkdirTemp("", "related-images-bundle-*")
 		Expect(err).ToNot(HaveOccurred())
@@ -53,7 +56,7 @@ spec:
 	})
 	When("given a good CSV", func() {
 		It("should succeed", func() {
-			result, err := relatedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := relatedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
@@ -61,7 +64,7 @@ spec:
 	When("there is no CSV", func() {
 		It("should fail", func() {
 			Expect(os.RemoveAll(imageRef.ImageFSPath)).To(Succeed())
-			result, err := relatedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := relatedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
@@ -73,7 +76,7 @@ apiVersion: operators.coreos.com/v1alpha1
 spec:
 `
 			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
-			result, err := relatedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := relatedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
 		})
@@ -96,7 +99,7 @@ spec:
   - name: the-proxy
     image: registry.example.io/foo/proxy@sha256:5e33f9d095952866b9743cc8268fb740cce6d93439f00ce333a2de1e5974837e`
 			Expect(os.WriteFile(filepath.Join(imageRef.ImageFSPath, manifestsDir, clusterServiceVersionFilename), []byte(csvContents), 0o644)).To(Succeed())
-			result, err := relatedImagesCheck.Validate(context.TODO(), imageRef)
+			result, err := relatedImagesCheck.Validate(ctx, imageRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})

--- a/internal/policy/operator/scorecard_basic_check_spec_test.go
+++ b/internal/policy/operator/scorecard_basic_check_spec_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 var _ = Describe("ScorecardBasicCheck", func() {
@@ -82,6 +83,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		aw, err := artifacts.NewFilesystemWriter(artifacts.WithDirectory(tmpDir))
 		Expect(err).ToNot(HaveOccurred())
 		testcontext = artifacts.ContextWithWriter(context.Background(), aw)
+		testcontext = test.NewTestLoggerContext(testcontext)
 
 		DeferCleanup(os.RemoveAll, tmpDir)
 	})

--- a/internal/policy/operator/scorecard_olm_suite_test.go
+++ b/internal/policy/operator/scorecard_olm_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/bundle"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/operatorsdk"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 var _ = Describe("ScorecardBasicCheck", func() {
@@ -82,6 +83,7 @@ var _ = Describe("ScorecardBasicCheck", func() {
 		aw, err := artifacts.NewFilesystemWriter(artifacts.WithDirectory(tmpDir))
 		Expect(err).ToNot(HaveOccurred())
 		testcontext = artifacts.ContextWithWriter(context.Background(), aw)
+		testcontext = test.NewTestLoggerContext(testcontext)
 
 		DeferCleanup(os.RemoveAll, tmpDir)
 	})

--- a/internal/policy/operator/validate_operator_bundle_test.go
+++ b/internal/policy/operator/validate_operator_bundle_test.go
@@ -7,13 +7,16 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/image"
+	test "github.com/redhat-openshift-ecosystem/openshift-preflight/internal/test"
 )
 
 var _ = Describe("BundleValidateCheck", func() {
 	var bundleValidateCheck ValidateOperatorBundleCheck
+	var ctx context.Context
 
 	BeforeEach(func() {
 		bundleValidateCheck = *NewValidateOperatorBundleCheck()
+		ctx = test.NewTestLoggerContext(context.TODO())
 	})
 
 	AssertMetaData(&bundleValidateCheck)
@@ -26,7 +29,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				imageRef := image.ImageReference{
 					ImageFSPath: "./testdata/all_namespaces",
 				}
-				ok, err := bundleValidateCheck.Validate(context.TODO(), imageRef)
+				ok, err := bundleValidateCheck.Validate(ctx, imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -36,7 +39,7 @@ var _ = Describe("BundleValidateCheck", func() {
 				imageRef := image.ImageReference{
 					ImageFSPath: "./testdata/invalid_bundle",
 				}
-				ok, err := bundleValidateCheck.Validate(context.TODO(), imageRef)
+				ok, err := bundleValidateCheck.Validate(ctx, imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})


### PR DESCRIPTION
…s to GinkgoWriter

Replace direct os.Stdout and os.Stderr usage with package-level writer variables so tests can capture output via GinkgoWriter instead of polluting the terminal. Add test.NewTestLoggerContext across operator policy tests and the CLI test suite to ensure log output is properly captured by the Ginkgo test runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test suites to capture and route logs/output consistently, making test runs more reliable and diagnosable.
* **Chores**
  * Standardized stdout/stderr handling via configurable writer variables to improve testability and logging behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-openshift-ecosystem/openshift-preflight/pull/1472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->