### PR TITLE
engine: retry untar on transient registry EOF errors

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -174,8 +174,26 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	slices.Sort(requiredFilePatterns)
 	requiredFilePatterns = slices.Compact(requiredFilePatterns)
 
-	if err := untar(ctx, containerFSPath, img, requiredFilePatterns); err != nil {
-		return err
+	// Retry untar on transient EOF errors caused by registry blob stream truncation.
+	const maxUntarRetries = 3
+	for attempt := 1; ; attempt++ {
+		if err := untar(ctx, containerFSPath, img, requiredFilePatterns); err != nil {
+			if attempt < maxUntarRetries && strings.Contains(err.Error(), "unexpected EOF") {
+				logger.Info("retrying image extraction after transient error", "attempt", attempt, "err", err)
+				if rmErr := os.RemoveAll(containerFSPath); rmErr != nil {
+					//coverage:ignore
+					return fmt.Errorf("failed to clean up extraction directory: %v", rmErr)
+				}
+				if mkErr := os.MkdirAll(containerFSPath, 0o755); mkErr != nil {
+					//coverage:ignore
+					return fmt.Errorf("failed to recreate extraction directory: %v", mkErr)
+				}
+				time.Sleep(time.Duration(attempt) * time.Second)
+				continue
+			}
+			return err
+		}
+		break
 	}
 
 	reference, err := name.ParseReference(c.image)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -178,17 +178,21 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	const maxUntarRetries = 3
 	for attempt := 1; ; attempt++ {
 		if err := untar(ctx, containerFSPath, img, requiredFilePatterns); err != nil {
-			if attempt < maxUntarRetries && strings.Contains(err.Error(), "unexpected EOF") {
-				logger.Info("retrying image extraction after transient error", "attempt", attempt, "err", err)
+			if attempt < maxUntarRetries && errors.Is(err, io.ErrUnexpectedEOF) {
+				logger.Error(err, "retrying image extraction after transient error", "attempt", attempt)
 				if rmErr := os.RemoveAll(containerFSPath); rmErr != nil {
 					//coverage:ignore
-					return fmt.Errorf("failed to clean up extraction directory: %v", rmErr)
+					return fmt.Errorf("failed to clean up extraction directory: %w", rmErr)
 				}
 				if mkErr := os.MkdirAll(containerFSPath, 0o755); mkErr != nil {
 					//coverage:ignore
-					return fmt.Errorf("failed to recreate extraction directory: %v", mkErr)
+					return fmt.Errorf("failed to recreate extraction directory: %w", mkErr)
 				}
-				time.Sleep(time.Duration(attempt) * time.Second)
+				select {
+				case <-time.After(time.Duration(attempt) * time.Second):
+				case <-ctx.Done():
+					return fmt.Errorf("waiting to retry image extraction: %w", ctx.Err())
+				}
 				continue
 			}
 			return err


### PR DESCRIPTION
## Problem

Registry blob streams (e.g. quay.io) are intermittently truncated during download, causing:

```
Error: failed to extract tarball: failed to drain io reader: unexpected EOF
```

This has been observed across multiple projects that use openshift-preflight internally. 

The preflight binary has no internal retry for the image extraction step, so any stream truncation is fatal — even though the next attempt would likely succeed. Consumers have been forced to add [external retry wrappers](https://github.com/mongodb/mongodb-kubernetes/blob/9dcd46794344687d548b4adb873ee2c16c7af97f/scripts/preflight_images.py#L160) around the entire preflight command, which re-runs the full pipeline (pull → export → extract → all checks → write artifacts) on each retry.

## Root Cause

The error occurs in `untarOnce` (`internal/engine/untar.go`):
1. `mutate.Extract(img)` creates a reader that lazily streams image layers from the registry
2. `io.Copy(io.Discard, fs)` drains the reader
3. When the registry truncates the blob stream, the reader returns `unexpected EOF`
4. This bubbles up as `failed to extract tarball: failed to drain io reader: unexpected EOF`

The image manifest pull (`crane.Pull`) succeeds — it is small. The truncation happens during layer blob download, which is lazy and only triggered during extraction.

## Fix

Retry the `untar` call up to 3 times on `unexpected EOF` errors. Between retries:
- Clean the extraction directory (partial files from the failed attempt)
- Crane's filesystem cache (`cache.Image`) handles layer-level caching: incomplete layers are not cached, so only the failed layer is re-downloaded on retry

This is a targeted retry of just the extraction step, not the entire preflight pipeline. Checks that already completed are not re-run.

## Testing

- `go build ./internal/engine/` — compiles clean
- `go test ./internal/engine/ -count=1` — all existing tests pass

## Notes

- The ideal long-term fix would be resume support (HTTP range requests) in the image pull path, but that requires changes in `go-containerregistry`/`crane`.
- This is a minimal workaround: 20 lines, no new abstractions, no new imports (all already used in the file).
- The retry only triggers on `unexpected EOF` — legitimate certification failures are not retried.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retries when image extraction encounters an unexpected end-of-file error.
  * Extraction attempts now include cleanup, recreation, and increasing wait intervals to improve reliability.
  * Other extraction failures continue to be reported immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->