### PR TITLE
fix: allow cross-architecture RPM additions in HasModifiedFiles check

### DIFF
--- a/internal/policy/container/has_modified_files.go
+++ b/internal/policy/container/has_modified_files.go
@@ -253,76 +253,105 @@ func (p *HasModifiedFilesCheck) validate(ctx context.Context, layerIDs []string,
 				// This is a net-new package file. Pass it.
 				continue
 			}
-			currentPackageVersion := ref.LayerPackageFiles[modifiedFile]
-			previousPackage := packageFiles[layerIDs[idx-1]].LayerPackages[previousPackageVersion]
-			currentPackage := ref.LayerPackages[currentPackageVersion]
+		currentPackageVersion := ref.LayerPackageFiles[modifiedFile]
+		previousPackage := packageFiles[layerIDs[idx-1]].LayerPackages[previousPackageVersion]
+		currentPackage := ref.LayerPackages[currentPackageVersion]
 
-			if previousPackageVersion == currentPackageVersion {
-				previousFileInfo := fileInfo{}
-				// Since the modified file will not necessarily be present in the immediately previous layer, we need
-				// to go backwards through the layers to look for the last time this file was in a layer, and get the
-				// mode from there.
-				for layerIdx := idx - 1; layerIdx > -1; layerIdx-- {
-					if pfi, found := packageFiles[layerIDs[layerIdx]].LayerFiles[modifiedFile]; found {
-						previousFileInfo.Mode = pfi.Mode
-						break
-					}
+		// Handle cross-architecture package additions (e.g. i686 installed alongside x86_64).
+		// When the file's owning package differs between layers only in architecture and
+		// the original architecture's package is still present, this is a legitimate addition.
+		if previousPackageVersion != currentPackageVersion &&
+			isCrossArchAddition(previousPackageVersion, currentPackageVersion, ref.LayerPackages) {
+			logger.V(log.DBG).Info("cross-architecture package addition detected, original package still present",
+				"file", modifiedFile,
+				"originalPackage", previousPackageVersion,
+				"additionalPackage", currentPackageVersion)
+			continue
+		}
+
+		if previousPackageVersion == currentPackageVersion {
+			previousFileInfo := fileInfo{}
+			// Since the modified file will not necessarily be present in the immediately previous layer, we need
+			// to go backwards through the layers to look for the last time this file was in a layer, and get the
+			// mode from there.
+			for layerIdx := idx - 1; layerIdx > -1; layerIdx-- {
+				if pfi, found := packageFiles[layerIDs[layerIdx]].LayerFiles[modifiedFile]; found {
+					previousFileInfo.Mode = pfi.Mode
+					break
 				}
-				setUIDRemoved := previousFileInfo.Mode&fs.ModeSetuid > 0 && modifiedFileInfo.Mode&fs.ModeSetuid == 0
-				setGIDRemoved := previousFileInfo.Mode&fs.ModeSetgid > 0 && modifiedFileInfo.Mode&fs.ModeSetgid == 0
+			}
+			setUIDRemoved := previousFileInfo.Mode&fs.ModeSetuid > 0 && modifiedFileInfo.Mode&fs.ModeSetuid == 0
+			setGIDRemoved := previousFileInfo.Mode&fs.ModeSetgid > 0 && modifiedFileInfo.Mode&fs.ModeSetgid == 0
 
-				// Something in the mode changed. The only thing we support is removal of setuid/setgid bits
-				if setUIDRemoved || setGIDRemoved {
-					logger.V(log.DBG).Info("setuid/setgid bit removed")
-					continue
-				}
-
-				if !strings.Contains(currentPackage.Release, packageDist) && packageDist != "unknown" {
-					// This means it's _probably_ not a RH package. If the file is changed, warn, but don't fail
-					logger.Info("WARN: an rpm-installed file was modified outside of rpm, but appears to be from a third-party. This could be a failure in the future")
-					continue
-				}
-
-				if currentPackage.Vendor != "Red Hat, Inc." && previousPackage.Vendor != "Red Hat, Inc." {
-					//coverage:ignore
-					// This means it's _probably_ not a RH package. If the file is changed, warn, but don't fail
-					logger.Info("WARN: an rpm-installed file was modified outside of rpm, but appears to be from a third-party. This could be a failure in the future")
-					continue
-				}
-
-				if currentPackage.InstallTime > previousPackage.InstallTime {
-					//coverage:ignore
-					// This _probably_ means that the package was either:
-					// a) explicitly rpm -e then rpm -i
-					// b) dnf reinstall
-					// This should not trigger. Going to trace log this, but not always report
-					logger.V(log.TRC).Info("package appears to have been re-installed or removed and installed in the same layer", "package", currentPackage.Name)
-					continue
-				}
-
-				// Nope, nope, nope. File was modified without using RPM
-				logger.Info("found disallowed modification in layer", "file", modifiedFile)
-				disallowedModifications = true
+			// Something in the mode changed. The only thing we support is removal of setuid/setgid bits
+			if setUIDRemoved || setGIDRemoved {
+				logger.V(log.DBG).Info("setuid/setgid bit removed")
 				continue
 			}
 
-			// Check that release contains the same arch, this is to ensure that a package did not get rebuilt with
-			// a different architecture
-			previousOsRelease := strings.Contains(previousPackage.Release, packageDist)
-			currentOsRelease := strings.Contains(currentPackage.Release, packageDist)
-
-			if previousOsRelease && !currentOsRelease {
-				logger.Info("mismatch in OS release", "file", modifiedFile)
-				disallowedModifications = true
+			if !strings.Contains(currentPackage.Release, packageDist) && packageDist != "unknown" {
+				// This means it's _probably_ not a RH package. If the file is changed, warn, but don't fail
+				logger.Info("WARN: an rpm-installed file was modified outside of rpm, but appears to be from a third-party. This could be a failure in the future")
 				continue
 			}
 
-			// Check that the architectures for previous version and current version of a given package match
-			if previousPackage.Arch != currentPackage.Arch {
-				logger.Info("mismatch in package architecture", "file", modifiedFile)
-				disallowedModifications = true
+			if currentPackage.Vendor != "Red Hat, Inc." && previousPackage.Vendor != "Red Hat, Inc." {
+				//coverage:ignore
+				// This means it's _probably_ not a RH package. If the file is changed, warn, but don't fail
+				logger.Info("WARN: an rpm-installed file was modified outside of rpm, but appears to be from a third-party. This could be a failure in the future")
 				continue
 			}
+
+			if currentPackage.InstallTime > previousPackage.InstallTime {
+				//coverage:ignore
+				// This _probably_ means that the package was either:
+				// a) explicitly rpm -e then rpm -i
+				// b) dnf reinstall
+				// This should not trigger. Going to trace log this, but not always report
+				logger.V(log.TRC).Info("package appears to have been re-installed or removed and installed in the same layer", "package", currentPackage.Name)
+				continue
+			}
+
+			// Check if a cross-architecture variant of this package was added in this layer,
+			// causing shared files to be rewritten without actual content changes.
+			if crossArchPackageAdded(ref.LayerPackages, packageFiles[layerIDs[idx-1]].LayerPackages, currentPackage) {
+				logger.V(log.DBG).Info("file modified during cross-architecture package installation",
+					"file", modifiedFile, "package", currentPackage.Name)
+				continue
+			}
+
+			// Nope, nope, nope. File was modified without using RPM
+			logger.Info("found disallowed modification in layer", "file", modifiedFile)
+			disallowedModifications = true
+			continue
+		}
+
+		// Check that release contains the same arch, this is to ensure that a package did not get rebuilt with
+		// a different architecture
+		previousOsRelease := strings.Contains(previousPackage.Release, packageDist)
+		currentOsRelease := strings.Contains(currentPackage.Release, packageDist)
+
+		if previousOsRelease && !currentOsRelease {
+			logger.Info("mismatch in OS release", "file", modifiedFile)
+			disallowedModifications = true
+			continue
+		}
+
+		// Check that the architectures for previous version and current version of a given package match
+		if previousPackage.Arch != currentPackage.Arch {
+			// Before failing, verify this isn't a cross-arch addition where both architectures
+			// now coexist. If the original package is still present, this is legitimate.
+			if _, stillPresent := ref.LayerPackages[previousPackageVersion]; stillPresent {
+				logger.V(log.DBG).Info("cross-architecture package coexistence detected",
+					"file", modifiedFile,
+					"previousArch", previousPackage.Arch,
+					"currentArch", currentPackage.Arch)
+				continue
+			}
+			logger.Info("mismatch in package architecture", "file", modifiedFile)
+			disallowedModifications = true
+			continue
+		}
 
 			// This appears like an update. This is allowed.
 			// No further action required
@@ -369,6 +398,41 @@ func extractPackageNameVersionRelease(pkgList []*rpmdb.PackageInfo) map[string]p
 		}
 	}
 	return pkgNameList
+}
+
+// isCrossArchAddition returns true if previousPkgVer and currentPkgVer refer to the same
+// package name/version/release but differ only in architecture, AND the original (previous)
+// package is still present in the current layer's packages. This indicates a cross-architecture
+// addition (e.g. i686 installed alongside x86_64) rather than a replacement.
+func isCrossArchAddition(previousPkgVer, currentPkgVer string, currentLayerPackages map[string]packageMeta) bool {
+	prevParts := strings.SplitN(previousPkgVer, "-", 4)
+	currParts := strings.SplitN(currentPkgVer, "-", 4)
+	if len(prevParts) != 4 || len(currParts) != 4 {
+		return false
+	}
+	if prevParts[0] != currParts[0] || prevParts[1] != currParts[1] || prevParts[2] != currParts[2] {
+		return false
+	}
+	if prevParts[3] == currParts[3] {
+		return false
+	}
+	_, stillPresent := currentLayerPackages[previousPkgVer]
+	return stillPresent
+}
+
+// crossArchPackageAdded returns true if a new architecture variant of the given package
+// was added in the current layer compared to the previous layer. This handles the case
+// where shared files are rewritten during cross-arch package installation without actual
+// content modification.
+func crossArchPackageAdded(currentPackages, previousPackages map[string]packageMeta, pkg packageMeta) bool {
+	for nvra, meta := range currentPackages {
+		if meta.Name == pkg.Name && meta.Version == pkg.Version && meta.Release == pkg.Release && meta.Arch != pkg.Arch {
+			if _, existedBefore := previousPackages[nvra]; !existedBefore {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // findRPMDB attempts to extract a valid RPMDB from layers in the order

--- a/internal/policy/container/has_modified_files_test.go
+++ b/internal/policy/container/has_modified_files_test.go
@@ -395,7 +395,192 @@ var _ = Describe("HasModifiedFiles", func() {
 				Expect(ok).To(BeFalse())
 			})
 		})
-		When("release dist does not match installed OS", func() {
+		When("a cross-architecture package is added alongside the original", func() {
+		When("the file maps to the new architecture in the current layer (Path 1)", func() {
+			var pkgs map[string]packageFilesRef
+			BeforeEach(func() {
+				pkgs = deepCopyPackage(pkgRef)
+
+				// Simulate: base layer has foo-1.0-1.d9 as x86_64.
+				// New layer adds i686 variant. The shared file maps to i686 in the current layer
+				// due to map iteration order, but x86_64 is still present.
+				pkgSecondLayerPackages := pkgs["secondlayer"].LayerPackages
+				pkgSecondLayerPackages["foo-1.0-1.d9-i686"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "i686",
+					Vendor:  "Red Hat, Inc.",
+				}
+				// Rename original to include arch in the key for clarity
+				delete(pkgSecondLayerPackages, "foo-1.0-1.d9")
+				pkgSecondLayerPackages["foo-1.0-1.d9-x86_64"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "x86_64",
+					Vendor:  "Red Hat, Inc.",
+				}
+
+				pkgSecondLayerPackageFiles := pkgs["secondlayer"].LayerPackageFiles
+				// File now maps to i686 variant (simulating non-deterministic iteration)
+				pkgSecondLayerPackageFiles["this"] = "foo-1.0-1.d9-i686"
+
+				pkgSecondLayerFiles := pkgs["secondlayer"].LayerFiles
+				pkgSecondLayerFiles["this"] = fileInfo{Mode: fileMask}
+
+				pkgs["secondlayer"] = packageFilesRef{
+					LayerPackages:     pkgSecondLayerPackages,
+					LayerPackageFiles: pkgSecondLayerPackageFiles,
+					LayerFiles:        pkgSecondLayerFiles,
+					HasRPMDB:          true,
+				}
+
+				// Also update first layer to use arch-qualified key
+				pkgFirstLayerPackages := pkgs["firstlayer"].LayerPackages
+				delete(pkgFirstLayerPackages, "foo-1.0-1.d9")
+				pkgFirstLayerPackages["foo-1.0-1.d9-x86_64"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "x86_64",
+					Vendor:  "Red Hat, Inc.",
+				}
+				pkgFirstLayerPackageFiles := pkgs["firstlayer"].LayerPackageFiles
+				pkgFirstLayerPackageFiles["this"] = "foo-1.0-1.d9-x86_64"
+				pkgs["firstlayer"] = packageFilesRef{
+					LayerPackages:     pkgFirstLayerPackages,
+					LayerPackageFiles: pkgFirstLayerPackageFiles,
+					LayerFiles:        pkgs["firstlayer"].LayerFiles,
+					HasRPMDB:          true,
+				}
+			})
+			It("should pass validate because the original arch is still present", func() {
+				ok, err := hasModifiedFiles.validate(context.Background(), layers, pkgs, dist)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		When("the file maps to the same architecture but is rewritten by cross-arch install (Path 2)", func() {
+			var pkgs map[string]packageFilesRef
+			BeforeEach(func() {
+				pkgs = deepCopyPackage(pkgRef)
+
+				// Simulate: both layers map file to x86_64 (consistent iteration),
+				// but the file appears in LayerFiles because installing i686 rewrites shared files.
+				pkgSecondLayerPackages := pkgs["secondlayer"].LayerPackages
+				delete(pkgSecondLayerPackages, "foo-1.0-1.d9")
+				pkgSecondLayerPackages["foo-1.0-1.d9-x86_64"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "x86_64",
+					Vendor:  "Red Hat, Inc.",
+				}
+				// i686 variant added in this layer
+				pkgSecondLayerPackages["foo-1.0-1.d9-i686"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "i686",
+					Vendor:  "Red Hat, Inc.",
+				}
+
+				pkgSecondLayerPackageFiles := pkgs["secondlayer"].LayerPackageFiles
+				pkgSecondLayerPackageFiles["this"] = "foo-1.0-1.d9-x86_64"
+
+				pkgSecondLayerFiles := pkgs["secondlayer"].LayerFiles
+				pkgSecondLayerFiles["this"] = fileInfo{Mode: fileMask}
+
+				pkgs["secondlayer"] = packageFilesRef{
+					LayerPackages:     pkgSecondLayerPackages,
+					LayerPackageFiles: pkgSecondLayerPackageFiles,
+					LayerFiles:        pkgSecondLayerFiles,
+					HasRPMDB:          true,
+				}
+
+				// First layer only has x86_64
+				pkgFirstLayerPackages := pkgs["firstlayer"].LayerPackages
+				delete(pkgFirstLayerPackages, "foo-1.0-1.d9")
+				pkgFirstLayerPackages["foo-1.0-1.d9-x86_64"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "x86_64",
+					Vendor:  "Red Hat, Inc.",
+				}
+				pkgFirstLayerPackageFiles := pkgs["firstlayer"].LayerPackageFiles
+				pkgFirstLayerPackageFiles["this"] = "foo-1.0-1.d9-x86_64"
+				pkgs["firstlayer"] = packageFilesRef{
+					LayerPackages:     pkgFirstLayerPackages,
+					LayerPackageFiles: pkgFirstLayerPackageFiles,
+					LayerFiles:        pkgs["firstlayer"].LayerFiles,
+					HasRPMDB:          true,
+				}
+			})
+			It("should pass validate because cross-arch package was added", func() {
+				ok, err := hasModifiedFiles.validate(context.Background(), layers, pkgs, dist)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+		When("the architecture truly changes without the original present", func() {
+			var pkgs map[string]packageFilesRef
+			BeforeEach(func() {
+				pkgs = deepCopyPackage(pkgRef)
+
+				// Simulate: original x86_64 is REMOVED and replaced with i686 only.
+				// This should still fail.
+				pkgSecondLayerPackages := pkgs["secondlayer"].LayerPackages
+				delete(pkgSecondLayerPackages, "foo-1.0-1.d9")
+				pkgSecondLayerPackages["foo-1.0-1.d9-i686"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "i686",
+					Vendor:  "Red Hat, Inc.",
+				}
+
+				pkgSecondLayerPackageFiles := pkgs["secondlayer"].LayerPackageFiles
+				pkgSecondLayerPackageFiles["this"] = "foo-1.0-1.d9-i686"
+
+				pkgSecondLayerFiles := pkgs["secondlayer"].LayerFiles
+				pkgSecondLayerFiles["this"] = fileInfo{Mode: fileMask}
+
+				pkgs["secondlayer"] = packageFilesRef{
+					LayerPackages:     pkgSecondLayerPackages,
+					LayerPackageFiles: pkgSecondLayerPackageFiles,
+					LayerFiles:        pkgSecondLayerFiles,
+					HasRPMDB:          true,
+				}
+
+				// First layer uses arch-qualified key
+				pkgFirstLayerPackages := pkgs["firstlayer"].LayerPackages
+				delete(pkgFirstLayerPackages, "foo-1.0-1.d9")
+				pkgFirstLayerPackages["foo-1.0-1.d9-x86_64"] = packageMeta{
+					Name:    "foo",
+					Version: "1.0",
+					Release: "1.d9",
+					Arch:    "x86_64",
+					Vendor:  "Red Hat, Inc.",
+				}
+				pkgFirstLayerPackageFiles := pkgs["firstlayer"].LayerPackageFiles
+				pkgFirstLayerPackageFiles["this"] = "foo-1.0-1.d9-x86_64"
+				pkgs["firstlayer"] = packageFilesRef{
+					LayerPackages:     pkgFirstLayerPackages,
+					LayerPackageFiles: pkgFirstLayerPackageFiles,
+					LayerFiles:        pkgs["firstlayer"].LayerFiles,
+					HasRPMDB:          true,
+				}
+			})
+			It("should fail because original package is not present", func() {
+				ok, err := hasModifiedFiles.validate(context.Background(), layers, pkgs, dist)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+	When("release dist does not match installed OS", func() {
 			When("package is a net-new", func() {
 				When("a file is modified", func() {
 					var pkgs map[string]packageFilesRef
@@ -605,4 +790,84 @@ var _ = Describe("HasModifiedFiles", func() {
 	})
 
 	AssertMetaData(&hasModifiedFiles)
+
+	Describe("isCrossArchAddition", func() {
+		var currentLayerPackages map[string]packageMeta
+
+		BeforeEach(func() {
+			currentLayerPackages = map[string]packageMeta{
+				"libstdc++-8.5.0-20.el8-x86_64": {Name: "libstdc++", Version: "8.5.0", Release: "20.el8", Arch: "x86_64"},
+				"libstdc++-8.5.0-20.el8-i686":   {Name: "libstdc++", Version: "8.5.0", Release: "20.el8", Arch: "i686"},
+			}
+		})
+
+		It("should return true when same NVR, different arch, original still present", func() {
+			result := isCrossArchAddition("libstdc++-8.5.0-20.el8-x86_64", "libstdc++-8.5.0-20.el8-i686", currentLayerPackages)
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false when the original package is not in current layer", func() {
+			delete(currentLayerPackages, "libstdc++-8.5.0-20.el8-x86_64")
+			result := isCrossArchAddition("libstdc++-8.5.0-20.el8-x86_64", "libstdc++-8.5.0-20.el8-i686", currentLayerPackages)
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when versions differ", func() {
+			result := isCrossArchAddition("libstdc++-8.5.0-20.el8-x86_64", "libstdc++-9.0.0-20.el8-i686", currentLayerPackages)
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when names differ", func() {
+			result := isCrossArchAddition("glibc-2.28-20.el8-x86_64", "libstdc++-8.5.0-20.el8-i686", currentLayerPackages)
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when architectures are the same", func() {
+			result := isCrossArchAddition("libstdc++-8.5.0-20.el8-x86_64", "libstdc++-8.5.0-20.el8-x86_64", currentLayerPackages)
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false with malformed package version strings", func() {
+			result := isCrossArchAddition("bad-format", "libstdc++-8.5.0-20.el8-i686", currentLayerPackages)
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Describe("crossArchPackageAdded", func() {
+		It("should return true when a new arch variant exists in current but not previous", func() {
+			current := map[string]packageMeta{
+				"foo-1.0-1.el8-x86_64": {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"},
+				"foo-1.0-1.el8-i686":   {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "i686"},
+			}
+			previous := map[string]packageMeta{
+				"foo-1.0-1.el8-x86_64": {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"},
+			}
+			pkg := packageMeta{Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"}
+			Expect(crossArchPackageAdded(current, previous, pkg)).To(BeTrue())
+		})
+
+		It("should return false when both arch variants existed before", func() {
+			current := map[string]packageMeta{
+				"foo-1.0-1.el8-x86_64": {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"},
+				"foo-1.0-1.el8-i686":   {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "i686"},
+			}
+			previous := map[string]packageMeta{
+				"foo-1.0-1.el8-x86_64": {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"},
+				"foo-1.0-1.el8-i686":   {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "i686"},
+			}
+			pkg := packageMeta{Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"}
+			Expect(crossArchPackageAdded(current, previous, pkg)).To(BeFalse())
+		})
+
+		It("should return false when no other arch variant exists", func() {
+			current := map[string]packageMeta{
+				"foo-1.0-1.el8-x86_64": {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"},
+			}
+			previous := map[string]packageMeta{
+				"foo-1.0-1.el8-x86_64": {Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"},
+			}
+			pkg := packageMeta{Name: "foo", Version: "1.0", Release: "1.el8", Arch: "x86_64"}
+			Expect(crossArchPackageAdded(current, previous, pkg)).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #1127 — `HasModifiedFiles` false positive when i686 RPMs are installed alongside existing x86_64 RPMs.

### Problem

When an i686 package is installed alongside an existing x86_64 package of the same name/version/release (e.g. `libstdc++-8.5.0-20.el8.i686` alongside `libstdc++-8.5.0-20.el8.x86_64`), shared files (like Python scripts owned by both architectures) appear in the layer but are not actually modified in a meaningful way.

The check incorrectly flagged these as either:
1. **"mismatch in package architecture"** — when non-deterministic map iteration caused the file to map to the i686 NVR in the current layer but x86_64 NVR in the base layer
2. **"found disallowed modification in layer"** — when both layers mapped to x86_64 consistently, but the shared files appeared in the tar because `rpm` rewrites them during cross-arch install

### Fix

Two new helper functions handle cross-architecture package additions:

- `isCrossArchAddition()` — checks if two package version strings differ only in architecture and the original package is still present in the current layer (handles Path 1)
- `crossArchPackageAdded()` — checks if a new architecture variant of a package was added in the current layer vs. the previous layer (handles Path 2)

Additionally, the existing arch mismatch check at line 321 now verifies the original package is truly gone before failing.

### Tests

- **Path 1 test**: file maps to new arch (i686) in current layer, original (x86_64) still present → passes
- **Path 2 test**: file maps to same arch (x86_64) in both layers, but i686 variant added → passes  
- **Replacement test**: original arch removed and replaced with different arch (no coexistence) → still fails correctly
- **Unit tests for `isCrossArchAddition()`**: 6 cases covering valid cross-arch, missing original, version mismatch, name mismatch, same arch, and malformed strings
- **Unit tests for `crossArchPackageAdded()`**: 3 cases covering new variant added, both existed before, no variant exists

All 32 focused tests pass. The test image from the issue (`quay.io/acornett/ibm-686-x86:only_stdc`) can be used for integration validation.

## Test Plan

- [x] All existing `HasModifiedFiles` tests pass
- [x] New unit tests for both failure paths pass
- [x] New helper function unit tests pass
- [ ] Integration test with `quay.io/acornett/ibm-686-x86:only_stdc` (maintainer validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of package changes across CPU architectures.
  * Prevented valid shared-file rewrites and additional architecture variants from being incorrectly reported as modifications.
  * Continued detecting genuine architecture replacements when the original package is no longer installed.
* **Tests**
  * Added coverage for cross-architecture additions, replacements, shared files, and invalid package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->