### PR TITLE
feat: add --exit-with-failure flag for non-zero exit on check failures

### DIFF
--- a/cmd/preflight/cmd/check.go
+++ b/cmd/preflight/cmd/check.go
@@ -23,6 +23,9 @@ func checkCmd() *cobra.Command {
 	checkCmd.PersistentFlags().String("artifacts", "", "Where check-specific artifacts will be written. (env: PFLT_ARTIFACTS)")
 	_ = viper.BindPFlag("artifacts", checkCmd.PersistentFlags().Lookup("artifacts"))
 
+	checkCmd.PersistentFlags().Bool("exit-with-failure", false, "Exit with a non-zero status code when checks fail or encounter errors. (env: PFLT_EXIT_WITH_FAILURE)")
+	_ = viper.BindPFlag("exit_with_failure", checkCmd.PersistentFlags().Lookup("exit-with-failure"))
+
 	checkCmd.AddCommand(checkOperatorCmd(cli.RunPreflight))
 	checkCmd.AddCommand(checkContainerCmd(cli.RunPreflight))
 

--- a/cmd/preflight/cmd/check_container.go
+++ b/cmd/preflight/cmd/check_container.go
@@ -182,6 +182,7 @@ func checkContainerRunE(cmd *cobra.Command, args []string, runpreflight runPrefl
 			cli.CheckConfig{
 				IncludeJUnitResults: cfg.WriteJUnit,
 				SubmitResults:       cfg.Submit,
+				ExitOnFailure:       cfg.ExitWithFailure,
 			},
 			formatter,
 			&runtime.ResultWriterFile{},

--- a/cmd/preflight/cmd/check_operator.go
+++ b/cmd/preflight/cmd/check_operator.go
@@ -139,6 +139,7 @@ func checkOperatorRunE(cmd *cobra.Command, args []string, runpreflight runPrefli
 		cli.CheckConfig{
 			IncludeJUnitResults: cfg.WriteJUnit,
 			SubmitResults:       false, // operator results are not submitted.
+			ExitOnFailure:       cfg.ExitWithFailure,
 		},
 		formatter,
 		&runtime.ResultWriterFile{},

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -1,15 +1,28 @@
 package main
 
 import (
-	"log"
+	"errors"
+	"fmt"
+	"os"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/cmd/preflight/cmd"
+	"github.com/redhat-openshift-ecosystem/openshift-preflight/internal/cli"
 )
 
 func main() {
 	//coverage:ignore
 	if err := cmd.Execute(); err != nil {
 		//coverage:ignore
-		log.Fatal(err)
+		switch {
+		case errors.Is(err, &cli.ChecksErroredError{}):
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		case errors.Is(err, &cli.ChecksFailedError{}):
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		default:
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	}
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -10,6 +10,7 @@ The following configurables are available for the `preflight` tool.
 |`PFLT_LOGFILE`|env|Where the execution logfile will be written.|optional|[preflight.log](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L5)|
 |`PFLT_ARTIFACTS`|env|Where check-specific artifacts will be written.|optional|[artifacts/](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L7)|
 |`PFLT_JUNIT`|env|Will write results as JUnit XML.|optional|false|
+|`PFLT_EXIT_WITH_FAILURE`|env|Exit with a non-zero status code when checks fail (exit 2) or encounter errors (exit 1). Default behavior exits 0 regardless of check results.|optional|false|
 
 ## Operator Policy Configuration
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,6 +21,29 @@ import (
 type CheckConfig struct {
 	IncludeJUnitResults bool
 	SubmitResults       bool
+	ExitOnFailure       bool
+}
+
+// ChecksFailedError is returned when one or more checks have a "failed" result
+// and ExitOnFailure is enabled.
+type ChecksFailedError struct{}
+
+func (e *ChecksFailedError) Error() string { return "one or more checks failed" }
+
+func (e *ChecksFailedError) Is(target error) bool {
+	_, ok := target.(*ChecksFailedError)
+	return ok
+}
+
+// ChecksErroredError is returned when one or more checks encountered an error
+// during execution and ExitOnFailure is enabled.
+type ChecksErroredError struct{}
+
+func (e *ChecksErroredError) Error() string { return "one or more checks encountered an error" }
+
+func (e *ChecksErroredError) Is(target error) bool {
+	_, ok := target.(*ChecksErroredError)
+	return ok
 }
 
 var stdout io.Writer = os.Stdout
@@ -88,6 +111,15 @@ func RunPreflight(
 	}
 
 	logger.Info(fmt.Sprintf("Preflight result: %s", convertPassedOverall(results.PassedOverall)))
+
+	if cfg.ExitOnFailure {
+		if len(results.Errors) > 0 {
+			return &ChecksErroredError{}
+		}
+		if len(results.Failed) > 0 {
+			return &ChecksFailedError{}
+		}
+	}
 
 	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -221,3 +221,235 @@ var _ = DescribeTable("Checking overall pass/fail",
 	Entry("when passing true", true, "PASSED"),
 	Entry("when passing false", false, "FAILED"),
 )
+
+var _ = Describe("ExitOnFailure behavior", func() {
+	var oldStdout io.Writer
+	var testcontext context.Context
+	var testFormatter formatters.ResponseFormatter
+
+	BeforeEach(func() {
+		oldStdout = stdout
+		stdout = GinkgoWriter
+
+		tmpDir, err := os.MkdirTemp("", "exit-on-failure-*")
+		Expect(err).ToNot(HaveOccurred(), "should create temp directory")
+		DeferCleanup(os.RemoveAll, tmpDir)
+
+		artifactWriter, err := artifacts.NewFilesystemWriter(artifacts.WithDirectory(tmpDir))
+		Expect(err).ToNot(HaveOccurred(), "should create artifact writer")
+		testcontext = artifacts.ContextWithWriter(context.Background(), artifactWriter)
+
+		testFormatter, err = formatters.NewByName(formatters.DefaultFormat)
+		Expect(err).ToNot(HaveOccurred(), "should create formatter")
+	})
+
+	AfterEach(func() {
+		stdout = oldStdout
+	})
+
+	When("ExitOnFailure is enabled", func() {
+		It("should return ChecksFailedError when checks fail", func() {
+			err := RunPreflight(testcontext, func(ctx context.Context) (certification.Results, error) {
+				return certification.Results{
+					TestedImage:   "test-image",
+					PassedOverall: false,
+					Passed:        []certification.Result{},
+					Failed: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"failingCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+					Errors: []certification.Result{},
+				}, nil
+			}, CheckConfig{ExitOnFailure: true}, testFormatter, &runtime.ResultWriterFile{}, nil)
+			Expect(err).To(HaveOccurred(), "should return an error when checks fail")
+			Expect(errors.Is(err, &ChecksFailedError{})).To(BeTrue(), "error should be ChecksFailedError")
+		})
+
+		It("should return ChecksErroredError when checks encounter errors", func() {
+			err := RunPreflight(testcontext, func(ctx context.Context) (certification.Results, error) {
+				return certification.Results{
+					TestedImage:   "test-image",
+					PassedOverall: false,
+					Passed:        []certification.Result{},
+					Failed:        []certification.Result{},
+					Errors: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"erroringCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+				}, nil
+			}, CheckConfig{ExitOnFailure: true}, testFormatter, &runtime.ResultWriterFile{}, nil)
+			Expect(err).To(HaveOccurred(), "should return an error when checks error")
+			Expect(errors.Is(err, &ChecksErroredError{})).To(BeTrue(), "error should be ChecksErroredError")
+		})
+
+		It("should prioritize errors over failures", func() {
+			err := RunPreflight(testcontext, func(ctx context.Context) (certification.Results, error) {
+				return certification.Results{
+					TestedImage:   "test-image",
+					PassedOverall: false,
+					Passed:        []certification.Result{},
+					Failed: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"failingCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+					Errors: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"erroringCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+				}, nil
+			}, CheckConfig{ExitOnFailure: true}, testFormatter, &runtime.ResultWriterFile{}, nil)
+			Expect(err).To(HaveOccurred(), "should return an error")
+			Expect(errors.Is(err, &ChecksErroredError{})).To(BeTrue(), "errors should take priority over failures")
+		})
+
+		It("should return nil when all checks pass", func() {
+			err := RunPreflight(testcontext, func(ctx context.Context) (certification.Results, error) {
+				return certification.Results{
+					TestedImage:   "test-image",
+					PassedOverall: true,
+					Passed: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"passingCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return true, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+					Failed: []certification.Result{},
+					Errors: []certification.Result{},
+				}, nil
+			}, CheckConfig{ExitOnFailure: true}, testFormatter, &runtime.ResultWriterFile{}, nil)
+			Expect(err).ToNot(HaveOccurred(), "should not return an error when all checks pass")
+		})
+	})
+
+	When("ExitOnFailure is disabled", func() {
+		It("should return nil even when checks fail", func() {
+			err := RunPreflight(testcontext, func(ctx context.Context) (certification.Results, error) {
+				return certification.Results{
+					TestedImage:   "test-image",
+					PassedOverall: false,
+					Passed:        []certification.Result{},
+					Failed: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"failingCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+					Errors: []certification.Result{},
+				}, nil
+			}, CheckConfig{ExitOnFailure: false}, testFormatter, &runtime.ResultWriterFile{}, nil)
+			Expect(err).ToNot(HaveOccurred(), "should not return an error when ExitOnFailure is disabled")
+		})
+	})
+
+	When("results file is written before exit code", func() {
+		It("should write results even when ExitOnFailure returns an error", func() {
+			tmpDir, err := os.MkdirTemp("", "results-written-*")
+			Expect(err).ToNot(HaveOccurred(), "should create temp directory for results test")
+			DeferCleanup(os.RemoveAll, tmpDir)
+
+			artifactWriter, err := artifacts.NewFilesystemWriter(artifacts.WithDirectory(tmpDir))
+			Expect(err).ToNot(HaveOccurred(), "should create artifact writer for results test")
+			ctx := artifacts.ContextWithWriter(context.Background(), artifactWriter)
+
+			runErr := RunPreflight(ctx, func(ctx context.Context) (certification.Results, error) {
+				return certification.Results{
+					TestedImage:   "test-image",
+					PassedOverall: false,
+					Passed:        []certification.Result{},
+					Failed: []certification.Result{
+						{
+							Check: check.NewGenericCheck(
+								"failingCheck",
+								func(ctx context.Context, ir image.ImageReference) (bool, error) { return false, nil },
+								check.Metadata{},
+								check.HelpText{},
+								nil,
+							),
+							ElapsedTime: 1,
+						},
+					},
+					Errors: []certification.Result{},
+				}, nil
+			}, CheckConfig{ExitOnFailure: true}, testFormatter, &runtime.ResultWriterFile{}, nil)
+
+			Expect(runErr).To(HaveOccurred(), "should return exit-on-failure error")
+			resultsFile := filepath.Join(tmpDir, "results.json")
+			Expect(resultsFile).To(BeAnExistingFile(), "results file should exist even when returning failure error")
+		})
+	})
+})
+
+var _ = Describe("Error types", func() {
+	It("ChecksFailedError should have correct message", func() {
+		err := &ChecksFailedError{}
+		Expect(err.Error()).To(Equal("one or more checks failed"))
+	})
+
+	It("ChecksErroredError should have correct message", func() {
+		err := &ChecksErroredError{}
+		Expect(err.Error()).To(Equal("one or more checks encountered an error"))
+	})
+
+	It("errors.Is should match separate instances of ChecksFailedError", func() {
+		Expect(errors.Is(&ChecksFailedError{}, &ChecksFailedError{})).To(BeTrue(),
+			"separate ChecksFailedError instances should match via errors.Is")
+	})
+
+	It("errors.Is should match separate instances of ChecksErroredError", func() {
+		Expect(errors.Is(&ChecksErroredError{}, &ChecksErroredError{})).To(BeTrue(),
+			"separate ChecksErroredError instances should match via errors.Is")
+	})
+
+	It("errors.Is should not match across error types", func() {
+		var failedErr error = &ChecksFailedError{}
+		var erroredErr error = &ChecksErroredError{}
+		Expect(errors.Is(failedErr, &ChecksErroredError{})).To(BeFalse(),
+			"ChecksFailedError should not match ChecksErroredError")
+		Expect(errors.Is(erroredErr, &ChecksFailedError{})).To(BeFalse(),
+			"ChecksErroredError should not match ChecksFailedError")
+	})
+})

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -12,15 +12,16 @@ import (
 
 // Config contains configuration details for running preflight.
 type Config struct {
-	Image          string
-	Policy         policy.Policy
-	ResponseFormat string
-	Bundle         bool
-	Scratch        bool
-	LogFile        string
-	Artifacts      string
-	WriteJUnit     bool
-	TempDir        string
+	Image           string
+	Policy          policy.Policy
+	ResponseFormat  string
+	Bundle          bool
+	Scratch         bool
+	LogFile         string
+	Artifacts       string
+	WriteJUnit      bool
+	ExitWithFailure bool
+	TempDir         string
 	// Container-Specific Fields
 	CertificationComponentID string
 	PyxisHost                string
@@ -61,6 +62,7 @@ func NewConfigFrom(vcfg viper.Viper) (*Config, error) {
 	cfg.DockerConfig = vcfg.GetString("dockerConfig")
 	cfg.Artifacts = vcfg.GetString("artifacts")
 	cfg.WriteJUnit = vcfg.GetBool("junit")
+	cfg.ExitWithFailure = vcfg.GetBool("exit_with_failure")
 	cfg.TempDir = vcfg.GetString("tempDir")
 	cfg.storeContainerPolicyConfiguration(vcfg)
 	cfg.storeOperatorPolicyConfiguration(vcfg)


### PR DESCRIPTION
## Summary

Add an opt-in `--exit-with-failure` flag that causes preflight to exit with a non-zero status code when checks fail (exit 2) or encounter errors (exit 1). Default behavior (exit 0 regardless of check results) is preserved for backward compatibility.

This is a re-implementation of reverted PR #1316, with both bugs that caused the revert now fixed:
1. Default behavior is **unchanged** — preflight exits 0 regardless of check results
2. Flag logic is consistent across all code paths (container and operator modes)

## Architecture

```
cobra flag (check.go PersistentFlag)
  → viper.BindPFlag("exit_with_failure")
    → runtime.Config.ExitWithFailure (NewConfigFrom)
      → CheckConfig.ExitOnFailure (passed from RunE)
        → RunPreflight returns typed error
          → main.go maps to exit code
```

- Flag defined in \`check.go\` as PersistentFlag (shared by both subcommands)
- Config read through \`runtime.Config\` (correct pattern, not direct viper reads)
- Check commands (\`check_container.go\`, \`check_operator.go\`) don't contain any flag-specific logic — they just pass \`cfg.ExitWithFailure\` naturally
- \`RunPreflight\` returns \`ChecksErroredError\` or \`ChecksFailedError\` typed errors
- \`main.go\` translates typed errors to exit codes (1 for errors, 2 for failures)
- Both error types implement \`Is(target error) bool\` for proper \`errors.Is\` matching

## Exit Codes

| Condition | Exit Code |
|-----------|-----------|
| All checks pass | 0 |
| Flag not set (any result) | 0 |
| Checks errored + flag set | 1 |
| Checks failed + flag set | 2 |

## Testing

- Tests added to existing \`internal/cli/cli_test.go\` (20/20 pass)
- Covers: failures, errors, priority (errors > failures), success, disabled mode, results-file-written-before-exit
- Error type matching via \`errors.Is\` tested
- No new test failures introduced (6 pre-existing cmd test failures are ARM fixture issues on main)

## Documentation

- \`docs/CONFIG.md\` updated with \`PFLT_EXIT_WITH_FAILURE\` entry

Closes #1235