### PR TITLE
Revert "switching to hardened images to reduce image size and CVE footprint"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,24 +13,6 @@ ARG OS
 # which prohibits copying from `/tmp` during make build cmd
 USER root
 
-# Define versions for dependencies
-ARG OPERATOR_SDK_VERSION=1.42.3
-
-# Install and verify Operator SDK binary
-# Verification follows https://sdk.operatorframework.io/docs/installation/#2-verify-the-downloaded-binary
-ARG OPERATOR_SDK_GPG_KEY=3B2F1481D146238080B346BB052996E2A20B5C7E
-RUN dnf install -y gnupg2 && dnf clean all \
-    && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION} \
-    && curl --fail -Lo /usr/local/bin/operator-sdk ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH} \
-    && curl --fail -Lo /tmp/checksums.txt ${OPERATOR_SDK_DL_URL}/checksums.txt \
-    && curl --fail -Lo /tmp/checksums.txt.asc ${OPERATOR_SDK_DL_URL}/checksums.txt.asc \
-    && gpg --keyserver keyserver.ubuntu.com --recv-keys ${OPERATOR_SDK_GPG_KEY} \
-    && gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify /tmp/checksums.txt.asc \
-    && grep "operator-sdk_linux_${ARCH}" /tmp/checksums.txt | sed "s|operator-sdk_linux_${ARCH}|/usr/local/bin/operator-sdk|" | sha256sum -c - \
-    && chmod 755 /usr/local/bin/operator-sdk \
-    && rm -rf /tmp/checksums.txt /tmp/checksums.txt.asc "$HOME/.gnupg" \
-    && dnf remove -y gnupg2 && dnf clean all
-
 # Override UBI10 Go toolset microarchitecture defaults to maintain backward
 # compatibility with the same hardware baseline as UBI9-built releases.
 # See https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/1339
@@ -42,8 +24,8 @@ COPY . /go/src/preflight
 WORKDIR /go/src/preflight
 RUN make build RELEASE_TAG=${release_tag}
 
-# Hardened Image core-runtime:latest
-FROM registry.access.redhat.com/hi/core-runtime:latest
+# ubi10:latest
+FROM registry.access.redhat.com/ubi10/ubi:latest
 ARG quay_expiration
 ARG release_tag
 ARG preflight_commit
@@ -69,17 +51,29 @@ LABEL quay.expires-after=${quay_expiration}
 LABEL ARCH=${ARCH}
 LABEL OS=${OS}
 
+# Define versions for dependencies
+ARG OPERATOR_SDK_VERSION=1.42.3
+
+# Install and verify Operator SDK binary
+# Verification follows https://sdk.operatorframework.io/docs/installation/#2-verify-the-downloaded-binary
+ARG OPERATOR_SDK_GPG_KEY=3B2F1481D146238080B346BB052996E2A20B5C7E
+RUN dnf install -y gnupg2 && dnf clean all \
+    && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION} \
+    && curl --fail -Lo /usr/local/bin/operator-sdk ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH} \
+    && curl --fail -Lo /tmp/checksums.txt ${OPERATOR_SDK_DL_URL}/checksums.txt \
+    && curl --fail -Lo /tmp/checksums.txt.asc ${OPERATOR_SDK_DL_URL}/checksums.txt.asc \
+    && gpg --keyserver keyserver.ubuntu.com --recv-keys ${OPERATOR_SDK_GPG_KEY} \
+    && gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify /tmp/checksums.txt.asc \
+    && grep "operator-sdk_linux_${ARCH}" /tmp/checksums.txt | sed "s|operator-sdk_linux_${ARCH}|/usr/local/bin/operator-sdk|" | sha256sum -c - \
+    && chmod 755 /usr/local/bin/operator-sdk \
+    && rm -rf /tmp/checksums.txt /tmp/checksums.txt.asc "$HOME/.gnupg" \
+    && dnf remove -y gnupg2 && dnf clean all
+
 # Add preflight binary
 COPY --from=builder /go/src/preflight/preflight /usr/local/bin/preflight
 
-# Add operator-sdk binary
-COPY --from=builder /usr/local/bin/operator-sdk /usr/local/bin/operator-sdk
-
-# Copy license
+#copy license
 COPY LICENSE /licenses/LICENSE
-
-# Switching to root user, for backwards compatability with writing artifacts to the container
-USER 0
 
 ENTRYPOINT ["/usr/local/bin/preflight"]
 CMD ["--help"]


### PR DESCRIPTION
Reverts redhat-openshift-ecosystem/openshift-preflight#1481

Need to revert this change, since it seems not all arches are supported, even though documentation says otherwise.

Main build gets the below error:
```
Trying to pull registry.access.redhat.com/hi/core-runtime:latest...
Error: creating build container: choosing an image from manifest list docker://registry.access.redhat.com/hi/core-runtime:latest: no image found in image index for architecture ppc64le, variant "", OS linux
```
```
❯ crane manifest registry.access.redhat.com/hi/core-runtime:latest | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:a793ae2e6969409a2dab5bfdf9823cb77bc3cb2a43ba6dcd1c9b17d8b063bdca",
      "size": 4272,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:ec589a753ffc6589bdc540330b8271eab82281a12eb6559b5d4d23c194c4a267",
      "size": 4272,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    }
  ]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the preflight runtime image to use a newer Universal Base Image.
  * Improved Operator SDK installation and verification during image creation.
  * Continued to include the preflight binary and license while preserving existing startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->