### PR TITLE
updating go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG release_tag=0.0.0
 ARG ARCH=amd64
 ARG OS=linux
 
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 ARG quay_expiration
 ARG release_tag
 ARG ARCH

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,9 +23,9 @@ Vagrant.configure("2") do |config|
     containers-common \
     openscap-containers
 
-    curl -L https://go.dev/dl/go1.25.7.linux-amd64.tar.gz --output go1.25.7.linux-amd64.tar.gz
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.25.7.linux-amd64.tar.gz
-    rm go1.25.7.linux-amd64.tar.gz
+    curl -L https://go.dev/dl/go1.26.3.linux-amd64.tar.gz --output go1.26.3.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.3.linux-amd64.tar.gz
+    rm go1.26.3.linux-amd64.tar.gz
 
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz --output oc.tar.gz
     tar -C /usr/local/bin -xzf oc.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-openshift-ecosystem/openshift-preflight
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain from 1.25.7 to 1.26.3 across build and development environments, ensuring builds and local provisioning use the newer Go release.
  * Container build process adjusted to align with the updated toolchain while runtime behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->