### PR TITLE
update go to 1.26.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,9 +23,9 @@ Vagrant.configure("2") do |config|
     containers-common \
     openscap-containers
 
-    curl -L https://go.dev/dl/go1.26.3.linux-amd64.tar.gz --output go1.26.3.linux-amd64.tar.gz
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.3.linux-amd64.tar.gz
-    rm go1.26.3.linux-amd64.tar.gz
+    curl -L https://go.dev/dl/go1.26.5.linux-amd64.tar.gz --output go1.26.5.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.5.linux-amd64.tar.gz
+    rm go1.26.5.linux-amd64.tar.gz
 
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz --output oc.tar.gz
     tar -C /usr/local/bin -xzf oc.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-openshift-ecosystem/openshift-preflight
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
### Motivation
- builder images are no avilable for this update

```
❯ podman run -it --rm registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23 go version
Trying to pull registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.26-openshift-4.23...

go version go1.26.5 (Red Hat 1.26.5-1.el9_8) linux/amd64
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.26.5 for improved compatibility and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->