### PR TITLE
removing scorecard/operator-sdk info from skills/readme/config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ For the complete container and operator bundle certification workflow instructio
 
 For running the Preflight binary, the host or VM must have at least RHEL 8.5, CentOS 8.5 or Fedora 35 installed.
 
-The Preflight binary currently requires that you have the following tools installed,
-functional, and in your path.
-
-| Name             | Tool cli          | Minimum version |
-|----------------- |:-----------------:|----------------:|
-| OperatorSDK      | `operator-sdk`    |         v1.42.3 |
-
 See our [Vagrantfile](Vagrantfile) for more information on setting up a
 development environment. Some checks may also require access to an OpenShift
 cluster. which is not provided by the Vagrantfile
@@ -47,15 +40,18 @@ Usage:
   preflight [command]
 
 Available Commands:
-  check          Run checks for an operator or container
-  completion     Generate the autocompletion script for the specified shell
-  help           Help about any command
-  runtime-assets Returns information about assets used at runtime.
-  support        Submits a support request
+  check       Run checks for an operator or container
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  list-checks List all checks that will be executed for each policy
+  support     Creates a support request
 
 Flags:
-  -h, --help      help for preflight
-  -v, --version   version for preflight
+      --config string     A preflight config file. The default is config.yaml (env: PFLT_CONFIG)
+  -h, --help              help for preflight
+      --logfile string    Where the execution logfile will be written. (env: PFLT_LOGFILE)
+      --loglevel string   The verbosity of the preflight tool itself. Ex. warn, debug, trace, info, error. (env: PFLT_LOGLEVEL)
+  -v, --version           version for preflight
 
 Use "preflight [command] --help" for more information about a command.
 ```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -18,13 +18,9 @@ is called.
 
 |Variable|Kind|Doc|Required or Optional|Default|
 |--|--|--|--|--|
-|`KUBECONFIG`|env|The operator policy must interact with a Kubernetes cluster for checks such as `DeployableByOLM` and running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/).|required|-|
-|`PFLT_NAMESPACE`|env|The namespace to use when running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/)|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L8)|
-|`PFLT_SERVICEACCOUNT`|env|The service account to use when running [OperatorSDK Scorecard](https://sdk.operatorframework.io/docs/testing-operators/scorecard/)|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L9)|
+|`KUBECONFIG`|env|The operator policy must interact with a Kubernetes cluster for checks such as `DeployableByOLM`.|required|-|
 |`PFLT_INDEXIMAGE`|env|The index image to use when testing that an operator is `DeployableByOLM`|required|-|
 |`PFLT_DOCKERCONFIG`|env|The full path to a dockerconfigjson file, which is pushed to the target test cluster to access images in private repositories in the `DeployableByOLM`. If empty, no secret is created and the resource is assumed to be public.|optional|-|
-|`PFLT_SCORECARD_IMAGE`|env|A uri that points to the scorecard image digest, used in disconnected environments. It should only be used in a disconnected environment. Use `preflight runtime-assets` on a connected workstation to generate the digest that needs to be mirrored.|optional|-|
-|`PFLT_SCORECARD_WAIT_TIME`|env|A time value that will be passed to scorecard's `--wait-time` environment variable.|optional|[default](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/cmd/defaults.go#L10)|
 |`PFLT_CHANNEL`|env|The name of the operator channel which is used by `DeployableByOLM` to deploy the operator. If empty, the default operator channel in bundle's annotations file is used.|optional|-|
 
 

--- a/docs/skills/preflight-check-operator/SKILL.md
+++ b/docs/skills/preflight-check-operator/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: preflight-check-operator
-description: Guide users running preflight check operator for Red Hat OpenShift Operator Certification. Use when users want to validate operator bundles, debug check failures, understand OLM deployment issues, interpret scorecard results, build index images, or work with operator certification requirements. Trigger on mentions of preflight operator, operator bundle, OLM, scorecard, DeployableByOLM, operator certification, or index images.
+description: Guide users running preflight check operator for Red Hat OpenShift Operator Certification. Use when users want to validate operator bundles, debug check failures, understand OLM deployment issues, build index images, or work with operator certification requirements. Trigger on mentions of preflight operator, operator bundle, OLM, DeployableByOLM, operator certification, or index images.
 ---
 
 # Preflight Operator Check Skill
 
-Help end users run `preflight check operator` to validate their operator bundles for Red Hat OpenShift Operator Certification. This skill assists with running checks, building index images, debugging failures, interpreting scorecard results, and understanding operator certification requirements.
+Help end users run `preflight check operator` to validate their operator bundles for Red Hat OpenShift Operator Certification. This skill assists with running checks, building index images, debugging failures, results, and understanding operator certification requirements.
 
 ## When to Use This Skill
 
 Use this skill when users:
 - Want to validate an operator bundle for Red Hat OpenShift certification
 - Need help building or configuring index images with `opm`
-- Need to understand check failures or errors (especially DeployableByOLM, Scorecard)
+- Need to understand check failures or errors (especially DeployableByOLM)
 - Ask about specific operator checks (DeployableByOLM, ValidateOperatorBundle, CertifiedImages, etc.)
 - Need to interpret results, artifacts, or log files from operator validation
 - Have issues with KUBECONFIG, cluster access, or OLM deployment
@@ -67,20 +67,6 @@ preflight check operator registry.example.org/your-namespace/your-bundle:v1.0 \
   --serviceaccount=preflight-sa
 ```
 
