### PR TITLE
deployablebyolm: add random namespace suffix to avoid collisions

### DIFF
--- a/internal/policy/operator/default.go
+++ b/internal/policy/operator/default.go
@@ -2,9 +2,17 @@ package operator
 
 import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
+	// namespaceSuffixLen is the length of the random suffix appended to namespaces to avoid collisions
+	namespaceSuffixLen = 5
+	// targetSuffix is appended to the install namespace to form the target namespace
+	targetSuffix = "-target"
+	// maxAppNameLen keeps the target namespace within the K8s DNS label limit
+	maxAppNameLen = validation.DNS1035LabelMaxLength - namespaceSuffixLen - len("-") - len(targetSuffix)
+
 	// secretName is the K8s secret name which stores the auth keys for the private registry access
 	secretName = "registry-auth-keys"
 

--- a/internal/policy/operator/deployable_by_olm.go
+++ b/internal/policy/operator/deployable_by_olm.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -69,6 +70,7 @@ type DeployableByOlmCheck struct {
 	validImages         bool
 	csvTimeout          time.Duration
 	subscriptionTimeout time.Duration
+	namespaceSuffix     func(int) string
 }
 
 func (p *DeployableByOlmCheck) initClient() error {
@@ -153,9 +155,10 @@ func NewDeployableByOlmCheck(
 	opts ...Option,
 ) *DeployableByOlmCheck {
 	c := &DeployableByOlmCheck{
-		dockerConfig: dockerConfig,
-		indexImage:   indexImage,
-		channel:      channel,
+		dockerConfig:    dockerConfig,
+		indexImage:      indexImage,
+		channel:         channel,
+		namespaceSuffix: rand.String,
 	}
 
 	for _, opt := range opts {
@@ -332,13 +335,18 @@ func (p *DeployableByOlmCheck) operatorMetadata(ctx context.Context, bundleRef i
 		deploymentNames = append(deploymentNames, deployment.Name)
 	}
 
+	namespace := appName[:min(len(appName), maxAppNameLen)]
+	if suffix := p.namespaceSuffix(namespaceSuffixLen); suffix != "" {
+		namespace = fmt.Sprintf("%s-%s", namespace, suffix)
+	}
+
 	return &operatorData{
 		CatalogImage:     catalogImage,
 		Channel:          channel,
 		PackageName:      packageName,
 		App:              appName,
-		InstallNamespace: appName,
-		TargetNamespace:  appName + "-target",
+		InstallNamespace: namespace,
+		TargetNamespace:  namespace + targetSuffix,
 		InstallModes:     installModes,
 		DeploymentNames:  deploymentNames,
 	}, nil

--- a/internal/policy/operator/deployable_by_olm_test.go
+++ b/internal/policy/operator/deployable_by_olm_test.go
@@ -37,6 +37,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 		now := metav1.Now()
 		og.Status.LastUpdated = &now
 		deployableByOLMCheck = *NewDeployableByOlmCheck("test_indeximage", "", "", WithCSVTimeout(1*time.Second), WithSubscriptionTimeout(1*time.Second))
+		deployableByOLMCheck.namespaceSuffix = func(int) string { return "abcde" }
 		scheme := apiruntime.NewScheme()
 		Expect(openshift.AddSchemes(scheme)).To(Succeed())
 		Expect(appsv1.AddToScheme(scheme)).To(Succeed())
@@ -75,7 +76,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 
 				// changing the namespace since OwnNamespace operators CSV get applied to `InstallNamespace`
 				ownCSV := csv.DeepCopy()
-				ownCSV.Namespace = "p-testPackage"
+				ownCSV.Namespace = "p-testPackage-abcde"
 
 				scheme := apiruntime.NewScheme()
 				Expect(openshift.AddSchemes(scheme)).To(Succeed())
@@ -116,7 +117,7 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				badSub := sub
 				Expect(deployableByOLMCheck.client.Get(testcontext, crclient.ObjectKey{
 					Name:      "p-testPackage",
-					Namespace: "p-testPackage",
+					Namespace: "p-testPackage-abcde",
 				}, &badSub)).To(Succeed())
 				badSub.Status.InstalledCSV = ""
 				Expect(deployableByOLMCheck.client.Update(testcontext, &badSub, &crclient.UpdateOptions{})).To(Succeed())
@@ -156,6 +157,28 @@ var _ = Describe("DeployableByOLMCheck", func() {
 				ok, err := deployableByOLMCheck.Validate(testcontext, imageRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("operatorMetadata namespace generation", func() {
+		Context("When namespaceSuffix returns a non-empty value", func() {
+			It("Should append the suffix to InstallNamespace and TargetNamespace", func() {
+				data, err := deployableByOLMCheck.operatorMetadata(testcontext, imageRef)
+				Expect(err).ToNot(HaveOccurred(), "failed to load operator metadata")
+				Expect(data.InstallNamespace).To(Equal("p-testPackage-abcde"), "install namespace should include the generated suffix")
+				Expect(data.TargetNamespace).To(Equal("p-testPackage-abcde-target"), "target namespace should derive from the suffixed install namespace")
+			})
+		})
+		Context("When appName exceeds the maximum length", func() {
+			It("Should truncate to keep namespaces within the 63-char DNS label limit", func() {
+				imageRef.ImageFSPath = "./testdata/long_name"
+				data, err := deployableByOLMCheck.operatorMetadata(testcontext, imageRef)
+				Expect(err).ToNot(HaveOccurred(), "failed to load operator metadata for long package name")
+				Expect(data.InstallNamespace).To(HaveLen(56), "install namespace should be truncated appName + suffix")
+				Expect(data.TargetNamespace).To(HaveLen(63), "target namespace should not exceed DNS label limit")
+				Expect(data.InstallNamespace).To(Equal("this-is-a-very-long-package-name-that-exceeds-fift-abcde"), "appName should be truncated to 50 chars before suffix")
+				Expect(data.TargetNamespace).To(Equal("this-is-a-very-long-package-name-that-exceeds-fift-abcde-target"), "target namespace should append -target to install namespace")
 			})
 		})
 	})

--- a/internal/policy/operator/operator_suite_test.go
+++ b/internal/policy/operator/operator_suite_test.go
@@ -101,7 +101,7 @@ var pod2 = corev1.Pod{
 var pod3 = corev1.Pod{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "pod3",
-		Namespace: "p-testPackage",
+		Namespace: "p-testPackage-abcde",
 		Labels: map[string]string{
 			"app": "testapp1",
 		},
@@ -131,7 +131,7 @@ var pods = corev1.PodList{
 var csv = operatorsv1alpha1.ClusterServiceVersion{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "csv-v0.0.0",
-		Namespace: "p-testPackage-target",
+		Namespace: "p-testPackage-abcde-target",
 	},
 	Spec: operatorsv1alpha1.ClusterServiceVersionSpec{},
 	Status: operatorsv1alpha1.ClusterServiceVersionStatus{
@@ -179,7 +179,7 @@ var secret = corev1.Secret{
 var sub = operatorsv1alpha1.Subscription{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "p-testPackage",
-		Namespace: "p-testPackage",
+		Namespace: "p-testPackage-abcde",
 	},
 	Status: operatorsv1alpha1.SubscriptionStatus{
 		InstalledCSV: "csv-v0.0.0",
@@ -189,7 +189,7 @@ var sub = operatorsv1alpha1.Subscription{
 var og = operatorsv1.OperatorGroup{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "p-testPackage",
-		Namespace: "p-testPackage",
+		Namespace: "p-testPackage-abcde",
 	},
 	Status: operatorsv1.OperatorGroupStatus{
 		LastUpdated: nil,
@@ -220,7 +220,7 @@ var isList = imagestreamv1.ImageStreamList{
 var deployment = appsv1.Deployment{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "memcached-operator-controller-manager",
-		Namespace: "p-testPackage",
+		Namespace: "p-testPackage-abcde",
 	},
 	Spec: appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{

--- a/internal/policy/operator/testdata/long_name/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/policy/operator/testdata/long_name/manifests/memcached-operator.clusterserviceversion.yaml
@@ -1,0 +1,225 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+  name: memcached-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  description: Memcached Operator description. TODO.
+  displayName: Memcached Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cache.example.com
+          resources:
+          - memcacheds
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cache.example.com
+          resources:
+          - memcacheds/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - cache.example.com
+          resources:
+          - memcacheds/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: memcached-operator-controller-manager
+      deployments:
+      - name: memcached-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                image: quay.io/example/memcached-operator:v0.0.1
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 30Mi
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: memcached-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: memcached-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - memcached-operator
+  links:
+  - name: Memcached Operator
+    url: https://memcached-operator.domain
+  maintainers:
+  - email: your@email.com
+    name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
+  version: 0.0.1
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: memcached-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vmemcached.kb.io
+    rules:
+    - apiGroups:
+      - cache.example.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - memcacheds
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-cache-example-com-v1alpha1-memcached
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: memcached-operator-controller-manager
+    failurePolicy: Fail
+    generateName: mmemcached.kb.io
+    rules:
+    - apiGroups:
+      - cache.example.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - memcacheds
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-cache-example-com-v1alpha1-memcached

--- a/internal/policy/operator/testdata/long_name/metadata/annotations.yaml
+++ b/internal/policy/operator/testdata/long_name/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  com.redhat.openshift.versions: "v4.6-v4.9"
+  operators.operatorframework.io.bundle.package.v1: this-is-a-very-long-package-name-that-exceeds-fifty-chars
+  operators.operatorframework.io.bundle.channel.default.v1: testChannel


### PR DESCRIPTION
- Fixes: #1355 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced operator namespace collisions by generating install and target namespaces from the app name, truncating to DNS-label limits and appending an optional suffix when needed.

* **Tests**
  * Expanded coverage for namespace suffixing and truncation, including new checks for `operatorMetadata` namespace generation.
  * Updated existing test fixtures and added long-name OLM manifest/annotation fixtures to validate metadata and namespace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->