### PR TITLE
ci: separate test dependencies from prod in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,14 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      dev-dependencies:
-        dependency-type: "development"
+      test-dependencies:
+        patterns:
+          - "github.com/onsi/ginkgo*"
+          - "github.com/onsi/gomega*"
       prod-dependencies:
-        dependency-type: "production"
+        exclude-patterns:
+          - "github.com/onsi/ginkgo*"
+          - "github.com/onsi/gomega*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Replace `dependency-type` based grouping with explicit pattern-based
groups in the dependabot config.

Only `ginkgo` and `gomega` are true test-only dependencies (used
exclusively in `*_test.go` files and test-build-tagged infrastructure).
All other 23 direct dependencies are imported in production code.

### Changes

- **`test-dependencies` group**: Explicitly matches `github.com/onsi/ginkgo*`
  and `github.com/onsi/gomega*` by pattern.
- **`prod-dependencies` group**: Uses `exclude-patterns` to match everything
  except the test dependencies.

This gives clearer separation in dependabot PRs between test framework
bumps and production dependency updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to reorganize how test and production dependencies are grouped for automated updates, improving the separation and management of different dependency types in the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->