-**Disconnected/air-gapped environment:**
-```bash
-# First, get the scorecard image digest on a connected machine
-preflight runtime-assets
-
-# Mirror the scorecard image to your disconnected registry
-# Then use it in disconnected environment
-export KUBECONFIG=/path/to/your/kubeconfig
-export PFLT_INDEXIMAGE=registry.internal/operators/your-index:v1.0
-preflight check operator registry.internal/operators/your-bundle:v1.0 \
-  --scorecard-image=registry.internal/scorecard@sha256:abc123... \
-  --docker-config=/path/to/config.json
-```
-
 ## Important Flags and Environment Variables
 
 ### Required
@@ -92,12 +78,6 @@ preflight check operator registry.internal/operators/your-bundle:v1.0 \
 
 ### Operator Configuration
 - `--channel` / `PFLT_CHANNEL`: Operator channel name for DeployableByOLM check (uses default channel from bundle annotations if empty)
-- `--namespace` / `PFLT_NAMESPACE`: Namespace for OperatorSDK Scorecard execution (default: "default")
-- `--serviceaccount` / `PFLT_SERVICEACCOUNT`: Service account for OperatorSDK Scorecard (default: "default")
-- `--scorecard-wait-time` / `PFLT_SCORECARD_WAIT_TIME`: Time value passed to scorecard's --wait-time
-
-### Disconnected Environments
-- `--scorecard-image` / `PFLT_SCORECARD_IMAGE`: URI pointing to scorecard image digest (for disconnected environments only)
 
 ### Output and Logging
 - `--artifacts` / `PFLT_ARTIFACTS`: Where artifacts are written (default: `artifacts/`)
@@ -145,7 +125,7 @@ export PFLT_DOCKERCONFIG=/path/to/docker/config.json
 After running preflight, check these locations:
 - **Results JSON**: `artifacts/results.json` - detailed pass/fail for each check
 - **Log file**: `preflight.log` (or custom location) - execution details
-- **Artifacts**: `artifacts/` directory - check-specific evidence and scorecard output
+- **Artifacts**: `artifacts/` directory - check-specific evidence
 
 ### Common Operator Checks
 
@@ -155,8 +135,6 @@ When debugging failures, understand what each check validates:
 |------------|---------|-----------------|
 | **DeployableByOLM** | Validates operator can be deployed via OLM | Index image not accessible, CSV issues, missing dependencies, cluster connectivity |
 | **ValidateOperatorBundle** | Runs `operator-sdk bundle validate` | Invalid bundle structure, missing required files, annotation errors |
-| **ScorecardBasicSpecCheck** | Runs OperatorSDK Scorecard basic tests | Operator doesn't install properly, status not updated, CRD validation issues |
-| **ScorecardOlmSuiteCheck** | Runs OperatorSDK Scorecard OLM suite | OLM-specific issues, bundle metadata problems, CSV validation failures |
 | **CertifiedImages** | Verifies all container images are Red Hat certified | Using non-certified base images or dependencies |
 | **RequiredAnnotations** | Checks for required bundle annotations | Missing annotations in metadata/annotations.yaml |
 | **RelatedImages** | Validates relatedImages in CSV | Missing or incorrect relatedImages section in ClusterServiceVersion |
@@ -167,7 +145,7 @@ When debugging failures, understand what each check validates:
 When a check fails:
 
 1. **Read the result message**: The `results.json` contains a `message` field with details
