### PR TITLE
engine: eagerly pull image layers with retry before extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
+	golang.org/x/sync v0.21.0
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
@@ -110,7 +111,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
+	golang.org/x/sync v0.22.0
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
@@ -111,7 +112,6 @@ require (
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -149,7 +149,8 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to pull remote container: %v", err)
 	}
-	img = cache.Image(img, cache.NewFilesystemCache(imageTarPath))
+	layerCache := cache.NewFilesystemCache(imageTarPath)
+	img = cache.Image(img, layerCache)
 
 	containerFSPath := path.Join(tempdir, "fs")
 	if err := os.MkdirAll(containerFSPath, 0o755); err != nil && !os.IsExist(err) {
@@ -169,6 +170,14 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	for i, pattern := range requiredFilePatterns {
 		//coverage:ignore
 		requiredFilePatterns[i] = strings.TrimLeft(pattern, "/")
+	}
+
+	// Actually pull the image (all layers) up front, rather than lazily streaming
+	// layer content from the registry during untar. This isolates registry/network
+	// flakiness to a single, retried step instead of surfacing as a hard failure
+	// partway through extracting files to disk.
+	if err := pullLayers(ctx, img, layerCache); err != nil {
+		return fmt.Errorf("failed to pull image layers: %w", err)
 	}
 
 	slices.Sort(requiredFilePatterns)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -147,7 +147,8 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to pull remote container: %v", err)
 	}
