### PR TITLE
updating docs urls (docs.rh.com redirect is broken)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ subject to change, and some features are not fully implemented.
 ## Certification Workflow Guide
 
 For the complete container and operator bundle certification workflow instructions, please reference our 
-[official certification documentation](https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html/red_hat_software_certification_workflow_guide/index).
+[official certification documentation](https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html/red_hat_software_certification_workflow_guide/index).
 
 ## Requirements
 

--- a/internal/policy/container/base_on_ubi.go
+++ b/internal/policy/container/base_on_ubi.go
@@ -77,7 +77,7 @@ func (p *BasedOnUBICheck) Name() string {
 
 func (p *BasedOnUBICheck) Metadata() check.Metadata {
 	return check.Metadata{
-		Description:      "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)",
+		Description:      "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI) or Red Hat Hardened Images (RHHI)",
 		Level:            "best",
 		KnowledgeBaseURL: certDocumentationURL,
 		CheckURL:         certDocumentationURL,

--- a/internal/policy/container/defaults.go
+++ b/internal/policy/container/defaults.go
@@ -1,3 +1,3 @@
 package container
 
-var certDocumentationURL = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
+var certDocumentationURL = "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"

--- a/internal/policy/operator/certified_images.go
+++ b/internal/policy/operator/certified_images.go
@@ -116,8 +116,8 @@ func (p *certifiedImagesCheck) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Checking that all images referenced in the CSV are certified. Currently, this check is not enforced.",
 		Level:            "optional",
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operand-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 

--- a/internal/policy/operator/related_images.go
+++ b/internal/policy/operator/related_images.go
@@ -85,8 +85,8 @@ func (p *RelatedImagesCheck) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Check that all images in the CSV are listed in RelatedImages section. Currently, this check is not enforced.",
 		Level:            "optional",
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 

--- a/internal/policy/operator/required_annotations.go
+++ b/internal/policy/operator/required_annotations.go
@@ -92,8 +92,8 @@ func (h RequiredAnnotations) Metadata() check.Metadata {
 	return check.Metadata{
 		Description:      "Checks that the CSV has all of the required feature annotations.",
 		Level:            check.LevelBest,
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 

--- a/internal/policy/operator/restricted_network_aware.go
+++ b/internal/policy/operator/restricted_network_aware.go
@@ -100,8 +100,8 @@ func (p FollowsRestrictedNetworkEnablementGuidelines) Metadata() check.Metadata 
 		// TODO: If this check is enforced and no longer optional, we need to identify ways to reduce false failures that may be caused by
 		// developers injecting related images in other ways.
 		Level:            "optional",
-		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
-		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		KnowledgeBaseURL: "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
+		CheckURL:         "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2026/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multiple help and reference links to point to the 2026 certification policy guides.
  * Refreshed the README link to the latest Certification Workflow Guide.
  * Expanded one check’s description to cover both Red Hat Universal Base Image (UBI) and Red Hat Hardened Images (RHHI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->