-2. **Check artifacts**: Look in `artifacts/` for check-specific evidence (scorecard output, logs)
+2. **Check artifacts**: Look in `artifacts/` for check-specific evidence (output, logs)
 3. **Review cluster logs**: For DeployableByOLM failures, check cluster events and pod logs
 4. **Use debug logging**: Run with `--loglevel=debug` or `--loglevel=trace`
 5. **Verify prerequisites**: Confirm KUBECONFIG, PFLT_INDEXIMAGE, and cluster access
@@ -226,46 +204,6 @@ oc get subscription -n <namespace>
 oc get csv -n <namespace>
 oc describe csv <csv-name> -n <namespace>
 ```
-
-### Scorecard Failures
-
-Scorecard checks run OperatorSDK tests against your operator.
-
-**Common issues:**
-
-1. **Timeout waiting for scorecard**
-   ```
-   Error: Scorecard timed out
-   ```
-   **Fix:** Increase wait time:
-   ```bash
-   preflight check operator <bundle> --scorecard-wait-time=300s
-   ```
-
-2. **Service account permissions**
-   ```
-   Error: ServiceAccount doesn't have required permissions
-   ```
-   **Fix:** Use a service account with appropriate RBAC:
-   ```bash
-   # Create service account with proper permissions
-   oc create serviceaccount preflight-sa -n preflight-testing
-   # Add necessary role bindings
-   oc create rolebinding preflight-admin --clusterrole=admin --serviceaccount=preflight-testing:preflight-sa -n preflight-testing
-   
-   preflight check operator <bundle> \
-     --namespace=preflight-testing \
-     --serviceaccount=preflight-sa
-   ```
-
-3. **Scorecard image not available (disconnected)**
-   ```
-   Error: Failed to pull scorecard image
-   ```
-   **Fix:** Use `preflight runtime-assets` on connected machine, mirror the image, then:
-   ```bash
-   preflight check operator <bundle> --scorecard-image=<internal-registry>/scorecard@sha256:...
-   ```
 
 ### ValidateOperatorBundle Failures
 
@@ -355,10 +293,7 @@ dockerConfig: /path/to/config.json
 loglevel: debug
 logfile: artifacts/preflight.log
 artifacts: artifacts
-namespace: preflight-testing
-serviceaccount: preflight-sa
 channel: stable
-scorecard_wait_time: 300s
 ```
 
 Then set environment variables and run:
@@ -427,36 +362,6 @@ $CONTAINER_TOOL run \
   quay.io/opdev/preflight:stable check operator registry.example.org/your-namespace/your-bundle:v1.0
 ```
 
-## Disconnected/Air-Gapped Environments
-
-### Step 1: Get Required Images (on connected machine)
-
-```bash
-# Get the scorecard image digest
-preflight runtime-assets
-```
-
-This outputs the scorecard image and other runtime assets that need to be mirrored.
-
-### Step 2: Mirror Images
-
-Mirror these images to your internal registry:
-- Scorecard image
-- Your operator bundle
-- Your index image
-- All images referenced in your operator's CSV
-
-### Step 3: Run Preflight (in disconnected environment)
-
-```bash
-export KUBECONFIG=/path/to/kubeconfig
-export PFLT_INDEXIMAGE=registry.internal/operators/my-index:v1.0
-preflight check operator registry.internal/operators/my-bundle:v1.0 \
-  --scorecard-image=registry.internal/scorecard@sha256:abc123... \
-  --docker-config=/path/to/config.json \
-  --loglevel=debug
-```
-
 ## Cluster Requirements
 
 ### Minimum Requirements
@@ -523,7 +428,6 @@ Operator checks differ from container checks:
 - **Requires cluster**: Must have access to OpenShift cluster with OLM
 - **Requires index image**: Must build index image containing bundle
 - **Tests deployment**: DeployableByOLM actually deploys the operator on the cluster
-- **Scorecard integration**: Runs OperatorSDK Scorecard tests
 - **More complex**: Operator certification has more moving parts than container certification
 
 ## When to Escalate


### PR DESCRIPTION
- Relates: #1501 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated operator policy configuration documentation to list only the currently supported image index and Docker configuration settings.
  * Removed documentation for namespace, service account, scorecard image, and scorecard wait-time settings.
  * Simplified setup requirements by removing prerequisite-tool and Operator SDK version guidance while retaining host operating-system and Vagrantfile information.
  * Removed Scorecard-specific guidance, examples, troubleshooting, outputs, checks, and configuration details from the preflight check documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->