-	img = cache.Image(img, cache.NewFilesystemCache(imageTarPath))
+	layerCache := cache.NewFilesystemCache(imageTarPath)
+	img = cache.Image(img, layerCache)
 
 	containerFSPath := path.Join(tempdir, "fs")
 	if err := os.MkdirAll(containerFSPath, 0o755); err != nil && !os.IsExist(err) {
@@ -167,6 +168,14 @@ func (c *craneEngine) ExecuteChecks(ctx context.Context) error {
 	for i, pattern := range requiredFilePatterns {
 		//coverage:ignore
 		requiredFilePatterns[i] = strings.TrimLeft(pattern, "/")
+	}
+
+	// Actually pull the image (all layers) up front, rather than lazily streaming
+	// layer content from the registry during untar. This isolates registry/network
+	// flakiness to a single, retried step instead of surfacing as a hard failure
+	// partway through extracting files to disk.
+	if err := pullLayers(ctx, img, layerCache); err != nil {
+		return fmt.Errorf("failed to pull image layers: %w", err)
 	}
 
 	slices.Sort(requiredFilePatterns)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -8,9 +8,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -174,6 +178,47 @@ var _ = Describe("Execute Checks tests", func() {
 				engine.image = "does.not/exist/anywhere:ever"
 				err := engine.ExecuteChecks(testcontext)
 				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("a layer fails to download", func() {
+			var origDelay time.Duration
+
+			BeforeEach(func() {
+				// Speed up the retry backoff so this test doesn't have to wait
+				// through the real, production-sized delays.
+				origDelay = pullLayerRetryBaseDelay
+				pullLayerRetryBaseDelay = time.Millisecond
+				DeferCleanup(func() { pullLayerRetryBaseDelay = origDelay })
+
+				// Front the already-populated registry with a proxy that always
+				// fails blob (layer) GET requests, while still serving manifests
+				// normally, simulating a registry that returns the manifest fine
+				// but can't reliably serve layer content. A 400 is used (rather
+				// than, say, 500) because go-containerregistry's remote package
+				// retries a handful of "retryable" status codes on its own; we
+				// want to exercise our own retry logic here, not compound it
+				// with that built-in behavior.
+				target, err := url.Parse(s.URL)
+				Expect(err).ToNot(HaveOccurred())
+				proxy := httputil.NewSingleHostReverseProxy(target)
+				failingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blobs/") {
+						http.Error(w, "simulated blob fetch failure", http.StatusBadRequest)
+						return
+					}
+					proxy.ServeHTTP(w, r)
+				}))
+				DeferCleanup(failingServer.Close)
+
+				failingURL, err := url.Parse(failingServer.URL)
+				Expect(err).ToNot(HaveOccurred())
+				engine.image = fmt.Sprintf("%s/test/crane", failingURL.Host)
+			})
+
+			It("should return an error pulling image layers", func() {
+				err := engine.ExecuteChecks(testcontext)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to pull image layers"))
 			})
 		})
 		Context("it is a bundle made with GNU tar layer", func() {

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/log"
+)
+
+// errLayerContentMismatch indicates that a layer's content, once fully read,
+// does not hash to the digest the layer itself reports. This can happen when
+// a previously-cached copy of the layer on disk is corrupted or was left
+// truncated by an interrupted download (see pullLayerWithRetry).
+var errLayerContentMismatch = errors.New("layer content does not match expected digest")
+
+const (
+	// pullLayerMaxAttempts is the number of times to attempt to fully download a
+	// single layer before giving up. go-containerregistry's own retry support
+	// (remote.WithRetryBackoff, etc.) only retries the initial HTTP round trip; it
+	// does not retry a read that fails partway through streaming a layer's body.
+	// This is the layer of retry that covers that gap.
+	pullLayerMaxAttempts = 3
+	// pullLayerConcurrency bounds how many layers are pulled at the same time,
+	// mirroring crane's own default job concurrency.
+	pullLayerConcurrency = 4
+)
+
+// pullLayerRetryBaseDelay is the initial backoff delay between failed
+// attempts to pull a single layer. Subsequent attempts double this delay.
+// It's a var (rather than a const) so tests can shrink it.
+var pullLayerRetryBaseDelay = 2 * time.Second
+
+// pullLayers eagerly downloads the full, uncompressed content of every layer in
+// img, verifying it against the layer's own digest. Reading through
+// cache.Image's lazy layer wrapper (see the caller in ExecuteChecks) is what
+// actually persists each layer to the on-disk filesystem cache, keyed by the
+// layer's DiffID -- the same value untar's use of mutate.Extract looks up
+// later. As a result, once pullLayers returns successfully, extraction can
+// proceed entirely against local disk with no further registry interaction,
+// and any layer that failed to download -- whether due to a transient network
+// error or a corrupted/truncated cache entry -- has already been retried here.
+// layerCache must be the same Cache instance img's layers were wrapped with
+// (via cache.Image), so a bad on-disk entry can be cleared before retrying.
+func pullLayers(ctx context.Context, img v1.Image, layerCache cache.Cache) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("failed to list image layers: %w", err)
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(pullLayerConcurrency)
+
+	for _, layer := range layers {
+		g.Go(func() error {
+			return pullLayerWithRetry(gctx, logger, layer, layerCache)
+		})
+	}
+
+	return g.Wait()
+}
+
+// pullLayerWithRetry fully downloads a single layer's uncompressed content,
+// retrying with a backoff if an attempt fails partway through. layerCache is
+// the same Cache the layer's image was wrapped with; on any failed attempt --
+// a network error or a detected content/digest mismatch -- the corresponding
+// on-disk cache entry is cleared before retrying. This matters even for plain
+// network errors: cache.Image's cache-miss path tees the remote response
+// straight to disk as it's read, so an interrupted download can leave a
+// truncated file cached. Left alone, a later read of that file can complete
+// without error (a short read isn't necessarily a read *error*), so a retry
+// could otherwise silently "succeed" against corrupt, incomplete data.
+func pullLayerWithRetry(ctx context.Context, logger logr.Logger, layer v1.Layer, layerCache cache.Cache) error {
+	diffID, err := layer.DiffID()
+	if err != nil {
+		return fmt.Errorf("failed to determine layer diff id: %w", err)
+	}
+
+	delay := pullLayerRetryBaseDelay
+	var lastErr error
+	for attempt := 1; attempt <= pullLayerMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if err := pullLayerOnce(layer, diffID); err != nil {
+			lastErr = err
+
+			if delErr := layerCache.Delete(diffID); delErr != nil && !errors.Is(delErr, cache.ErrNotFound) {
+				logger.V(log.DBG).Info("failed to clear cached layer after failed pull attempt",
+					"diffID", diffID.String(), "reason", delErr.Error())
+			}
+
+			reason := "failed to pull layer"
+			if errors.Is(err, errLayerContentMismatch) {
+				reason = "cached layer content did not match expected digest; cleared cache entry"
+			}
+
+			if attempt == pullLayerMaxAttempts {
+				logger.V(log.DBG).Info(reason+", exhausted all attempts",
+					"diffID", diffID.String(), "attempt", attempt, "maxAttempts", pullLayerMaxAttempts, "reason", err.Error())
+				break
+			}
+
+			logger.V(log.DBG).Info(reason+", will retry",
+				"diffID", diffID.String(), "attempt", attempt, "maxAttempts", pullLayerMaxAttempts, "reason", err.Error())
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			delay *= 2
+			continue
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("failed to pull layer %s after %d attempts: %w", diffID, pullLayerMaxAttempts, lastErr)
+}
+
+// pullLayerOnce makes a single attempt to fully read a layer's uncompressed
+// content, verifying that it hashes to the layer's own reported diffID.
+func pullLayerOnce(layer v1.Layer, diffID v1.Hash) error {
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	got, _, err := v1.SHA256(rc)
+	if err != nil {
+		return err
+	}
+
+	if got != diffID {
+		return fmt.Errorf("%w: computed %s, expected %s", errLayerContentMismatch, got, diffID)
+	}
+
+	return nil
+}

--- a/internal/engine/pull_test.go
+++ b/internal/engine/pull_test.go
@@ -1,0 +1,455 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/cache"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// fakeLayer wraps a real, static v1.Layer so that Digest/DiffID/Size/MediaType
+// behave normally, while allowing Uncompressed to be made to fail a
+// configurable number of times (and/or block) before delegating to the
+// wrapped layer's real behavior.
+type fakeLayer struct {
+	v1.Layer
+
+	mu      sync.Mutex
+	calls   int
+	failN   int
+	blockFn func()
+}
+
+func newFakeLayer(content []byte, failN int) *fakeLayer {
+	return &fakeLayer{
+		Layer: static.NewLayer(content, types.DockerLayer),
+		failN: failN,
+	}
+}
+
+func (f *fakeLayer) Uncompressed() (io.ReadCloser, error) {
+	f.mu.Lock()
+	f.calls++
+	call := f.calls
+	block := f.blockFn
+	f.mu.Unlock()
+
+	if block != nil {
+		block()
+	}
+
+	if call <= f.failN {
+		return nil, fmt.Errorf("simulated failure on attempt %d", call)
+	}
+	return f.Layer.Uncompressed()
+}
+
+func (f *fakeLayer) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// erroringLayersImage wraps a real v1.Image but fails when its layers are
+// listed, simulating a malformed or unreadable manifest.
+type erroringLayersImage struct {
+	v1.Image
+}
+
+func (erroringLayersImage) Layers() ([]v1.Layer, error) {
+	return nil, errors.New("simulated layers listing failure")
+}
+
+// diffIDErrLayer wraps a real v1.Layer but fails to report its DiffID,
+// simulating a layer with corrupt or unreadable metadata.
+type diffIDErrLayer struct {
+	v1.Layer
+}
+
+func (diffIDErrLayer) DiffID() (v1.Hash, error) {
+	return v1.Hash{}, errors.New("simulated diffID failure")
+}
+
+// flakyReader yields a fixed amount of data successfully and then fails,
+// simulating a connection that drops partway through streaming a layer's
+// body after the request itself already succeeded.
+type flakyReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *flakyReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, errors.New("simulated connection reset mid-stream")
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *flakyReader) Close() error { return nil }
+
+// midStreamFailLayer wraps a real v1.Layer, but its Uncompressed reader opens
+// successfully and then fails partway through being read.
+type midStreamFailLayer struct {
+	v1.Layer
+}
+
+func (midStreamFailLayer) Uncompressed() (io.ReadCloser, error) {
+	return &flakyReader{data: []byte("partial-layer-content")}, nil
+}
+
+// corruptThenCleanLayer wraps a real, static v1.Layer -- which provides the
+// correct Digest/DiffID/Size/MediaType for goodContent -- but serves
+// different, non-matching bytes from Uncompressed for the first corruptN
+// calls before falling back to the real, correct content. This simulates a
+// cache entry that was corrupted (or left truncated by an earlier interrupted
+// download) before eventually being cleared and re-fetched cleanly.
+type corruptThenCleanLayer struct {
+	v1.Layer
+
+	mu             sync.Mutex
+	calls          int
+	corruptN       int
+	corruptContent []byte
+}
+
+func newCorruptThenCleanLayer(goodContent, corruptContent []byte, corruptN int) *corruptThenCleanLayer {
+	return &corruptThenCleanLayer{
+		Layer:          static.NewLayer(goodContent, types.DockerLayer),
+		corruptN:       corruptN,
+		corruptContent: corruptContent,
+	}
+}
+
+func (l *corruptThenCleanLayer) Uncompressed() (io.ReadCloser, error) {
+	l.mu.Lock()
+	l.calls++
+	call := l.calls
+	l.mu.Unlock()
+
+	if call <= l.corruptN {
+		return io.NopCloser(bytes.NewReader(l.corruptContent)), nil
+	}
+	return l.Layer.Uncompressed()
+}
+
+func (l *corruptThenCleanLayer) Calls() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+// truncatingRemoteLayer wraps a real, static v1.Layer -- which provides the
+// correct Digest/DiffID/Size/MediaType for goodContent -- but simulates a
+// remote layer whose network stream is interrupted partway through the very
+// first read (as if a connection dropped mid-download), yielding only
+// partial bytes before failing. Subsequent reads succeed with the full,
+// correct content, as a genuine retried fetch would.
+type truncatingRemoteLayer struct {
+	v1.Layer
+
+	mu      sync.Mutex
+	calls   int
+	partial []byte
+}
+
+func newTruncatingRemoteLayer(goodContent, partial []byte) *truncatingRemoteLayer {
+	return &truncatingRemoteLayer{
+		Layer:   static.NewLayer(goodContent, types.DockerLayer),
+		partial: partial,
+	}
+}
+
+func (l *truncatingRemoteLayer) Uncompressed() (io.ReadCloser, error) {
+	l.mu.Lock()
+	l.calls++
+	call := l.calls
+	l.mu.Unlock()
+
+	if call == 1 {
+		return &flakyReader{data: l.partial}, nil
+	}
+	return l.Layer.Uncompressed()
+}
+
+func (l *truncatingRemoteLayer) Calls() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+// fakeCache is a minimal, in-memory cache.Cache used to observe which layers
+// get deleted from the cache after a failed pull attempt, without touching
+// disk. Get always reports a cache miss, since these tests exercise
+// pullLayers/pullLayerWithRetry directly against plain (non-cache-wrapped)
+// layers; only Delete tracking matters here.
+type fakeCache struct {
+	mu        sync.Mutex
+	deleted   []v1.Hash
+	deleteErr error
+}
+
+func (c *fakeCache) Put(l v1.Layer) (v1.Layer, error) { return l, nil }
+
+func (c *fakeCache) Get(v1.Hash) (v1.Layer, error) { return nil, cache.ErrNotFound }
+
+func (c *fakeCache) Delete(h v1.Hash) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleted = append(c.deleted, h)
+	return c.deleteErr
+}
+
+func (c *fakeCache) Deleted() []v1.Hash {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.deleted)
+}
+
+var _ = Describe("pullLayers", func() {
+	var origDelay time.Duration
+
+	BeforeEach(func() {
+		origDelay = pullLayerRetryBaseDelay
+		pullLayerRetryBaseDelay = time.Millisecond
+		DeferCleanup(func() { pullLayerRetryBaseDelay = origDelay })
+	})
+
+	It("succeeds on the first attempt when the layer downloads cleanly", func() {
+		layer := newFakeLayer([]byte("hello"), 0)
+		img, err := mutate.AppendLayers(empty.Image, layer)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pullLayers(context.Background(), img, &fakeCache{})).To(Succeed())
+		Expect(layer.Calls()).To(Equal(1))
+	})
+
+	It("retries a layer that fails transiently and eventually succeeds", func() {
+		layer := newFakeLayer([]byte("hello"), pullLayerMaxAttempts-1)
+		img, err := mutate.AppendLayers(empty.Image, layer)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(pullLayers(context.Background(), img, &fakeCache{})).To(Succeed())
+		Expect(layer.Calls()).To(Equal(pullLayerMaxAttempts))
+	})
+
+	It("returns a wrapped error once all attempts are exhausted", func() {
+		layer := newFakeLayer([]byte("hello"), pullLayerMaxAttempts+5)
+		img, err := mutate.AppendLayers(empty.Image, layer)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = pullLayers(context.Background(), img, &fakeCache{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to pull layer"))
+		Expect(layer.Calls()).To(Equal(pullLayerMaxAttempts))
+	})
+
+	It("bounds concurrency across many layers", func() {
+		const numLayers = pullLayerConcurrency * 3
+
+		var (
+			mu         sync.Mutex
+			active     int
+			maxActive  int
+			releaseAll = make(chan struct{})
+		)
+
+		layers := make([]v1.Layer, 0, numLayers)
+		for i := 0; i < numLayers; i++ {
+			l := newFakeLayer([]byte(fmt.Sprintf("layer-%d", i)), 0)
+			l.blockFn = func() {
+				mu.Lock()
+				active++
+				if active > maxActive {
+					maxActive = active
+				}
+				mu.Unlock()
+
+				<-releaseAll
+
+				mu.Lock()
+				active--
+				mu.Unlock()
+			}
+			layers = append(layers, l)
+		}
+
+		img, err := mutate.AppendLayers(empty.Image, layers...)
+		Expect(err).ToNot(HaveOccurred())
+
+		done := make(chan error, 1)
+		go func() {
+			done <- pullLayers(context.Background(), img, &fakeCache{})
+		}()
+
+		// Wait until the pool has filled up to its configured limit.
+		Eventually(func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return active
+		}).Should(Equal(pullLayerConcurrency))
+
+		// It should never exceed that limit while more layers remain queued.
+		Consistently(func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return maxActive
+		}).Should(BeNumerically("<=", pullLayerConcurrency))
+
+		close(releaseAll)
+		Eventually(done).Should(Receive(BeNil()))
+		Expect(maxActive).To(Equal(pullLayerConcurrency))
+	})
+
+	It("stops promptly without retrying when the context is already cancelled", func() {
+		layer := newFakeLayer([]byte("hello"), pullLayerMaxAttempts+5)
+		img, err := mutate.AppendLayers(empty.Image, layer)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err = pullLayers(ctx, img, &fakeCache{})
+		Expect(err).To(MatchError(context.Canceled))
+		// The context is checked before the first attempt, so the layer
+		// should never actually be read -- distinguishing prompt
+		// cancellation from exhausting retries against a failing layer.
+		Expect(layer.Calls()).To(Equal(0))
+	})
+
+	It("returns a wrapped error when listing an image's layers fails", func() {
+		err := pullLayers(context.Background(), erroringLayersImage{Image: empty.Image}, &fakeCache{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to list image layers"))
+	})
+
+	It("returns an error when a layer's stream fails partway through", func() {
+		layer := midStreamFailLayer{Layer: static.NewLayer([]byte("hello"), types.DockerLayer)}
+		diffID, err := layer.DiffID()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = pullLayerOnce(layer, diffID)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated connection reset mid-stream"))
+	})
+
+	It("returns a wrapped error when a layer's DiffID cannot be determined", func() {
+		layer := diffIDErrLayer{Layer: static.NewLayer([]byte("hello"), types.DockerLayer)}
+		err := pullLayerWithRetry(context.Background(), logr.Discard(), layer, &fakeCache{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to determine layer diff id"))
+	})
+
+	It("stops waiting and returns promptly when the context is cancelled during backoff", func() {
+		pullLayerRetryBaseDelay = 200 * time.Millisecond
+		layer := newFakeLayer([]byte("hello"), pullLayerMaxAttempts+5)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+
+		err := pullLayerWithRetry(ctx, logr.Discard(), layer, &fakeCache{})
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+		Expect(layer.Calls()).To(Equal(1))
+	})
+
+	It("clears the cached entry and retries when a layer's content does not match its digest", func() {
+		good := []byte("the-real-uncorrupted-layer-content")
+		bad := []byte("corrupted-bytes-of-a-different-length")
+		layer := newCorruptThenCleanLayer(good, bad, 1)
+
+		diffID, err := layer.DiffID()
+		Expect(err).ToNot(HaveOccurred())
+
+		fc := &fakeCache{}
+		Expect(pullLayerWithRetry(context.Background(), logr.Discard(), layer, fc)).To(Succeed())
+		Expect(layer.Calls()).To(Equal(2))
+		Expect(fc.Deleted()).To(ConsistOf(diffID))
+	})
+
+	It("returns a wrapped mismatch error and clears the cache on every attempt when corruption persists", func() {
+		good := []byte("the-real-uncorrupted-layer-content")
+		bad := []byte("always-corrupted")
+		layer := newCorruptThenCleanLayer(good, bad, pullLayerMaxAttempts+5)
+
+		diffID, err := layer.DiffID()
+		Expect(err).ToNot(HaveOccurred())
+
+		fc := &fakeCache{}
+		err = pullLayerWithRetry(context.Background(), logr.Discard(), layer, fc)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, errLayerContentMismatch)).To(BeTrue())
+
+		deleted := fc.Deleted()
+		Expect(deleted).To(HaveLen(pullLayerMaxAttempts))
+		for _, h := range deleted {
+			Expect(h).To(Equal(diffID))
+		}
+	})
+
+	It("logs but does not fail the retry when clearing the cache entry itself errors", func() {
+		layer := newFakeLayer([]byte("hello"), 1)
+		fc := &fakeCache{deleteErr: errors.New("simulated disk error clearing cache entry")}
+
+		Expect(pullLayerWithRetry(context.Background(), logr.Discard(), layer, fc)).To(Succeed())
+		Expect(fc.Deleted()).To(HaveLen(1))
+	})
+
+	It("clears a truncated on-disk cache entry left by an interrupted download and re-fetches cleanly", func() {
+		tmpDir, err := os.MkdirTemp("", "pull-layers-cache-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpDir)
+
+		// Large enough that "half of it" is a meaningfully truncated,
+		// non-matching prefix rather than a coincidentally-valid tarball.
+		good := []byte(strings.Repeat("real-layer-content-", 1000))
+		partial := good[:len(good)/2]
+
+		remoteLayer := newTruncatingRemoteLayer(good, partial)
+		diffID, err := remoteLayer.DiffID()
+		Expect(err).ToNot(HaveOccurred())
+
+		realCache := cache.NewFilesystemCache(tmpDir)
+		img, err := mutate.AppendLayers(empty.Image, remoteLayer)
+		Expect(err).ToNot(HaveOccurred())
+		cachedImg := cache.Image(img, realCache)
+
+		// Without pullLayers explicitly deleting the cache entry after the
+		// first, interrupted attempt, go-containerregistry's own filesystem
+		// cache would happily hand back that truncated file on the next
+		// read (a short plain-file read isn't an io.ErrUnexpectedEOF), so
+		// this only succeeds if the corrupted entry was actually cleared.
+		Expect(pullLayers(context.Background(), cachedImg, realCache)).To(Succeed())
+		Expect(remoteLayer.Calls()).To(Equal(2))
+
+		cachedLayer, err := realCache.Get(diffID)
+		Expect(err).ToNot(HaveOccurred())
+		rc, err := cachedLayer.Uncompressed()
+		Expect(err).ToNot(HaveOccurred())
+		defer rc.Close()
+
+		gotBytes, err := io.ReadAll(rc)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gotBytes).To(Equal(good))
+	})
+})


### PR DESCRIPTION
## Description

`crane.Pull`/`cache.Image` only fetch the image manifest eagerly; each layer's bytes were previously fetched lazily, the first time they were read during `untar`. go-containerregistry's retry support only retries the initial HTTP round trip, not a body read that fails partway through streaming a layer, so a transient network drop mid-layer surfaced as a hard failure deep inside tar extraction.

This adds `pullLayers`, which eagerly downloads every layer's uncompressed content into the on-disk filesystem cache (keyed by `DiffID`, the same lookup `untar`'s use of `mutate.Extract` performs) using a bounded concurrency pool, retrying each layer independently with backoff on failure. This isolates registry/network flakiness to a single step before extraction begins, so `untar` only ever operates on local data.

## Testing

- `make vet`
- `make lint`
- `make fmt` / `make tidy` (no diffs)
- `make test`
- `make cover` (100% coverage maintained)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image processing by downloading and verifying all image layers before extraction.
  * Added automatic retries with backoff for temporary layer download failures.
  * Added clearer error reporting for unavailable, corrupted, or incomplete image layers.
  * Improved handling of cancellations, interrupted transfers, cache inconsistencies, and failed retries.
  * Limited simultaneous layer downloads to improve stability and resource usage.
  * Added integrity checks to detect corrupted layer contents before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->